### PR TITLE
OCLOMRS-103: Enable viewing own dictionaries when on public dictionaries interface

### DIFF
--- a/src/components/dashboard/container/DictionariesDisplay.jsx
+++ b/src/components/dashboard/container/DictionariesDisplay.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import autoBind from 'react-autobind';
 import propTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import '../styles/index.css';
 import { fetchDictionaries, searchDictionaries } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import { clearDictionaries } from '../../../redux/actions/dictionaries/dictionaryActions';
@@ -63,7 +64,11 @@ export class DictionaryDisplay extends Component {
               fetching={isFetching}
             />
           </div>
-
+          <div className="back">
+            <Link to="/dashboard/userdictionaries" >
+              <i className="fas fa-chevron-left" /> Back to my Dictionaries
+            </Link>
+          </div>
 
           <div className="row justify-content-center public-search" id="container">
             <div className="offset-sm-1 col-10">

--- a/src/components/dashboard/styles/index.css
+++ b/src/components/dashboard/styles/index.css
@@ -537,6 +537,11 @@ p{
 }
 
 #load {
-  width: 600px;
+  width: 900px;
   padding-left: 55%;
+}
+
+.back{
+  margin-right:3%;
+  margin-top:1rem;
 }


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-103: Enable viewing own dictionaries when on public dictionaries interface](https://issues.openmrs.org/browse/OCLOMRS-103)

# Summary:
Currently, when a user is viewing public dictionaries, they are unable to return to their own dictionaries aside from clicking the application name to return them to the home page, which should not be the case

