### PR TITLE
Getting a working docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
+version: '2.1'
+
 services:
   oclclient:
-    image: openmrs/ocl-client:qa
+    image: openmrs/ocl-client:local
     ports:
       - 8081:80
     restart: always
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/ping"]
+      test: ["CMD", "wget", "-q", "-s", "http://localhost/"]


### PR DESCRIPTION
# JIRA TICKET NAME:
OCLOMRS-27: getting a docker compose

# Summary:
The currently one doesn't work. 
This one has the proper healthcheck, also it points to a new image that you can build locally. 
