### PR TITLE
OCLOMRS-140: Implement the retrieval of CIEL concepts on the bulk concept page

### DIFF
--- a/src/components/bulkConcepts/addBulkConcepts.jsx
+++ b/src/components/bulkConcepts/addBulkConcepts.jsx
@@ -1,15 +1,32 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import './style.css';
+import fetchCielConcepts from '../../redux/actions/bulkConcepts';
+import BulkConceptList from '../bulkConcepts/bulkConceptList';
 
-class AddBulkConcepts extends Component {
+export class AddBulkConcepts extends Component {
+  static propTypes = {
+    fetchCielConcepts: PropTypes.func.isRequired,
+    cielConcepts: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.string,
+    })).isRequired,
+    isFetching: PropTypes.bool.isRequired,
+  };
+  handleCielClick=() => {
+    this.props.fetchCielConcepts();
+  }
   render() {
     const dictionaryName = localStorage.getItem('dictionaryName');
+    const { cielConcepts } = this.props;
     return (
       <div className="container add-bulk-concepts">
         <a href={document.referrer} id="dictionary-link">
           <i className="fas fa-chevron-left" /> Back to {dictionaryName}
         </a>
-        <h3><strong>{dictionaryName} Dictionary</strong>: Bulk Add Concepts</h3>
+        <h3>
+          <strong>{dictionaryName} Dictionary</strong>: Bulk Add Concepts
+        </h3>
         <fieldset className="scheduler-border">
           <legend className="scheduler-border">Select a source</legend>
           <div className="select-box">
@@ -18,8 +35,9 @@ class AddBulkConcepts extends Component {
                 className="form-check-input"
                 type="radio"
                 name="exampleRadios"
-                id="exampleRadios1"
+                id="ciel"
                 value="option1"
+                onClick={this.handleCielClick}
               />
               <label className="form-check-label" htmlFor="exampleRadios1">
                 CIEL
@@ -66,19 +84,33 @@ class AddBulkConcepts extends Component {
           </div>
         </fieldset>
         <h4>Concept IDs to add</h4>
-        <div className="preffered-concepts" />
+        <div className="prefered-concepts">
+          <BulkConceptList
+            cielConcepts={cielConcepts}
+            fetching={this.props.isFetching}
+          />
+        </div>
         <br />
         <div className="add-all-btn">
           <a href={document.referrer}>
             <button type="button" className="btn btn-secondary">
-          Back
-            </button></a>{' '}
+              Back
+            </button>
+          </a>{' '}
           <button type="button" className="btn btn-primary">
-            <i className="fa fa-plus" />{' '}Add All
+            <i className="fa fa-plus" /> Add All
           </button>
         </div>
       </div>
     );
   }
 }
-export default AddBulkConcepts;
+
+export const mapStateToProps = state => ({
+  cielConcepts: state.cielConcepts.cielConcepts,
+  isFetching: state.cielConcepts.loading,
+});
+export default connect(
+  mapStateToProps,
+  { fetchCielConcepts },
+)(AddBulkConcepts);

--- a/src/components/bulkConcepts/bulkConceptList.jsx
+++ b/src/components/bulkConcepts/bulkConceptList.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import BulkConceptTable from './bulkConceptTable';
+import Loader from '../Loader';
+
+const BulkConceptList = ({ cielConcepts, fetching }) => {
+  if (cielConcepts.length >= 1) {
+    return (
+      <table className="table table-bordered table-striped">
+        <thead className="header text-white">
+          <tr>
+            <th scope="col">concept ID</th>
+            <th scope="col">concept Name</th>
+          </tr>
+
+        </thead>
+        <tbody>
+
+          {cielConcepts.map(concept => (
+            <BulkConceptTable concept={concept} key={concept.id} />
+    ))}
+        </tbody>
+      </table>
+    );
+  }
+  if (fetching) {
+    return (
+      <div className="text-center mt-3">
+        <Loader />
+      </div>
+    );
+  }
+  return (
+    <div className="text-center mt-3">
+      <h5>No concept found</h5>
+    </div>
+  );
+};
+BulkConceptList.propTypes = {
+  fetching: PropTypes.bool.isRequired,
+  cielConcepts: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string,
+  })).isRequired,
+};
+export default BulkConceptList;

--- a/src/components/bulkConcepts/bulkConceptTable.jsx
+++ b/src/components/bulkConcepts/bulkConceptTable.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const BulkConceptTable = (concept) => {
+  const {
+    concept: {
+      id,
+      display_name,
+    },
+  } = concept;
+  return (
+    <tr className="concept-table">
+      <td>{id}</td>
+      <td>{display_name}</td>
+    </tr>
+  );
+};
+export default BulkConceptTable;

