### PR TITLE
OCLOMRS-82: fix dictionary name

### DIFF
--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -135,7 +135,7 @@ export class DictionaryConcepts extends Component {
   render() {
     const {
       match: {
-        params: { typeName },
+        params: { typeName, collectionName },
       },
       location: { pathname },
       concepts,
@@ -147,7 +147,7 @@ export class DictionaryConcepts extends Component {
     const { conceptsCount, searchInput } = this.state;
     return (
       <div className="container-fluid custom-dictionary-concepts">
-        <Header typeName={typeName} />
+        <Header typeName={collectionName} />
         <section className="row mt-2">
           <div className="col-12 col-md-2 pt-1">
             <h4>Concepts</h4>

--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -15,6 +15,7 @@ describe('Test suite for dictionary concepts components', () => {
       match: {
         params: {
           typeName: 'dev-col',
+          collectionName: 'dev-col',
         },
       },
       location: {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix dictionary name](https://issues.openmrs.org/browse/OCLOMRS-82)

# Summary:
Currently, the name shown as the name of the dictionary in the *dictionary concept* page is the username of the user currently using the app, modify the code to display the actual dictionary name instead.