### PR TITLE
Allow Node tests to be parsed by Bamboo build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # testing
 /coverage
+junit.xml
 
 # production
 /build

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@
 ```
 For instances where port 3000 is being used it will prompt you to reply with letter Y to change the port automatically.
 ```
-## Setting up with Docker 
+## Setting up with Docker
+
+ Our environments are running in docker. 
 
  Ensure you have docker installed and running locally. Install docker [from here](https://www.docker.com/community-edition).
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "test:bamboo": "react-scripts test --env=jsdom -u --ci --coverage --testResultsProcessor ./node_modules/jest-junit"
   },
   "devDependencies": {
     "eslint-config-airbnb": "^16.1.0",
@@ -33,6 +34,7 @@
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.7.0",
+    "jest-junit": "^4.0.0",
     "react-addons-test-utils": "^15.6.2"
   },
   "jest": {


### PR DESCRIPTION
# Summary:
So, I'd like to configure Bamboo to parse logs results from this project, like:
https://pasteboard.co/HmEpmxo.png

Bamboo can parse junit and mocha (mostly), so I'd like to configure junit. 

I do believe it probably won't affect other functionalities. 