### PR TITLE
OCLOMRS-138: A new created Dictionary should automatically show among…

### DIFF
--- a/src/components/dashboard/components/dictionary/AddDictionary.jsx
+++ b/src/components/dashboard/components/dictionary/AddDictionary.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import DictionaryModal from '../dictionary/common/DictionaryModal';
-import { createDictionary, createDictionaryUser, fetchingOrganizations, fetchDictionaries } from '../../../../redux/actions/dictionaries/dictionaryActionCreators';
+import { createDictionary, createDictionaryUser, fetchingOrganizations } from '../../../../redux/actions/dictionaries/dictionaryActionCreators';
 
 export class AddDictionary extends React.Component {
   submit = data => (
     data.owner === 'Individual' ? this.props.createDictionaryUser(data).then(this.props.handleHide)
-      : this.props.createDictionary(data).then(this.props.handleHide)).then(this.props.fetchDictionaries())
+      : this.props.createDictionary(data).then(this.props.handleHide))
   render() {
     return (
       <DictionaryModal
@@ -32,5 +32,4 @@ export default connect(null, {
   createDictionary,
   createDictionaryUser,
   fetchingOrganizations,
-  fetchDictionaries
 })(AddDictionary);

--- a/src/redux/reducers/dictionaryReducer.js
+++ b/src/redux/reducers/dictionaryReducer.js
@@ -1,12 +1,7 @@
-import { ADDING_DICTIONARY, FETCHING_ORGANIZATIONS } from '../actions/types';
+import { FETCHING_ORGANIZATIONS } from '../actions/types';
 
 export default (state = {}, action) => {
   switch (action.type) {
-    case ADDING_DICTIONARY:
-      return {
-        ...state,
-        dictionaries: action.payload,
-      };
     case FETCHING_ORGANIZATIONS:
       return {
         ...state,

--- a/src/redux/reducers/user/index.js
+++ b/src/redux/reducers/user/index.js
@@ -4,6 +4,7 @@ import {
   FETCH_USER_ORGANIZATION,
   IS_FETCHING,
   CLEAR_DICTIONARY,
+  ADDING_DICTIONARY,
 } from '../../actions/types';
 
 const userInitialState = {
@@ -22,6 +23,11 @@ const userReducer = (state = userInitialState, action) => {
       return {
         ...state,
         user: action.payload,
+      };
+    case ADDING_DICTIONARY:
+      return {
+        ...state,
+        userDictionary: state.userDictionary.concat(action.payload),
       };
     case FETCH_USER_DICTIONARY:
       return {

--- a/src/tests/Dashboard/reducer/dictionaryReducers.test.js
+++ b/src/tests/Dashboard/reducer/dictionaryReducers.test.js
@@ -1,5 +1,6 @@
 import reducer from '../../../redux/reducers/dictionaryReducer';
 import dictionaryreducer from '../../../redux/reducers/dictionaryReducers';
+import userReducer from '../../../redux/reducers/user/index';
 import { FETCHING_ORGANIZATIONS, FETCHING_DICTIONARIES, IS_FETCHING, ADDING_DICTIONARY, FETCHING_DICTIONARY } from '../../../redux/actions/types';
 import dictionaries from '../../__mocks__/dictionaries';
 
@@ -7,15 +8,6 @@ const initialState = {};
 describe('Test suite for vote reducer', () => {
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual(initialState);
-  });
-  it('should return inital state', () => {
-    expect(reducer(
-      {},
-      {
-        type: ADDING_DICTIONARY,
-        payload: {},
-      },
-    )).toEqual({ dictionaries: {} });
   });
   it('should handle FETCHING_ORGANIZATIONS', () => {
     expect(reducer(
@@ -67,5 +59,16 @@ describe('Test suite for dictionaries reducers', () => {
         payload: [dictionaries],
       },
     )).toEqual({ dictionary: [dictionaries] });
+  });
+});
+describe('Test suite for dictionaries reducers', () => {
+  it('should return inital state ADD_DICTIONARY', () => {
+    expect(userReducer(
+      { userDictionary: [] },
+      {
+        type: ADDING_DICTIONARY,
+        payload: [dictionaries],
+      },
+    )).toEqual({ userDictionary: [dictionaries] });
   });
 });


### PR DESCRIPTION


# JIRA TICKET NAME:
[A new created Dictionary should automatically show among the dictionaries being displayed.](https://issues.openmrs.org/browse/OCLOMRS-138)

# Summary:
Currently
After a user has created a new dictionary, the user will have to refresh the page in order to see what they have created
After Fix
After a user has created a new dictionary, the dictionary should automatically show on the page that has all the user's dictionaries without a reload being done