### PR TITLE
OCLOMRS-128: Fix the functionality for creating a custom concept.

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -21,7 +21,8 @@ class ConceptNameRows extends Component {
     this.state = {
       id: this.props.newRow,
       name: '',
-      locale: defaultLocale,
+      locale: defaultLocale.value,
+      locale_full: defaultLocale,
       locale_preferred: 'Yes',
       name_type: 'Fully Specified',
     };
@@ -44,7 +45,7 @@ class ConceptNameRows extends Component {
 
   handleNameLocale(selectedOptions) {
     this.setState({
-      locale: selectedOptions,
+      locale_full: selectedOptions,
     });
     this.sendToTopComponent();
   }
@@ -88,8 +89,8 @@ class ConceptNameRows extends Component {
         </td>
         <th scope="row" className="concept-language">
           <Select
-            name="locale"
-            value={this.state.locale}
+            name="locale_full"
+            value={this.state.locale_full}
             onChange={this.handleNameLocale}
             options={locale}
             required

--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -20,7 +20,8 @@ class DescriptionRow extends Component {
     });
     this.state = {
       id: this.props.newRow,
-      locale: defaultLocale,
+      locale: defaultLocale.value,
+      locale_full: defaultLocale,
       description: '',
     };
     autoBind(this);
@@ -42,7 +43,7 @@ class DescriptionRow extends Component {
   }
   handleNameLocale(selectedOptions) {
     this.setState({
-      locale: selectedOptions,
+      locale_full: selectedOptions,
     });
     this.sendToTopComponent();
   }
@@ -72,9 +73,9 @@ class DescriptionRow extends Component {
         </td>
         <th scope="row" className="concept-language">
           <Select
-            name="locale"
+            name="locale_full"
             id="description-locale"
-            value={this.state.locale}
+            value={this.state.locale_full}
             onChange={this.handleNameLocale}
             options={locale}
             required

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -76,7 +76,7 @@ export class CreateConcept extends Component {
     const {
       match: {
         params: {
-          collectionName, type, typeName, dictionaryName,
+          collectionName, type, typeName, dictionaryName, language,
         },
       },
     } = this.props;
@@ -86,7 +86,7 @@ export class CreateConcept extends Component {
     if (isNewConcept && isAddedConcept) {
       setTimeout(() => {
         notify.show('concept successfully created', 'success', 3000);
-        nextProps.history.push(`/concepts/${type}/${typeName}/${collectionName}/${dictionaryName}`);
+        nextProps.history.push(`/concepts/${type}/${typeName}/${collectionName}/${dictionaryName}/${language}`);
       }, 3000);
     }
   }

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -18,6 +18,7 @@ describe('Test suite for dictionary concepts components', () => {
         collectionName: 'dev-col',
         type: 'users',
         typeName: 'emasys',
+        language: 'en',
       },
     },
     history: {


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-128: Fix the functionality for creating a custom concept.](https://issues.openmrs.org/browse/OCLOMRS-128)

# Summary:
Currently, when a user tries to create a concept an error indicating "the uuid must be unique" is thrown which should not be the case.
