### PR TITLE
OCLOMRS-68: Implement logic for adding CIEL concepts to a dictionary

### DIFF
--- a/src/components/dashboard/components/concepts/SpecificConceptTable.jsx
+++ b/src/components/dashboard/components/concepts/SpecificConceptTable.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import '../../styles/index.css';
 import AddConceptModal from './ConceptModal';
+import addExistingConcept from '../../../../redux/actions/concepts/addExistingConcepts/index';
 
-const SpecificConceptTable = (concept) => {
+const SpecificConceptTable = (props) => {
   const {
     concept: {
       id,
@@ -11,8 +14,15 @@ const SpecificConceptTable = (concept) => {
       display_name,
       source,
       owner,
+      url,
     },
-  } = concept;
+  } = props;
+  const handleAdd = () => {
+    const expressions = [url];
+    props.addExistingConcept({ data: { expressions } });
+    localStorage.setItem('conceptName', display_name);
+  };
+
   return (
     <tr className="concept-table">
       <td className="table1">{id}</td>
@@ -21,7 +31,7 @@ const SpecificConceptTable = (concept) => {
         {concept_class} / {datatype}
       </td>
       <td className="table3">
-        <a className="dummy-link"> Add </a> {' '}
+        <a href="#" onClick={() => handleAdd(props)} className="add-btn"> Add </a> {' '}
         <a href="!#" className="add-btn" data-toggle="modal" data-target={`#conceptPreview${id}`}>
           Preview
         </a>
@@ -37,4 +47,10 @@ const SpecificConceptTable = (concept) => {
   );
 };
 
-export default SpecificConceptTable;
+SpecificConceptTable.propTypes = {
+  addExistingConcept: PropTypes.func.isRequired,
+  concept: PropTypes.arrayOf(PropTypes.shape({
+    owner: PropTypes.string,
+  })).isRequired,
+};
+export default connect(null, { addExistingConcept })(SpecificConceptTable);

--- a/src/components/dashboard/container/SpecificConcept.jsx
+++ b/src/components/dashboard/container/SpecificConcept.jsx
@@ -87,6 +87,9 @@ export class SpecificConcept extends Component {
     } = this.state;
     const { hasMore, concepts } = this.props;
     const { organization, name } = this.props.match.params;
+    const typeName = localStorage.getItem('typeName');
+    const dictionaryId = localStorage.getItem('dictionaryId');
+    const userType = localStorage.getItem('type');
     return (
       <div className="dashboard-wrapper">
         <SideBar />
@@ -99,8 +102,8 @@ export class SpecificConcept extends Component {
         <div className="container-fluid pt-3">
           <div className="row justify-content-center">
             <div className="col-10 offset-sm-1">
-              <Link to="/dashboard/dictionaries" id="dictionary-link">
-                <i className="fas fa-chevron-left" /> Back to Dictionaries
+              <Link to={`/concepts/${userType}/${typeName}/${dictionaryId}`} id="dictionary-link">
+                <i className="fas fa-chevron-left" /> Back to {dictionaryId} Dictionary
               </Link>
               <InfiniteScroll
                 dataLength={concepts.length}

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -23,6 +23,8 @@ export class DictionaryConcepts extends Component {
     match: PropTypes.shape({
       params: PropTypes.shape({
         typeName: PropTypes.string,
+        collectionName: PropTypes.string,
+        type: PropTypes.string,
       }),
     }).isRequired,
     location: PropTypes.shape({
@@ -53,6 +55,9 @@ export class DictionaryConcepts extends Component {
         params: { collectionName, type, typeName },
       },
     } = this.props;
+    localStorage.setItem('dictionaryId', this.props.match.params.collectionName);
+    localStorage.setItem('type', this.props.match.params.type);
+    localStorage.setItem('typeName', this.props.match.params.typeName);
     this.setState({ collectionName, type, typeName });
   }
 

--- a/src/redux/actions/concepts/addExistingConcepts/index.js
+++ b/src/redux/actions/concepts/addExistingConcepts/index.js
@@ -1,0 +1,20 @@
+import { notify } from 'react-notify-toast';
+import instance from '../../../../config/axiosConfig';
+import { ADD_EXISTING_CONCEPTS } from '../../types';
+import { isSuccess } from '../../globalActionCreators';
+
+const addExistingConceptsAction = data => async (dispatch) => {
+  const typeName = localStorage.getItem('typeName');
+  const dictionaryId = localStorage.getItem('dictionaryId');
+  const userType = localStorage.getItem('type');
+  const url = `${userType}/${typeName}/collections/${dictionaryId}/references/`;
+  const payload = await instance.put(url, data);
+  dispatch(isSuccess(payload.data, ADD_EXISTING_CONCEPTS));
+  const conceptName = localStorage.getItem('conceptName');
+  if (payload.data[0].added === true) {
+    notify.show(`Concept ${conceptName} successfully added to your dictionary`, 'success', 3000);
+  }
+  notify.show(`Concept ${conceptName} already exists in your dictionary, add a new one`, 'error', 3000);
+};
+export default addExistingConceptsAction;
+

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -31,3 +31,4 @@ export const CLEAR_FORM_SELECTIONS = '[concepts] clear_form_selection';
 export const CREATE_NEW_CONCEPT = '[concepts] create_new_concept';
 export const ADD_CONCEPT_TO_DICTIONARY = '[concepts] add_concept_to_dictionary';
 
+export const ADD_EXISTING_CONCEPTS = '[concepts] add_existing_concepts';

--- a/src/tests/Dashboard/addExistingConcepts/actions/index.test.js
+++ b/src/tests/Dashboard/addExistingConcepts/actions/index.test.js
@@ -1,0 +1,82 @@
+import moxios from 'moxios';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import instance from '../../../../config/axiosConfig';
+import { ADD_EXISTING_CONCEPTS } from '../../../../redux/actions/types';
+import addExistingConceptsAction from '../../../../redux/actions/concepts/addExistingConcepts/index';
+
+const mockStore = configureStore([thunk]);
+jest.mock('react-notify-toast');
+
+describe('Test suite for sources actions', () => {
+  beforeEach(() => {
+    moxios.install(instance);
+  });
+
+  afterEach(() => {
+    moxios.uninstall(instance);
+  });
+  it('dispatches ADD_EXISTING_CONCEPTS  action type on respose from server', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [{ data: { data: [{ added: true }] } }],
+      });
+    });
+
+    const returnedAction = [{
+      type: ADD_EXISTING_CONCEPTS,
+      payload: [{ data: { data: [{ added: true }] } }],
+    }];
+    const data = { expressions: ['/orgs/WHO/sources/ICD-10/concepts/A15.1/'] };
+    const store = mockStore({});
+    return store.dispatch(addExistingConceptsAction(data))
+      .then(() => expect(store.getActions()).toEqual(returnedAction));
+  });
+  it('should return a success message after adding concepts', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [{ added: true }],
+      });
+    });
+
+    const expectedActions = [
+      {
+        type: ADD_EXISTING_CONCEPTS,
+        payload: [{ added: true }],
+      },
+    ];
+    const data = { expressions: ['/orgs/WHO/sources/ICD-10/concepts/A15.1/'] };
+    const store = mockStore({});
+
+    return store.dispatch(addExistingConceptsAction(data)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should return an error message from the db when add an already added concept', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [{ added: false }],
+      });
+    });
+
+    const expectedActions = [
+      {
+        type: ADD_EXISTING_CONCEPTS,
+        payload: [{ added: false }],
+      },
+    ];
+    const data = { expressions: ['/orgs/WHO/sources/ICD-10/concepts/A15.1/'] };
+    const store = mockStore({});
+
+    return store.dispatch(addExistingConceptsAction(data)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+});
+

