### PR TITLE
OCLOMRS-77: Add newly created concept to user dictionary

### DIFF
--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -43,6 +43,7 @@ export class CreateConcept extends Component {
       names: PropTypes.array,
       descriptions: PropTypes.array,
     }).isRequired,
+    addedConcept: PropTypes.array.isRequired,
   };
   constructor(props) {
     super(props);
@@ -77,8 +78,13 @@ export class CreateConcept extends Component {
         params: { collectionName, type, typeName },
       },
     } = this.props;
-    if (Object.keys(nextProps.newConcept).length) {
-      nextProps.history.push(`/concepts/${type}/${typeName}/${collectionName}`);
+    const { newConcept, addedConcept } = nextProps;
+    const isNewConcept = Object.keys(newConcept).length;
+    const isAddedConcept = addedConcept.length;
+    if (isNewConcept && isAddedConcept) {
+      setTimeout(() => {
+        nextProps.history.push(`/concepts/${type}/${typeName}/${collectionName}`);
+      }, 3000);
     }
   }
 
@@ -169,8 +175,7 @@ export class CreateConcept extends Component {
   addDataFromDescription(data) {
     const currentData = this.state.descriptions.filter(description => description.id === data.id);
     if (currentData.length) {
-      const newList = this.state.descriptions
-        .map(description => (description.id === data.id ? data : description));
+      const newList = this.state.descriptions.map(description => (description.id === data.id ? data : description));
       this.setState(() => ({
         descriptions: newList,
       }));
@@ -242,6 +247,7 @@ export const mapStateToProps = state => ({
   newName: state.concepts.newName,
   description: state.concepts.description,
   newConcept: state.concepts.newConcept,
+  addedConcept: state.concepts.addConceptToDictionary,
 });
 export default connect(
   mapStateToProps,

--- a/src/config/axiosConfig.js
+++ b/src/config/axiosConfig.js
@@ -5,6 +5,7 @@ const instance = axios.create({
 });
 
 instance.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded';
+instance.defaults.headers.put['Content-Type'] = 'application/x-www-form-urlencoded';
 
 instance.interceptors.request.use((config) => {
   // eslint-disable-next-line

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -12,6 +12,7 @@ import {
   REMOVE_ONE_DESCRIPTION,
   CLEAR_FORM_SELECTIONS,
   CREATE_NEW_CONCEPT,
+  ADD_CONCEPT_TO_DICTIONARY,
 } from '../types';
 import {
   isFetching,
@@ -125,12 +126,31 @@ export const createNewConcept = (data, dataUrl) => async dispatch => {
   try {
     const response = await instance.post(url, data);
     dispatch(isSuccess(response.data, CREATE_NEW_CONCEPT));
-    dispatch(isFetching(false));
+    dispatch(addConceptToDictionary(response.data.id, dataUrl));
     notify.show('concept successfully created', 'success', 3000);
   } catch (error) {
+    notify.show('concept could not be created', 'error', 3000);
     if (error.response) {
       dispatch(isErrored(error.response.data, CREATE_NEW_CONCEPT));
       dispatch(isFetching(false));
     }
+  }
+};
+
+export const addConceptToDictionary = (id, dataUrl) => async dispatch => {
+  const newConcept = `${dataUrl}${id}/`;
+  const urlConstruct = dataUrl.split('/');
+  const userType = urlConstruct[1];
+  const sourceName = urlConstruct[4];
+  const username = urlConstruct[2];
+  const data = { data: { expressions: [newConcept] } };
+  const url = `${userType}/${username}/collections/${sourceName}/references/`;
+  try {
+    const response = await instance.put(url, data);
+    dispatch(isSuccess(response.data, ADD_CONCEPT_TO_DICTIONARY));
+    dispatch(isFetching(false));
+    notify.show('concept successfully created', 'success', 3000);
+  } catch (error) {
+    notify.show('an error occurred', 'error', 3000);
   }
 };

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -29,4 +29,5 @@ export const ADD_NEW_DESCRIPTION = '[concepts] add_new_description';
 export const REMOVE_ONE_DESCRIPTION = '[concepts] remove_one_description';
 export const CLEAR_FORM_SELECTIONS = '[concepts] clear_form_selection';
 export const CREATE_NEW_CONCEPT = '[concepts] create_new_concept';
+export const ADD_CONCEPT_TO_DICTIONARY = '[concepts] add_concept_to_dictionary';
 

--- a/src/redux/reducers/ConceptReducers.js
+++ b/src/redux/reducers/ConceptReducers.js
@@ -13,6 +13,7 @@ import {
   REMOVE_ONE_DESCRIPTION,
   CLEAR_FORM_SELECTIONS,
   CREATE_NEW_CONCEPT,
+  ADD_CONCEPT_TO_DICTIONARY,
 } from '../actions/types';
 import { filterSources, filterClass, filterList, normalizeList, filterNames } from './util';
 
@@ -31,6 +32,7 @@ const initialState = {
   newName: [],
   description: [],
   newConcept: {},
+  addConceptToDictionary: [],
 };
 export default (state = initialState, action) => {
   const calculatePayload = () => {
@@ -54,6 +56,11 @@ export default (state = initialState, action) => {
       return {
         ...state,
         loading: action.payload,
+      };
+    case ADD_CONCEPT_TO_DICTIONARY:
+      return {
+        ...state,
+        addConceptToDictionary: action.payload,
       };
     case FILTER_BY_SOURCES:
       return {

--- a/src/tests/Dashboard/reducer/conceptReducer.test.js
+++ b/src/tests/Dashboard/reducer/conceptReducer.test.js
@@ -17,6 +17,7 @@ const initialState = {
   newName: [],
   description: [],
   newConcept: {},
+  addConceptToDictionary: [],
 };
 describe('Test suite for concepts reducer', () => {
   it('should return the initial state', () => {

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -15,6 +15,7 @@ import {
   REMOVE_ONE_DESCRIPTION,
   CLEAR_FORM_SELECTIONS,
   CREATE_NEW_CONCEPT,
+  ADD_CONCEPT_TO_DICTIONARY,
 } from '../../../redux/actions/types';
 import {
   fetchDictionaryConcepts,
@@ -26,10 +27,12 @@ import {
   removeDescription,
   clearSelections,
   createNewConcept,
+  addConceptToDictionary,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import concepts, { mockConceptStore, newConcept, newConceptData } from '../../__mocks__/concepts';
 
 jest.mock('uuid/v4', () => jest.fn(() => 1));
+jest.mock('react-notify-toast');
 const mockStore = configureStore([thunk]);
 
 describe('Test suite for dictionary concept actions', () => {
@@ -96,7 +99,6 @@ describe('Test suite for dictionary concept actions', () => {
     const expectedActions = [
       { type: IS_FETCHING, payload: true },
       { type: CREATE_NEW_CONCEPT, payload: newConcept },
-      { type: IS_FETCHING, payload: false },
     ];
 
     const store = mockStore(mockConceptStore);
@@ -123,6 +125,43 @@ describe('Test suite for dictionary concept actions', () => {
     const store = mockStore(mockConceptStore);
     const url = '/orgs/IHTSDO/sources/SNOMED-CT/concepts/';
     return store.dispatch(createNewConcept(newConceptData, url)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should handle ADD_CONCEPT_TO_DICTIONARY', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: { added: true },
+      });
+    });
+
+    const expectedActions = [
+      { type: ADD_CONCEPT_TO_DICTIONARY, payload: { added: true } },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    const store = mockStore(mockConceptStore);
+    const url = '/orgs/IHTSDO/sources/SNOMED-CT/concepts/';
+    return store.dispatch(addConceptToDictionary(newConceptData, url)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should handle error in ADD_CONCEPT_TO_DICTIONARY', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 400,
+        response: 'bad request',
+      });
+    });
+
+    const expectedActions = [];
+
+    const store = mockStore(mockConceptStore);
+    const url = '/orgs/IHTSDO/sources/SNOMED-CT/concepts/';
+    return store.dispatch(addConceptToDictionary(newConceptData, url)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -100,6 +100,7 @@ describe('Test suite for dictionary concepts components', () => {
   it('should test componentWillReceiveProps and unmount', () => {
     const newProps = {
       newConcept,
+      addedConcept: [{ added: true }],
     };
     const wrapper = shallow(<CreateConcept {...props} />);
     wrapper.setState({ searchInput: 'ciel' });

--- a/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
@@ -12,6 +12,7 @@ import {
   REMOVE_ONE_DESCRIPTION,
   CLEAR_FORM_SELECTIONS,
   CREATE_NEW_CONCEPT,
+  ADD_CONCEPT_TO_DICTIONARY,
 } from '../../../redux/actions/types';
 
 let state;
@@ -32,6 +33,7 @@ beforeEach(() => {
     newName: ['456'],
     description: ['456'],
     newConcept: {},
+    addConceptToDictionary: [],
   };
   action = {};
 });
@@ -189,6 +191,20 @@ describe('Test suite for single dictionary concepts', () => {
     expect(reducer(state, action)).toEqual({
       ...state,
       newConcept: action.payload,
+    });
+  });
+  it('should handle ADD_CONCEPT_TO_DICTIONARY', () => {
+    action = {
+      type: ADD_CONCEPT_TO_DICTIONARY,
+      payload: { added: true },
+    };
+
+    deepFreeze(state);
+    deepFreeze(action);
+
+    expect(reducer(state, action)).toEqual({
+      ...state,
+      addConceptToDictionary: action.payload,
     });
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[As a user, I should see my newly created concept in my dictionary](https://issues.openmrs.org/browse/OCLOMRS-77)

# Summary:
A newly created concept should be automatically added to a user's dictionary from the user's source.

Dev notes:
A newly created concept by default will be added to a source, you are to make sure it is added to collections(dictionary) at the point of creation as well.
