### PR TITLE
OCLOMRS-71: Fix the bug for concepts in a source not displaying when the owner is not an organization

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,7 +27,7 @@ const App = () => (
           <Route exact path="/dashboard/sources" component={Authenticate(SourceSearch)} />
           <Route exact path="/dashboard/concepts" component={Authenticate(ConceptSearch)} />
           <Route exact path="/dashboard/dictionaries" component={Authenticate(DictionaryDisplay)} />
-          <Route exact path="/dashboard/concepts/:organization/:name" component={Authenticate(SpecificConcept)} />
+          <Route exact path="/dashboard/concepts/:ownerType/:organization/:name" component={Authenticate(SpecificConcept)} />
           <Route exact path="/concepts/:type/:typeName/:collectionName" component={Authenticate(DictionaryConcepts)} />
           <Route exact path="/dictionary-details" component={Authenticate(DictionaryOverview)} />
           <Route exact path="/concepts/:type/:typeName/:collectionName/new/:conceptType?" component={Authenticate(CreateConcept)} />

--- a/src/components/dashboard/components/SourceCard.jsx
+++ b/src/components/dashboard/components/SourceCard.jsx
@@ -30,7 +30,7 @@ const SourceCard = (source) => {
           </div>
           <div className="description col-12 text-left">
             <p>
-              <a href={`/dashboard/concepts/${owner}/${name}`} className="source-type">
+              <a href={`/dashboard/concepts/${owner_type}/${owner}/${name}`} className="source-type">
                 {active_concepts} concepts,
               </a>{' '}
               <a href={`https://www.openconceptlab.com${versions_url}`} className="source-type">

--- a/src/components/dashboard/container/SpecificConcept.jsx
+++ b/src/components/dashboard/container/SpecificConcept.jsx
@@ -33,8 +33,8 @@ export class SpecificConcept extends Component {
   }
 
   componentDidMount() {
-    const { organization, name } = this.props.match.params;
-    this.props.fetchConceptsActionTypes(organization, name);
+    const { organization, name, ownerType } = this.props.match.params;
+    this.props.fetchConceptsActionTypes(organization, name, ownerType);
   }
 
   onSearch(event) {
@@ -113,7 +113,6 @@ export class SpecificConcept extends Component {
                   concepts={this.props.concepts}
                   fetching={this.props.isFetching}
                 />
-
               </InfiniteScroll>
             </div>
           </div>

--- a/src/redux/actions/concepts/specificConceptAction.js
+++ b/src/redux/actions/concepts/specificConceptAction.js
@@ -5,12 +5,16 @@ import { isErrored, fetchConcepts, isFetching } from './ConceptActionCreators';
 const fetchConceptsActionTypes = (
   owner,
   name,
+  ownerType,
   query = '',
   limit = 25,
   page = 1,
 ) => async (dispatch) => {
+  let url = `users/${owner}/sources/${name}/concepts/?q=${query}&limit=${limit}&page=${page}`;
   dispatch(isFetching(true));
-  const url = `orgs/${owner}/sources/${name}/concepts/?q=${query}&limit=${limit}&page=${page}`;
+  if (ownerType === 'Organization') {
+    url = `orgs/${owner}/sources/${name}/concepts/?q=${query}&limit=${limit}&page=${page}`;
+  }
   try {
     const response = await instance.get(url);
     dispatch(fetchConcepts(response.data));

--- a/src/tests/Dashboard/action/specificConceptAction.test.js
+++ b/src/tests/Dashboard/action/specificConceptAction.test.js
@@ -39,4 +39,27 @@ describe('Test suite for specific concepts actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
+
+  it('should return an error message from the db', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 400,
+        response: 'could not complete this request',
+      });
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: IS_FETCHING, payload: false },
+      { type: FETCH_CONCEPTS, payload: 'could not complete this request' },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    const store = mockStore({ payload: {} });
+
+    return store.dispatch(fetchConceptsActionTypes('malaria', 10, 1)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-71: Fix the bug for concepts in a source not displaying when the owner is not an organization](https://issues.openmrs.org/browse/OCLOMRS-71)

# Summary:
At the moment when viewing concepts in a source created by an owner that is not an organization, they are not displayed even when they exist which should not be the case.