--- a/src/components/bulkConcepts/style.css
+++ b/src/components/bulkConcepts/style.css
@@ -12,10 +12,10 @@ legend.scheduler-border {
     padding:0 20px; 
     border-bottom:none;
 }
-.preffered-concepts{
+.prefered-concepts{
     border-style: groove;
     display: block;
-    height: 260px;
+    height: auto;
     margin-top: 10px;
 }
 .add-bulk-concepts{

--- a/src/redux/actions/bulkConcepts/index.js
+++ b/src/redux/actions/bulkConcepts/index.js
@@ -1,0 +1,18 @@
+import instance from '../../../config/axiosConfig';
+import { isSuccess, isErrored, isFetching } from '../globalActionCreators';
+import { FETCH_CIEL_CONCEPTS } from '../types';
+
+const fetchCielConcepts = () => async (dispatch) => {
+  dispatch(isFetching(true));
+  const url = 'orgs/CIEL/sources/CIEL/concepts/';
+  try {
+    const response = await instance.get(url);
+    dispatch(isSuccess(response.data, FETCH_CIEL_CONCEPTS));
+    dispatch(isFetching(false));
+  } catch (error) {
+    dispatch(isErrored(error.response.data, FETCH_CIEL_CONCEPTS));
+    dispatch(isFetching(false));
+  }
+};
+export default fetchCielConcepts;
+

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -39,3 +39,5 @@ export const GET_USER = '[user] get_user';
 export const FETCH_USER_DICTIONARY = '[dictionary] fetch_user_dictionary';
 export const FETCH_ORG_DICTIONARY = '[dictionary] fetch_org_dictionary';
 export const FETCH_USER_ORGANIZATION = '[user] fetch_user_organization';
+
+export const FETCH_CIEL_CONCEPTS = '[concepts] fetch_ciel_concepts';

--- a/src/redux/reducers/bulkConcepts/index.js
+++ b/src/redux/reducers/bulkConcepts/index.js
@@ -1,0 +1,20 @@
+import { FETCH_CIEL_CONCEPTS, IS_FETCHING } from '../../actions/types';
+
+const initialState = { cielConcepts: [], loading: false };
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case FETCH_CIEL_CONCEPTS:
+      return {
+        ...state,
+        cielConcepts: action.payload,
+      };
+    case IS_FETCHING:
+      return {
+        ...state,
+        loading: action.payload,
+      };
+    default:
+      return state;
+  }
+};
+

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -6,6 +6,7 @@ import concepts from './ConceptReducers';
 import dictionaries from './dictionaryReducers';
 import generalSearch from './generalSearchReducer';
 import user from './user';
+import cielConcepts from './bulkConcepts/index';
 
 // combined reducer to give a global state
 const rootReducer = combineReducers({
@@ -16,6 +17,7 @@ const rootReducer = combineReducers({
   dictionaries,
   generalSearch,
   user,
+  cielConcepts,
 });
 
 export default rootReducer;

--- a/src/tests/bulkConcepts/actions/index.test.js
+++ b/src/tests/bulkConcepts/actions/index.test.js
@@ -1,0 +1,80 @@
+import moxios from 'moxios';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import instance from '../../../config/axiosConfig';
+import { FETCH_CIEL_CONCEPTS, IS_FETCHING } from '../../../redux/actions/types';
+import fetchCielConcepts from '../../../redux/actions/bulkConcepts';
+import cielConcepts from '../../__mocks__/concepts';
+
+const mockStore = configureStore([thunk]);
+
+describe('Test suite for ciel concepts actions', () => {
+  beforeEach(() => {
+    moxios.install(instance);
+  });
+
+  afterEach(() => {
+    moxios.uninstall(instance);
+  });
+
+  it('should return an array of ciel concepts', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [{ cielConcepts: { cielConcepts } }],
+      });
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_CIEL_CONCEPTS, payload: [{ cielConcepts: { cielConcepts } }] },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    const store = mockStore({ });
+
+    return store.dispatch(fetchCielConcepts()).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('dispatches FETCH_CIEL_CONCEPTS  action type on respose from server', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [{ cielConcepts: { cielConcepts } }],
+      });
+    });
+
+    const returnedAction = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_CIEL_CONCEPTS, payload: [{ cielConcepts: { cielConcepts } }] },
+      { type: IS_FETCHING, payload: false },
+    ];
+    const store = mockStore({});
+    return store.dispatch(fetchCielConcepts())
+      .then(() => expect(store.getActions()).toEqual(returnedAction));
+  });
+
+  it('dispatches an error message when a response is errored', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 400,
+        response: 'could not complete this request',
+      });
+    });
+
+    const returnedAction = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_CIEL_CONCEPTS, payload: 'could not complete this request' },
+      { type: IS_FETCHING, payload: false },
+    ];
+    const store = mockStore({});
+    return store.dispatch(fetchCielConcepts())
+      .then(() => expect(store.getActions()).toEqual(returnedAction));
+  });
+});

