### PR TITLE
OCLOMRS-54: A user should be able to view their personal dictionaries and dictionaries belonging to all other organizations and users

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionariesSearch.jsx
+++ b/src/components/dashboard/components/dictionary/DictionariesSearch.jsx
@@ -34,8 +34,62 @@ export const DictionariesSearch = ({ onSearch, onSubmit, searchValue }) => (
 
             <div className="dropdown-menu" aria-labelledby="concepts">
               <a className="dropdown-item" href="!#">
-               Dictionaries
+                Dictionaries
               </a>
+            </div>
+          </div>
+          <div className="search-filter">
+            <div className="dropdown d-none d-md-inline d-lg-inline d-xl-inline mini-sort-btn col-md-2">
+              <a
+                className="dropdown-toggle"
+                href="#!"
+                role="button"
+                id="dictionaryResults"
+                data-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false"
+              >
+                Filter Dictionaries View
+              </a>
+              <div
+                className="dropdown-menu source-menu"
+                aria-labelledby="dictionaryResults"
+              >
+                <div className="form-check ml-3">
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    name="organizations"
+                    id="organizations"
+                    onChange={onSearch}
+                  />
+                  <label className="form-check-label" htmlFor="organizations">
+                    All OpenMRS Dictionaries
+                  </label>
+                </div>
+                <div className="form-check ml-3">
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    name="user"
+                    id="user"
+                    onChange={onSearch}
+                  />
+                  <label className="form-check-label" htmlFor="user">
+                    Your Dictionaries
+                  </label>
+                </div>
+                <div className="form-check p-1">
+                  <a
+                    href="#!"
+                    className="btn btn-sm btn-block btn-secondary no-shadow text-white"
+                    onClick={onSubmit}
+                    id="filterdictionaries"
+                  >
+                    filter results
+                  </a>
+                </div>
+              </div>
             </div>
           </div>
         </form>
@@ -48,6 +102,5 @@ DictionariesSearch.propTypes = {
   onSearch: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   searchValue: PropTypes.string.isRequired,
-
 };
 export default DictionariesSearch;

--- a/src/components/dashboard/components/dictionary/ListDictionaries.jsx
+++ b/src/components/dashboard/components/dictionary/ListDictionaries.jsx
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import Card from './DictionaryCard';
 import Loader from '../../../Loader';
 
-const ListDictionaries = ({ dictionaries, fetching, fetchData }) => {
+const ListDictionaries = ({
+  dictionaries, fetching, fetchData, dictionaryViewOptions,
+}) => {
   if (fetching) {
     return (
       <div className="text-center mt-3">
@@ -13,21 +15,43 @@ const ListDictionaries = ({ dictionaries, fetching, fetchData }) => {
   }
   if (dictionaries.length >= 1) {
     return (
-      <div className="row justify-content-center">
-        {dictionaries.map((dictionary, index) => {
-          return dictionary.repository_type === 'OpenMRSDictionary' ?
-            <Card dictionary={dictionary} key={dictionary.uuid}
-            fetchData={fetchData}/>
-                        :
-            <div key={index}> {' '} </div>;
-                })}
+      <div>
+        { dictionaryViewOptions === 'user' ?
+          <div className="row justify-content-center">
+            {dictionaries.map((dictionary, index) => {
+            return dictionary.created_by === localStorage.getItem('username')
+              && dictionaryViewOptions === 'user' ?
+                <Card
+                  dictionary={dictionary}
+                  key={dictionary.uuid}
+                  fetchData={fetchData}
+                />
+              :
+                <div key={index}> {' '} </div>;
+          })}
+          </div>
+        :
+          <div className="row justify-content-center">
+            {dictionaries.map((dictionary, index) => {
+            return dictionary.repository_type === 'OpenMRSDictionary'
+              && dictionaryViewOptions === 'organizations' ?
+                <Card
+                  dictionary={dictionary}
+                  key={dictionary.uuid}
+                  fetchData={fetchData}
+                />
+              :
+                <div key={index}> {' '} </div>;
+          })}
+          </div>
+        }
       </div>
     );
   }
 
   return (
     <div className="text-center mt-3">
-      <h5>No Dictionaries Found</h5>
+      <h5>No Dictionaries Found <span aria-label="sad-emoji" role="img"> 😞 </span> </h5>
     </div>
   );
 };
@@ -37,5 +61,7 @@ ListDictionaries.propTypes = {
   dictionaries: PropTypes.arrayOf(PropTypes.shape({
     dictionaryName: PropTypes.string,
   })).isRequired,
+  fetchData: PropTypes.func.isRequired,
+  dictionaryViewOptions: PropTypes.string.isRequired,
 };
 export default ListDictionaries;

--- a/src/components/dashboard/components/dictionary/user/UserDashboard.jsx
+++ b/src/components/dashboard/components/dictionary/user/UserDashboard.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Alert } from 'react-bootstrap';
+
+const UserDashboard = ({ viewState, organizations }) => {
+  return (
+    <div className="container-fluid">
+      <div className="row justify-content-center">
+        <div className="col-1" />
+        <div className="col-sm-12 col-md-10  mt-2 col-12">
+          <Alert className="dashboard-alert">
+            <h6>
+              Hello {localStorage.getItem('username')} 👋, you belong to{' '}
+              <strong>
+                {' '}
+                {organizations &&
+                  organizations.map(organization => (
+                    <span value={organization.id} key={organization.id}>
+                      {organization.id}
+                      {', '}
+                    </span>
+                  ))}
+              </strong>
+              organization(s).
+            </h6>
+            <span> You are viewing {viewState === 'user' ? 'your' : 'all openmrs' } <strong>  {viewState} </strong> dictionaries</span>
+            <span> {''} </span>
+          </Alert>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UserDashboard;

--- a/src/components/dashboard/container/DictionariesDisplay.jsx
+++ b/src/components/dashboard/container/DictionariesDisplay.jsx
@@ -9,6 +9,7 @@ import { clearDictionaries } from '../../../redux/actions/dictionaries/dictionar
 import SideBar from '../components/SideNavigation';
 import ListDictionaries from '../components/dictionary/ListDictionaries';
 import SearchDictionaries from '../components/dictionary/DictionariesSearch';
+import UserDashboard from '../components/dictionary/user/UserDashboard';
 
 export class DictionaryDisplay extends Component {
     static propTypes = {
@@ -19,26 +20,34 @@ export class DictionaryDisplay extends Component {
       isFetching: propTypes.bool.isRequired,
       searchDictionaries: propTypes.func.isRequired,
       clearDictionaries: propTypes.func.isRequired,
+      fetchDictionary: propTypes.func.isRequired,
+      organizations: propTypes.arrayOf.isRequired,
     };
     constructor(props) {
       super(props);
       this.state = {
         searchInput: '',
+        dictionaryViewOptions: 'user',
       };
       autoBind(this);
     }
+
     componentDidMount() {
       this.props.fetchDictionaries();
     }
-    UNSAFE_componentWillReceiveProps(nextProps) {
-      const size = Object.keys(nextProps.dictionary).length;
-      { size > 0 &&
-            this.props.history.push('/dictionary-details');
+
+    onSubmit(event) {
+      event.preventDefault();
+      const { user } = this.state;
+      if (user) {
+        this.setState({ dictionaryViewOptions: 'user' });
+      } else {
+        this.setState({ dictionaryViewOptions: 'organizations' });
       }
+      this.props.clearDictionaries();
+      this.props.searchDictionaries(this.state.searchInput);
     }
-    handleDictionaryFetch = (data) => {
-      this.props.fetchDictionary(data.url);
-    }
+
     onSearch(event) {
       const { value, name, checked } = event.target;
       const trueValue = event.target.type === 'checkbox' ? checked : value;
@@ -49,12 +58,16 @@ export class DictionaryDisplay extends Component {
       }
     }
 
-    onSubmit(event) {
-      event.preventDefault();
-      this.props.clearDictionaries();
-      this.props.searchDictionaries(this.state.searchInput);
+    UNSAFE_componentWillReceiveProps(nextProps) {
+      const size = Object.keys(nextProps.dictionary).length;
+      { size > 0 &&
+            this.props.history.push('/dictionary-details');
+      }
     }
 
+    handleDictionaryFetch = (data) => {
+      this.props.fetchDictionary(data.url);
+    }
     renderEndMessage() {
       if (!this.props.isFetching) {
         return (
@@ -67,11 +80,16 @@ export class DictionaryDisplay extends Component {
       return '';
     }
     render() {
-      const { dictionaries, isFetching } = this.props;
-      const { searchInput } = this.state;
+      const { dictionaries, isFetching, organizations } = this.props;
+      const { searchInput, dictionaryViewOptions } = this.state;
       return (
         <div className="dashboard-wrapper">
           <SideBar />
+          <UserDashboard
+            dictionaries={dictionaries}
+            organizations={organizations}
+            viewState={dictionaryViewOptions}
+          />
           <SearchDictionaries
             onSearch={this.onSearch}
             onSubmit={this.onSubmit}
@@ -89,6 +107,7 @@ export class DictionaryDisplay extends Component {
                   dictionaries={dictionaries}
                   fetching={isFetching}
                   fetchData={this.handleDictionaryFetch}
+                  dictionaryViewOptions={dictionaryViewOptions}
                 />
               </InfiniteScroll>
             </div>
@@ -102,6 +121,7 @@ export const mapStateToProps = state => ({
   dictionaries: state.dictionaries.dictionaries,
   isFetching: state.dictionaries.loading,
   dictionary: state.dictionaries.dictionary,
+  organizations: state.organizations.organizations,
 });
 export default connect(mapStateToProps, {
   fetchDictionaries,

--- a/src/components/dashboard/styles/index.css
+++ b/src/components/dashboard/styles/index.css
@@ -390,6 +390,7 @@ nav {
   font-size: 1rem;
   color: #4f6196;
 }
+
 .add-btn:hover {
   border-bottom: thin solid #4f6196;
 }
@@ -399,6 +400,18 @@ nav {
   font-size: 0.9rem;
   color: #4f6196;
 }
+
 .modal-header {
   background-color: rgba(192, 189, 189, 0.733) !important;
+}
+
+.dashboard-alert{
+  background: #e9e9e9;
+  color: #000000!important;
+  text-align: center;
+}
+
+.search-filter {
+  padding-right: 5%;
+  float: right;
 }

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -41,19 +41,19 @@ export const fetchingOrganizations = () => dispatch =>
     .fetchOrganizations()
     .then(payload => dispatch(fetchOrganizations(payload)));
 
-    export const fetchDictionaries = () => dispatch => {
-      dispatch(isFetching(true));
-      return api.dictionaries
-        .fetchingDictionaries()
-        .then(payload => {
-          dispatch(isSuccess(payload));
-          dispatch(isFetching(false));
-        })
-        .catch(error => {
-          dispatch(isErrored(error.response.data));
-          dispatch(isFetching(false));
-        });
-    }
+export const fetchDictionaries = () => (dispatch) => {
+  dispatch(isFetching(true));
+  return api.dictionaries
+    .fetchingDictionaries()
+    .then((payload) => {
+      dispatch(isSuccess(payload));
+      dispatch(isFetching(false));
+    })
+    .catch((error) => {
+      dispatch(isErrored(error.response.data));
+      dispatch(isFetching(false));
+    });
+};
 
 export const searchDictionaries = searchItem => (dispatch) => {
   dispatch(isFetching(true));

--- a/src/tests/Dashboard/container/DictionaryDisplay.test.jsx
+++ b/src/tests/Dashboard/container/DictionaryDisplay.test.jsx
@@ -3,6 +3,7 @@ import { mount, shallow } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import { DictionaryDisplay, mapStateToProps } from '../../../components/dashboard/container/DictionariesDisplay';
 import dictionaries from '../../__mocks__/dictionaries';
+import organizations from '../../__mocks__/organizations';
 import { DictionariesSearch } from '../../../components/dashboard/components/dictionary/DictionariesSearch';
 import ListDictionaries from '../../../components/dashboard/components/dictionary/ListDictionaries';
 import DictionaryCard from '../../../components/dashboard/components/dictionary/DictionaryCard';
@@ -14,6 +15,7 @@ describe('DictionaryDisplay', () => {
       fetchDictionaries: jest.fn(),
       dictionaries: [],
       isFetching: false,
+      organizations: [organizations],
     };
     const wrapper = <MemoryRouter><DictionaryDisplay {...props} /></MemoryRouter>;
     const rShallow = shallow(wrapper);
@@ -24,6 +26,7 @@ describe('DictionaryDisplay', () => {
       fetchDictionaries: jest.fn(),
       dictionaries: [dictionaries],
       isFetching: true,
+      organizations: [organizations],
     };
     const wrapper = mount(<MemoryRouter><DictionaryDisplay {...props} /></MemoryRouter>);
 
@@ -35,6 +38,7 @@ describe('DictionaryDisplay', () => {
       fetchDictionaries: jest.fn(),
       dictionaries: [],
       isFetching: true,
+      organizations: [],
     };
     const wrapper = shallow(<MemoryRouter><DictionaryDisplay {...props} /></MemoryRouter>);
 
@@ -43,8 +47,10 @@ describe('DictionaryDisplay', () => {
   it('should test mapStateToProps', () => {
     const initialState = {
       dictionaries: { dictionaries: [], loading: false },
+      organizations: { organizations: [], loading: false },
     };
     expect(mapStateToProps(initialState).dictionaries).toEqual([]);
+    expect(mapStateToProps(initialState).organizations).toEqual([]);
     expect(mapStateToProps(initialState).isFetching).toEqual(false);
   });
   it('should search for a dictionary', () => {
@@ -56,6 +62,7 @@ describe('DictionaryDisplay', () => {
       searchDictionaries: jest.fn(),
       onSearch: jest.fn(),
       onSubmit: jest.fn(),
+      organizations: [organizations],
 
     };
     const wrapper = mount(<MemoryRouter><DictionaryDisplay {...props} /></MemoryRouter>);
@@ -83,6 +90,18 @@ describe('DictionaryDisplay', () => {
       const component = mount(<ListDictionaries {...props} />);
       expect(component).toMatchSnapshot();
     });
+
+    it('returns the openmrs user dictionaries when it receives correct properties', () => {
+      const props = {
+        dictionaries: [dictionaries],
+        fetching: false,
+        fetchData: true,
+        dictionaryViewOptions: 'user',
+      };
+      const component = mount(<ListDictionaries {...props} />);
+      expect(component.props().dictionaryViewOptions).toBe(props.dictionaryViewOptions);
+      expect(component.props().dictionaries[0].repository_type).toBe('OpenMRSDictionary');
+    });
   });
 });
 describe('DictionaryCard', () => {
@@ -90,7 +109,7 @@ describe('DictionaryCard', () => {
     const props = {
       dictionary: [dictionaries],
     };
-    const wrapper = shallow(<DictionaryCard {...props} />)
+    const wrapper = shallow(<DictionaryCard {...props} />);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/tests/Dictionary/UserDashboard.test.jsx
+++ b/src/tests/Dictionary/UserDashboard.test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import UserDashboard from '../../components/dashboard/components/dictionary/user/UserDashboard';
+
+describe('Tests functionality of User Dashbard Component', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(<UserDashboard />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-54](https://issues.openmrs.org/browse/OCLOMRS-54)

# Summary:
As a user after adding dictionaries, I want to view my dictionaries and also the dictionaries for all other OpenMRS organizations and users. 
A filter should be put in place to enable a user toggle between their dictionaries and all the dictionaries on the platform, the default should, however, be the dictionaries that have been created by the logged in user, either as personal dictionaries or as dictionaries belonging to their organizations.
