### PR TITLE
OCLOMRS-94: Rework the concept creation page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,9 +35,9 @@ const App = () => (
           <Route exact path="/dashboard/dictionaries" component={Authenticate(DictionaryDisplay)} />
           <Route exact path="/dashboard/userdictionaries" component={Authenticate(OwnerDictionary)} />
           <Route exact path="/dashboard/concepts/:ownerType/:organization/:name" component={Authenticate(SpecificConcept)} />
-          <Route exact path="/concepts/:type/:typeName/:collectionName/:dictionaryName" component={Authenticate(DictionaryConcepts)} />
+          <Route exact path="/concepts/:type/:typeName/:collectionName/:dictionaryName/:language" component={Authenticate(DictionaryConcepts)} />
           <Route exact path="/dictionaryOverview/:ownerType/:owner/:type/:name" component={Authenticate(DictionaryOverview)} />
-          <Route exact path="/concepts/:type/:typeName/:collectionName/:dictionaryName/new/:conceptType?" component={Authenticate(CreateConcept)} />
+          <Route exact path="/concepts/:type/:typeName/:collectionName/:dictionaryName/:language/new/:conceptType?" component={Authenticate(CreateConcept)} />
           <Route exact path="/search/:query?" component={Authenticate(GeneralSearchContainer)} />
           <Route component={NotFound} />
         </Switch>

--- a/src/components/dashboard/components/dictionary/DictionaryCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryCard.jsx
@@ -12,6 +12,7 @@ const DictionaryCard = (dictionary) => {
       active_concepts,
       created_by,
       url,
+      supported_locales,
     },
   } = dictionary;
 
