### PR TITLE
OCLOMRS-126: Change the naming of the submit button on create concept page

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -103,7 +103,7 @@ const CreateConceptForm = props => (
       </div>
       <div className="submit-button text-left">
         <button className="btn btn-sm mr-1 col-2 bg-blue" type="submit">
-          submit
+          Create
         </button>
         <button className="btn btn-sm btn-danger col-2" type="reset">
           Cancel


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-126: Change the naming of the submit button on create concept page](https://issues.openmrs.org/browse/OCLOMRS-126)

# Summary:
Currently, the creating concept button indicates “submit”, but this should say either be “save” or “create”