### PR TITLE
OCLOMRS:118: Make the entire dictionary card clickable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ yarn.lock
 #test snapshots
 **/__snapshots__/**
 src/components/dashboard/container/ListContainer.jsx
+.env

--- a/src/App.css
+++ b/src/App.css
@@ -74,3 +74,7 @@
 .error-template {
   margin-top: 10px !important;
 }
+
+.card-link {
+  cursor: pointer;
+}

--- a/src/components/dashboard/components/dictionary/DictionaryCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryCard.jsx
@@ -6,53 +6,47 @@ const DictionaryCard = (dictionary) => {
     dictionary: {
       name,
       owner,
-      short_code,
       owner_type,
-      owner_url,
       active_concepts,
       created_by,
       url,
-      supported_locales,
     },
+    gotoDictionary,
   } = dictionary;
 
   const ownerType = owner_type === 'Organization' ? 'org' : 'user';
   return (
-    <div className="col-12 col-sm-6 col-md-4 col-lg-3 p-3">
+    <div
+      className="col-12 col-sm-6 col-md-4 col-lg-3 p-3 card-link"
+      role="presentation"
+      onClick={() => gotoDictionary(`/dictionaryOverview${url}`)}
+    >
       <div className="card-container" id="dictionary">
         <div className="source-card-body">
           <div className="source-name col-12 mt-3" id="dictionaryHeader">
             <a>
               <h6 className="text-left" id="cardCapitalize">
-                { name }
+                {name}
               </h6>
             </a>
             <div className="float-created-at" id="dictionary-owner">
               <a className="source-owner-name">
-                { owner } <small>({ownerType})</small>
+                {owner} <small>({ownerType})</small>
               </a>
             </div>
           </div>
           <div className="description col-12 text-left">
             <p>
-              <Link
-                to={`/concepts${owner_url}${short_code}/${name}/${supported_locales}`}
-                className="source-type"
-              >
-                Concepts: { active_concepts }
-              </Link>
+              <span className="source-type">Concepts: {active_concepts}</span>
               <br />
               <a className="source-type" id="cardCapitalize">
-                Created By: { created_by }
+                Created By: {created_by}
               </a>
             </p>
           </div>
         </div>
         <div className="source-card-footer">
-          <Link
-            className="view-details-link"
-            to={`/dictionaryOverview${url}`}
-          >
+          <Link className="view-details-link" to={`/dictionaryOverview${url}`}>
             <span id="viewDetails">View Details</span>
           </Link>
         </div>

--- a/src/components/dashboard/components/dictionary/ListDictionaries.jsx
+++ b/src/components/dashboard/components/dictionary/ListDictionaries.jsx
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types';
 import Card from './DictionaryCard';
 import Loader from '../../../Loader';
 
-const ListDictionaries = ({
-  dictionaries, fetching, fetchData,
-}) => {
+const ListDictionaries = (props) => {
+  const { dictionaries, fetching, fetchData } = props;
   if (fetching) {
     return (
       <div className="text-center mt-3" id="load">
@@ -21,6 +20,7 @@ const ListDictionaries = ({
             dictionary={dictionary}
             key={dictionary.uuid}
             fetchData={fetchData}
+            {...props}
           />))}
 
       </div>

--- a/src/components/dashboard/container/DictionariesDisplay.jsx
+++ b/src/components/dashboard/container/DictionariesDisplay.jsx
@@ -18,6 +18,9 @@ export class DictionaryDisplay extends Component {
     isFetching: propTypes.bool.isRequired,
     searchDictionaries: propTypes.func.isRequired,
     clearDictionaries: propTypes.func.isRequired,
+    history: propTypes.shape({
+      push: propTypes.func,
+    }).isRequired,
   };
   constructor(props) {
     super(props);
@@ -45,6 +48,10 @@ export class DictionaryDisplay extends Component {
       this.props.clearDictionaries();
       this.props.fetchDictionaries(value);
     }
+  }
+
+  gotoDictionary = (url) => {
+    this.props.history.push(url);
   }
 
   render() {
@@ -75,6 +82,7 @@ export class DictionaryDisplay extends Component {
               <ListDictionaries
                 dictionaries={dictionaries}
                 fetching={isFetching}
+                gotoDictionary={this.gotoDictionary}
               />
             </div>
           </div>

--- a/src/components/userDasboard/components/CardWrapper.jsx
+++ b/src/components/userDasboard/components/CardWrapper.jsx
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import DictionaryCard from '../../dashboard/components/dictionary/DictionaryCard';
 import Loader from '../../Loader';
 
-const CardWrapper = ({ dictionaries, fetching, org }) => {
+const CardWrapper = (props) => {
+  const { dictionaries, fetching, org } = props;
   if (dictionaries.length >= 1) {
     return (
       <div className="row justify-content-center">
         {dictionaries.map(dictionary => (
-          <DictionaryCard dictionary={dictionary} key={dictionary.uuid} />
+          <DictionaryCard dictionary={dictionary} key={dictionary.uuid} {...props} />
         ))}
       </div>
     );

--- a/src/components/userDasboard/container/UserDashboard.jsx
+++ b/src/components/userDasboard/container/UserDashboard.jsx
@@ -21,11 +21,17 @@ export class UserDashboard extends Component {
       orgs: PropTypes.number,
       public_collections: PropTypes.number,
     }).isRequired,
+    history: PropTypes.shape({
+      push: PropTypes.func,
+    }).isRequired,
   };
 
-  state = {
-    show: false,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      show: false,
+    };
+  }
 
   componentDidMount() {
     const username = getUsername();
@@ -34,6 +40,10 @@ export class UserDashboard extends Component {
 
   componentWillUnmount() {
     this.props.clearDictionaryData();
+  }
+
+  gotoDictionary = (url) => {
+    this.props.history.push(url);
   }
 
   handleHide = () => this.setState({ show: false });
@@ -84,8 +94,17 @@ export class UserDashboard extends Component {
             </div>
             <div className="row justify-content-center">
               <div className="col-11">
-                <CardWrapper dictionaries={userDictionary} fetching={loading} />
-                <CardWrapper dictionaries={orgDictionary} fetching={loading} org />
+                <CardWrapper
+                  dictionaries={userDictionary}
+                  fetching={loading}
+                  gotoDictionary={this.gotoDictionary}
+                />
+                <CardWrapper
+                  dictionaries={orgDictionary}
+                  fetching={loading}
+                  org
+                  gotoDictionary={this.gotoDictionary}
+                />
               </div>
             </div>
           </div>

--- a/src/tests/Dashboard/container/DictionaryDisplay.test.jsx
+++ b/src/tests/Dashboard/container/DictionaryDisplay.test.jsx
@@ -11,7 +11,6 @@ import { DictionariesSearch } from '../../../components/dashboard/components/dic
 import ListDictionaries from '../../../components/dashboard/components/dictionary/ListDictionaries';
 import DictionaryCard from '../../../components/dashboard/components/dictionary/DictionaryCard';
 
-
 describe('DictionaryDisplay', () => {
   it('should render without any dictionary data', () => {
     const props = {
@@ -40,6 +39,20 @@ describe('DictionaryDisplay', () => {
     </MemoryRouter>);
 
     expect(wrapper.find('.dashboard-wrapper')).toHaveLength(1);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('Should handle click on dictionary card', () => {
+    const props = {
+      fetchDictionaries: jest.fn(),
+      dictionaries: [dictionaries],
+      isFetching: false,
+      organizations: [organizations],
+      history: { push: jest.fn() },
+    };
+    const wrapper = mount(<MemoryRouter>
+      <DictionaryDisplay {...props} />
+    </MemoryRouter>);
+    wrapper.find('.card-link').simulate('click');
     expect(wrapper).toMatchSnapshot();
   });
   it('should render preloader spinner', () => {

--- a/src/tests/userDashboard/container/UserDashboard.test.jsx
+++ b/src/tests/userDashboard/container/UserDashboard.test.jsx
@@ -131,4 +131,37 @@ describe('Test suite for dictionary concepts components', () => {
     expect(mapStateToProps(initialState).orgDictionary).toEqual([]);
     expect(mapStateToProps(initialState).loading).toEqual(false);
   });
+
+  it('Should handle click on dictionary card', () => {
+    const propsWithDictionary = {
+      fetchUserData: jest.fn(),
+      loading: false,
+      userDictionary: [dictionary],
+      orgDictionary: [],
+      clearDictionaryData: jest.fn(),
+      history: { push: jest.fn() },
+      userOrganization: [
+        {
+          id: 'Test',
+          name: 'Test org',
+          url: '/orgs/Test/',
+        },
+        {
+          id: 'Test2',
+          name: 'Test org 2',
+          url: '/orgs/Test2/',
+        },
+      ],
+      user: {
+        name: 'emasys nd',
+        orgs: 2,
+        public_collections: 1,
+      },
+    };
+    const wrapper = mount(<Router>
+      <UserDashboard {...propsWithDictionary} />
+    </Router>);
+    wrapper.find('.card-link').simulate('click');
+    expect(wrapper).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make the entire dictionary card clickable](https://issues.openmrs.org/browse/OCLOMRS-118)

# Summary:
Should make the entire card clickable, and it should redirect to the dictionary overview instead of having another option redirecting to the concepts page.