--- a/src/tests/bulkConcepts/addBulkConcepts.test.jsx
+++ b/src/tests/bulkConcepts/addBulkConcepts.test.jsx
@@ -1,12 +1,37 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
-import AddBulkConcepts from '../../components/bulkConcepts/addBulkConcepts';
+import { Provider } from 'react-redux';
+import { createMockStore } from 'redux-test-utils';
+import Authenticated from '../__mocks__/fakeStore';
+import { AddBulkConcepts } from '../../components/bulkConcepts/addBulkConcepts';
 
+const store = createMockStore(Authenticated);
 describe('Add Bulk Concepts', () => {
   it('Should render without crashing', () => {
-    const wrapper = mount(<MemoryRouter><AddBulkConcepts /></MemoryRouter>);
+    const props = {
+      fetchCielConcepts: jest.fn(),
+      cielConcepts: [],
+      isFetching: true,
+    };
+    const wrapper = mount(<MemoryRouter>
+      <Provider store={store}>
+        <AddBulkConcepts {...props} />
+      </Provider>
+    </MemoryRouter>);
     expect(wrapper).toMatchSnapshot();
   });
+  it('calls the handleClick function when the CIEL radio button is clicked', () => {
+    const props = {
+      fetchCielConcepts: jest.fn(),
+      cielConcepts: [],
+      isFetching: true,
+    };
+    const wrapper = mount(<MemoryRouter>
+      <Provider store={store}>
+        <AddBulkConcepts {...props} />
+      </Provider>
+    </MemoryRouter>);
+    wrapper.find('#ciel').at(0).simulate('click');
+  });
 });
-

--- a/src/tests/bulkConcepts/bulkConceptList.test.jsx
+++ b/src/tests/bulkConcepts/bulkConceptList.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { createMockStore } from 'redux-test-utils';
+import Authenticated from '../__mocks__/fakeStore';
+import BulkConceptList from '../../components/bulkConcepts/bulkConceptList';
+import { existingConcept } from '../__mocks__/concepts';
+
+const store = createMockStore(Authenticated);
+describe('Bulk Concepts List', () => {
+  const props = {
+    fetchCielConcepts: jest.fn(),
+    cielConcepts: [existingConcept],
+    isFetching: false,
+  };
+  it('Should render without crashing', () => {
+    const wrapper = mount(<MemoryRouter>
+      <Provider store={store}>
+        <BulkConceptList {...props} />
+      </Provider>
+    </MemoryRouter>);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/tests/bulkConcepts/bulkConceptTable.test.jsx
+++ b/src/tests/bulkConcepts/bulkConceptTable.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { createMockStore } from 'redux-test-utils';
+import Authenticated from '../__mocks__/fakeStore';
+import BulkConceptTable from '../../components/bulkConcepts/bulkConceptTable';
+import { existingConcept } from '../__mocks__/concepts';
+
+const store = createMockStore(Authenticated);
+describe('Bulk Concept Table', () => {
+  const props = {
+    concept: existingConcept,
+    isFetching: false,
+  };
+  it('Should render without crashing', () => {
+    const wrapper = mount(<MemoryRouter>
+      <Provider store={store}>
+        <BulkConceptTable {...props} />
+      </Provider>
+    </MemoryRouter>);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/tests/bulkConcepts/reducers/index.test.js
+++ b/src/tests/bulkConcepts/reducers/index.test.js
@@ -1,0 +1,33 @@
+import reducer from '../../../redux/reducers/bulkConcepts';
+import { FETCH_CIEL_CONCEPTS, IS_FETCHING } from '../../../redux/actions/types';
+
+const initialState = { cielConcepts: [], loading: false };
+describe('Test suite for vote reducer', () => {
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should handle FETCH_CIEL_CONCEPTS', () => {
+    expect(reducer(
+      {},
+      {
+        type: FETCH_CIEL_CONCEPTS,
+        payload: [],
+      },
+    )).toEqual({
+      cielConcepts: [],
+    });
+  });
+
+  it('should handle IS_FETCHING', () => {
+    expect(reducer(
+      {},
+      {
+        type: IS_FETCHING,
+        payload: false,
+      },
+    )).toEqual({
+      loading: false,
+    });
+  });
+});


### PR DESCRIPTION

# JIRA TICKET NAME:
[OCLOMRS-140: Implement the retrieval of CIEL concepts on the bulk concept page](https://issues.openmrs.org/browse/OCLOMRS-140)

# Summary:
- This involves implementing the logic for clicking the CIEL radio button and populating the field with CIEL concept IDs.
- Write tests to ensure functionality is working.
