### PR TITLE
OCLOMRS-132: Fix the preferred source grammar on Add Dictionary Modal

### DIFF
--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -97,7 +97,7 @@ export class DictionaryModal extends React.Component {
               <div className="row">
                 <div className="col-md-8">
                   <FormGroup style={{ marginTop: '12px' }}>
-                    Preferred Sources{' '}
+                    Preferred Source{' '}
                     {errors && <InlineError text={errors.preffered_sources} />}
                     <FormControl
                       componentClass="select"


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix the preferred source grammar on Add Dictionary Modal](https://issues.openmrs.org/browse/OCLOMRS-132)

# Summary:
Currently, the modal indicates “Preferred Sources” yet a user is only allowed to select 1. 
The naming should change it to singular i.e.“preferred source”