--- a/src/tests/Dashboard/addExistingConcepts/specificConceptTable.test.jsx
+++ b/src/tests/Dashboard/addExistingConcepts/specificConceptTable.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { createMockStore } from 'redux-test-utils';
+import SpecificConceptTable from '../../../components/dashboard/components/concepts/SpecificConceptTable';
+import Authenticated from '../../__mocks__/fakeStore';
+
+const store = createMockStore(Authenticated);
+describe('Dashboard SpecificConceptTable Component', () => {
+  it('should render without crashing', () => {
+    const props = {
+      concept: {},
+      addExistingConcept: jest.fn(),
+    };
+    const wrapper = mount(<MemoryRouter>
+      <Provider store={store}>
+        <SpecificConceptTable {...props} />
+      </Provider>
+    </MemoryRouter>);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('calls the handleAdd function when the Add link is clicked', () => {
+    const props = {
+      concept: {},
+      addExistingConcept: jest.fn(() => {}),
+    };
+    const wrapper = mount(<MemoryRouter>
+      <Provider store={store}>
+        <SpecificConceptTable {...props} />
+      </Provider>
+    </MemoryRouter>);
+    wrapper.find('.add-btn').at(0).simulate('click');
+  });
+});

--- a/src/tests/Dashboard/container/SpecificConcept.test.jsx
+++ b/src/tests/Dashboard/container/SpecificConcept.test.jsx
@@ -1,14 +1,17 @@
 import React from 'react';
-import { mount , shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { createMockStore } from 'redux-test-utils';
 import {
   SpecificConcept,
   mapStateToProps,
 } from '../../../components/dashboard/container/SpecificConcept';
 import concepts from '../../__mocks__/concepts';
+import Authenticated from '../../__mocks__/fakeStore';
 
 jest.mock('../../../components/dashboard/components/dictionary/AddDictionary');
-
+const store = createMockStore(Authenticated);
 describe('Dashboard SpecificConcept Component', () => {
   it('should render without crashing', () => {
     const props = {
@@ -47,9 +50,9 @@ describe('Dashboard SpecificConcept Component', () => {
         },
       },
     };
-    const wrapper = mount(<MemoryRouter>
+    const wrapper = mount(<MemoryRouter><Provider store={store}>
       <SpecificConcept {...props} match={{ params }} />
-    </MemoryRouter>);
+    </Provider></MemoryRouter>);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -89,9 +92,9 @@ describe('Dashboard SpecificConcept Component', () => {
         },
       },
     };
-    const wrapper = mount(<MemoryRouter>
+    const wrapper = mount(<MemoryRouter><Provider store={store}>
       <SpecificConcept {...props} match={{ params }} />
-    </MemoryRouter>);
+    </Provider></MemoryRouter>);
     const event = { target: { name: 'searchInput', value: 'drug' } };
     wrapper.find('#search').simulate('change', event);
     wrapper.find('.search-bar-wrapper').simulate('submit', {


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-68: Implement logic for adding CIEL concepts to a dictionary](https://issues.openmrs.org/browse/OCLOMRS-68)

# Summary:
- This happens after the user clicks the button to add CIEL concepts, It will show all concepts in CIEL source each with the Add button link infront, so a user can add one or multiple concepts by clicking the add link. And then when they navigate back to their dictionary they can see the concepts they added.