@@ -35,7 +36,7 @@ const DictionaryCard = (dictionary) => {
           <div className="description col-12 text-left">
             <p>
               <Link
-                to={`/concepts${owner_url}${short_code}/${name}`}
+                to={`/concepts${owner_url}${short_code}/${name}/${supported_locales}`}
                 className="source-type"
               >
                 Concepts: { active_concepts }

--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -6,7 +6,7 @@ const DictionaryDetailCard = (dictionary) => {
   const {
     dictionary: {
       name, created_on, updated_on, public_access, owner, owner_type, active_concepts, description,
-      owner_url, short_code,
+      owner_url, short_code, supported_locales,
     },
   } = dictionary;
 
@@ -30,7 +30,7 @@ const DictionaryDetailCard = (dictionary) => {
             <Link
               className="btn btn-secondary"
               id="conceptB"
-              to={`/concepts${owner_url}${short_code}/${name}`}
+              to={`/concepts${owner_url}${short_code}/${name}/${supported_locales}`}
             >
                 Go to concepts
             </Link>

--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -122,6 +122,7 @@ export class DictionaryModal extends React.Component {
                       name="supported_locales"
                       id="supported_locales"
                       placeholder="English"
+                      onChange={this.onChange}
                     >
                       {language &&
                       language.map(languages => (

--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -11,19 +11,22 @@ class ConceptNameRows extends Component {
     addDataFromRow: PropTypes.func.isRequired,
     removeRow: PropTypes.func.isRequired,
     removeDataFromRow: PropTypes.func.isRequired,
+    pathName: PropTypes.string.isRequired,
   };
   constructor(props) {
     super(props);
+    const defaultLocale = locale.find((currentLocale) => {
+      return currentLocale.value === props.pathName.language;
+    });
     this.state = {
       id: this.props.newRow,
       name: '',
-      locale: 'en',
+      locale: defaultLocale,
       locale_preferred: 'Yes',
       name_type: 'Fully Specified',
     };
     autoBind(this);
   }
-
   componentDidUpdate(prevProps, prevState) {
     if (prevState !== this.state) {
       this.sendToTopComponent();
@@ -41,7 +44,7 @@ class ConceptNameRows extends Component {
 
   handleNameLocale(selectedOptions) {
     this.setState({
-      locale: selectedOptions.value,
+      locale: selectedOptions,
     });
     this.sendToTopComponent();
   }
@@ -58,15 +61,18 @@ class ConceptNameRows extends Component {
   render() {
     return (
       <tr>
-        <th scope="row" className="concept-language">
-          <Select
-            name="locale"
-            value={this.state.locale.value}
-            onChange={this.handleNameLocale}
-            options={locale}
+        <td>
+          <input
+            type="text"
+            className="form-control"
+            onChange={this.handleChange}
+            placeholder="eg. Malaria"
+            name="name"
+            value={this.state.name}
+            id="concept-name"
             required
           />
-        </th>
+        </td>
         <td>
           <select
             id="type"
@@ -80,18 +86,15 @@ class ConceptNameRows extends Component {
             <option>Fully Specified</option>
           </select>
         </td>
-        <td>
-          <input
-            type="text"
-            className="form-control"
-            onChange={this.handleChange}
-            placeholder="eg. Malaria"
-            name="name"
-            value={this.state.name}
-            id="concept-name"
+        <th scope="row" className="concept-language">
+          <Select
+            name="locale"
+            value={this.state.locale}
+            onChange={this.handleNameLocale}
+            options={locale}
             required
           />
-        </td>
+        </th>
         <td>
           <select
             id="locale_preferred"

--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -57,31 +57,31 @@ const CreateConceptForm = props => (
             </div>
           </div>
         )}
-        <div className="form-group col-5">
-          <label htmlFor="datatype">Datatype</label>
-          <select
-            id="datatype"
-            name="datatype"
-            required
-            value={props.state.datatype}
-            className="form-control "
-            onChange={props.handleChange}
-          >
-            <option value="n/a" />
-            <option>Numeric</option>
-            <option>Text</option>
-            <option>None</option>
-            <option>Document</option>
-            <option>Date</option>
-            <option>Time</option>
-            <option>Datetime</option>
-            <option>Boolean</option>
-            <option>Rule</option>
-            <option>Structured-Numeric</option>
-            <option>Complex</option>
-            <option>Coded</option>
-          </select>
-        </div>
+      </div>
+      <div className="datatypefield">
+        <label htmlFor="datatype">Datatype</label>
+        <select
+          id="datatype"
+          name="datatype"
+          required
+          value={props.state.datatype}
+          className="form-control "
+          onChange={props.handleChange}
+        >
+          <option>N/A</option>
+          <option>Numeric</option>
+          <option>Text</option>
+          <option>None</option>
+          <option>Document</option>
+          <option>Date</option>
+          <option>Time</option>
+          <option>Datetime</option>
+          <option>Boolean</option>
+          <option>Rule</option>
+          <option>Structured-Numeric</option>
+          <option>Complex</option>
+          <option>Coded</option>
+        </select>
       </div>
       <div className="form-group">
         <div className="row col-12 custom-concept-list">

--- a/src/components/dictionaryConcepts/components/CreateConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptTable.jsx
@@ -6,9 +6,9 @@ const CreateConceptTable = props => (
   <table className="table table-striped table-bordered concept-form-table">
     <thead className="header text-white">
       <tr>
-        <th scope="col">Language</th>
-        <th scope="col">Type</th>
         <th scope="col">Name</th>
+        <th scope="col">Type</th>
+        <th scope="col">Language</th>
         <th scope="col">Preferred in locale</th>
         <th scope="col">Actions</th>
       </tr>

--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -11,12 +11,16 @@ class DescriptionRow extends Component {
     addDataFromDescription: PropTypes.func.isRequired,
     removeDescription: PropTypes.func.isRequired,
     removeDataFromRow: PropTypes.func.isRequired,
+    pathName: PropTypes.string.isRequired,
   }
   constructor(props) {
     super(props);
+    const defaultLocale = locale.find((currentLocale) => {
+      return currentLocale.value === props.pathName.language;
+    });
     this.state = {
       id: this.props.newRow,
-      locale: 'en',
+      locale: defaultLocale,
       description: '',
     };
     autoBind(this);
@@ -36,10 +40,9 @@ class DescriptionRow extends Component {
     this.setState(() => ({ [name]: value }));
     this.sendToTopComponent();
   }
-
   handleNameLocale(selectedOptions) {
     this.setState({
-      locale: selectedOptions.value,
+      locale: selectedOptions,
     });
     this.sendToTopComponent();
   }
@@ -56,16 +59,6 @@ class DescriptionRow extends Component {
   render() {
     return (
       <tr>
-        <th scope="row" className="concept-language">
-          <Select
-            name="locale"
-            id="description-locale"
-            value={this.state.locale.value}
-            onChange={this.handleNameLocale}
-            options={locale}
-            required
-          />
-        </th>
         <td>
           <textarea
             type="text"
@@ -77,6 +70,16 @@ class DescriptionRow extends Component {
             id="concept-description"
           />
         </td>
+        <th scope="row" className="concept-language">
+          <Select
+            name="locale"
+            id="description-locale"
+            value={this.state.locale}
+            onChange={this.handleNameLocale}
+            options={locale}
+            required
+          />
+        </th>
         <td>
           <a
             href="#!"

--- a/src/components/dictionaryConcepts/components/DescriptionTable.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionTable.jsx
@@ -6,8 +6,8 @@ const DescriptionTable = props => (
   <table className="table table-striped table-bordered concept-form-table">
     <thead className="header text-white">
       <tr>
-        <th scope="col">Language</th>
         <th scope="col">Description</th>
+        <th scope="col">Language</th>
         <th scope="col">Actions</th>
       </tr>
     </thead>

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -237,6 +237,7 @@ export class CreateConcept extends Component {
                 addDataFromRow={this.addDataFromRow}
                 addDataFromDescription={this.addDataFromDescription}
                 removeDataFromRow={this.removeDataFromRow}
+                pathName={this.props.match.params}
               />
             </div>
           </div>

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -201,6 +201,7 @@ export const mapStateToProps = state => ({
   filteredSources: state.concepts.filteredSources,
   loading: state.concepts.loading,
   filteredList: state.concepts.filteredList,
+  dictionaries: state.dictionaries.dictionary,
 });
 
 export default connect(

--- a/src/components/dictionaryConcepts/style/index.css
+++ b/src/components/dictionaryConcepts/style/index.css
@@ -294,3 +294,8 @@ select.form-control {
 .small-text {
   font-size: .7rem;
 }
+.datatypefield {
+  width: 41%;
+  font-size: .8rem;
+  padding-bottom: 1%;
+}

--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -123,11 +123,15 @@ describe('Test suite for dictionary concepts components', () => {
         filteredSources: [],
         filteredClass: [],
       },
+      dictionaries: {
+        dictionary: [],
+      },
     };
     expect(mapStateToProps(initialState).concepts).toEqual([]);
     expect(mapStateToProps(initialState).filteredClass).toEqual([]);
     expect(mapStateToProps(initialState).filteredSources).toEqual([]);
     expect(mapStateToProps(initialState).loading).toEqual(false);
+    expect(mapStateToProps(initialState).dictionaries).toEqual([]);
   });
   it('should handle concept pagination', () => {
     const props = {


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-94: Rework the concept creation page](https://issues.openmrs.org/browse/OCLOMRS-94)

# Summary:
Based on feedback received, the following should be rearranged:

- The datatype select element should be below the class select element
- The name column should come before the language column in both the Names and Description section.
- The language should be preloaded with the language of the dictionary itself
- Default value for datatype should be 'N/A'