### PR TITLE
OCLOMRS-79: Connect the concept page with the dictionary overview page

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import './styles/dictionary-modal.css';
+import persistActiveconcept from './helperFunction';
 
 const DictionaryDetailCard = (dictionary) => {
   const {
     dictionary: {
       name, created_on, updated_on, public_access, owner, owner_type, active_concepts, description,
+      owner_url, short_code,
     },
   } = dictionary;
 
@@ -25,9 +28,15 @@ const DictionaryDetailCard = (dictionary) => {
           <div className="col-6" id="rightside-detail">
             <h3 className="genCon">Concept Details</h3>
             <p className="paragraph">Total Concepts: { active_concepts }</p>
-            <button type="button" className="btn btn-secondary" id="conceptB">
+            <Link
+              className="btn btn-secondary"
+              id="conceptB"
+              to={`/concepts${owner_url}${short_code}`}
+              // this is a temporary fix, it will be optimized while working on paginations
+              onClick={() => persistActiveconcept(active_concepts)}
+            >
                 Go to concepts
-            </button>
+            </Link>
           </div>
         </div>
         <div className="row"><h3 id="descHd">Description</h3></div>

--- a/src/components/dictionaryConcepts/components/Header.jsx
+++ b/src/components/dictionaryConcepts/components/Header.jsx
@@ -2,22 +2,32 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
-const Header = ({ typeName }) => (
-  <section className="row concept-header">
-    <div className="col-12">
-      <div>
-        <Link to="/dashboard/dictionaries" className="collection-name small-text">
-          <i className="fas fa-chevron-left" /> Go back to dictionaries
-        </Link>
+const Header = ({ locationPath }) => {
+  const { type, typeName, collectionName } = locationPath;
+  return (
+    <section className="row concept-header">
+      <div className="col-12">
+        <div>
+          <Link
+            to={`/dictionaryOverview/${type}/${typeName}/collections/${collectionName}`}
+            className="collection-name small-text"
+          >
+            <i className="fas fa-chevron-left" /> Go back to {collectionName} dictionary
+          </Link>
+        </div>
+        <header>
+          <h2 className="text-capitalize">{collectionName} Dictionary</h2>
+        </header>
       </div>
-      <header>
-        <h2 className="text-capitalize">{typeName} Dictionary</h2>
-      </header>
-    </div>
-  </section>
-);
+    </section>
+  );
+};
 
 Header.propTypes = {
-  typeName: PropTypes.string.isRequired,
+  locationPath: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    typeName: PropTypes.string.isRequired,
+    collectionName: PropTypes.string.isRequired,
+  }).isRequired,
 };
 export default Header;

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -135,7 +135,7 @@ export class DictionaryConcepts extends Component {
   render() {
     const {
       match: {
-        params: { typeName, collectionName },
+        params: { typeName },
       },
       location: { pathname },
       concepts,
@@ -147,7 +147,7 @@ export class DictionaryConcepts extends Component {
     const { conceptsCount, searchInput } = this.state;
     return (
       <div className="container-fluid custom-dictionary-concepts">
-        <Header typeName={collectionName} />
+        <Header locationPath={this.props.match.params} />
         <section className="row mt-2">
           <div className="col-12 col-md-2 pt-1">
             <h4>Concepts</h4>


### PR DESCRIPTION
# JIRA TICKET NAME:
[Connect the concept page with the dictionary overview page](https://issues.openmrs.org/browse/OCLOMRS-79)

# Summary:
As a user, while viewing the dictionary overview page, I should be able to click on `Go to concepts` button to see all the concepts in that dictionary.
