### PR TITLE
OCLOMRS-107: Fix the link to view own dictionaries redirecting to wrong dashboard when viewing public dictionaries

### DIFF
--- a/src/components/dashboard/container/DictionariesDisplay.jsx
+++ b/src/components/dashboard/container/DictionariesDisplay.jsx
@@ -65,7 +65,7 @@ export class DictionaryDisplay extends Component {
             />
           </div>
           <div className="back">
-            <Link to="/dashboard/userdictionaries" >
+            <Link to="/dashboard" >
               <i className="fas fa-chevron-left" /> Back to my Dictionaries
             </Link>
           </div>


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-107: Fix the link to view own dictionaries redirecting to wrong dashboard when viewing public dictionaries](https://issues.openmrs.org/browse/OCLOMRS-107)

# Summary:
Currently, when you click the link to go back to your dictionaries, you are redirected to the wrong dashboard. This should not be the case since changes had been made to the dashboard and a new component was created.
