### PR TITLE
OCLOMRS-55: Fix the loader right before the dictionaries are retrieved

### DIFF
--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -1,5 +1,5 @@
 import { notify } from 'react-notify-toast';
-import { addDictionary, fetchOrganizations, isSuccess, isFetching } from './dictionaryActions';
+import { addDictionary, fetchOrganizations, isSuccess, isFetching, isErrored } from './dictionaryActions';
 import api from './../../api';
 
 export const createDictionary = data => dispatch =>
@@ -28,21 +28,16 @@ export const fetchingOrganizations = () => dispatch =>
     .then(payload =>
       dispatch(fetchOrganizations(payload)));
 
-export const fetchDictionaries = () => dispatch =>     
-api.dictionaries
-        .fetchingDictionaries()
-        .then(dispatch(isFetching(true)))  
-        .then(payload =>
-          dispatch(isSuccess(payload)),
-          dispatch(isFetching(false))
-        )
-        .catch((error) => () => {
-          if (error.payload){
-            dispatch(isSuccess(error.payload));
-            dispatch(isFetching(false));
-          } else {
-            dispatch(isErrored(error.payload.data));
-            dispatch(isFetching(false));
-          }
-        }
-        );
+export const fetchDictionaries = () => dispatch => {
+  dispatch(isFetching(true));
+  return api.dictionaries
+    .fetchingDictionaries()
+    .then(payload => {
+      dispatch(isSuccess(payload));
+      dispatch(isFetching(false));
+    })
+    .catch(error => {
+      dispatch(isErrored(error.response.data));
+      dispatch(isFetching(false));
+    });
+}

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -22,7 +22,7 @@ export default {
     fetchingDictionaries: () =>
       instance
       .get(`collections/?q=${''}&limit=${1000}&page=${1}&verbose=true`)
-      .then(payload => payload.data) 
+      .then(payload => payload.data)
   },
   organizations: {
     fetchOrganizations: () =>

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -52,8 +52,8 @@ describe('Test suite for dictionary actions', () => {
 
     const expectedActions = [
       { type: IS_FETCHING, payload: true },
-      { type: IS_FETCHING, payload: false },
       { type: FETCHING_DICTIONARIES, payload: [dictionaries] },
+      { type: IS_FETCHING, payload: false },
     ];
 
     const store = mockStore({ payload: {} });
@@ -73,6 +73,7 @@ describe('Test suite for dictionary actions', () => {
 
     const expectedActions = [
       { type: IS_FETCHING, payload: true },
+      { type: FETCHING_DICTIONARIES, payload: 'could not complete this request' },
       { type: IS_FETCHING, payload: false },
     ];
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-55](https://issues.openmrs.org/browse/OCLOMRS-55)

# Summary:
A fix to show the loader right during the fetching process of dictionaries