### PR TITLE
OCLOMRS-43: Changing the API call  url from production to QA

### DIFF
--- a/src/config/axiosConfig.js
+++ b/src/config/axiosConfig.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const instance = axios.create({
-  baseURL: 'https://api.openconceptlab.org/',
+  baseURL: 'https://api.qa.openconceptlab.org/',
 });
 
 instance.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded';

--- a/src/redux/actions/auth/authActions.js
+++ b/src/redux/actions/auth/authActions.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { login, loginFailed, loginStarted, logout } from './authActionCreators';
 
-const BASE_URL = 'https://api.openconceptlab.org/';
+const BASE_URL = 'https://api.qa.openconceptlab.org/';
 
 const loginAction = ({ username, token }) => async (dispatch) => {
   try {


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-43](https://issues.openmrs.org/browse/OCLOMRS-43)

# Summary:
Currently, the API calls are made from the production version openconceptlab.org and they should be made from the QA version at api.qa.openconceptlab.org
The PR seeks to solve that :)