### PR TITLE
OCLOMRS-130: Change the header naming on the create concept form

### DIFF
--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -193,7 +193,7 @@ export class CreateConcept extends Component {
     const {
       match: {
         params: {
-          conceptType, collectionName, dictionaryName,
+          conceptType, dictionaryName,
         },
       },
     } = this.props;
@@ -212,8 +212,7 @@ export class CreateConcept extends Component {
               </Link>
             </div>
             <h3>
-              Create a<span className="text-capitalize">{concept}</span> Concept <br />
-              <small className="text-muted">in source: {collectionName} custom concepts</small>
+              {dictionaryName}: Create a<span className="text-capitalize">{concept}</span> Concept <br />
             </h3>
           </div>
         </div>

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -43,7 +43,7 @@ describe('Test suite for dictionary concepts components', () => {
     const wrapper = mount(<Router>
       <CreateConcept {...props} />
     </Router>);
-    expect(wrapper.find('h3').text()).toEqual('Create a diagnosis Concept in source: dev-col custom concepts');
+    expect(wrapper.find('h3').text()).toEqual(': Create a diagnosis Concept ');
     expect(wrapper).toMatchSnapshot();
   });
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-130: Change the header naming on the create concept form](https://issues.openmrs.org/browse/OCLOMRS-130)

# Summary:
Currently, the heading indicates “in source: DTD custom concepts” DTD is a short code, which isn’t consistent with showing the full name of the dictionary.
The heading should only indicate “Dictionary Name: Create a Diagnosis Concept” on a single line.
