### PR TITLE
OCLOMRS-125: Fix the row added after the user clicks Add Name/Synonym and Add Description buttons

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptTable.jsx
@@ -14,7 +14,7 @@ const CreateConceptTable = props => (
       </tr>
     </thead>
     <tbody>
-      {props.nameRows.map(newRow => <ConceptNameRows newRow={newRow} key={newRow} {...props} />)}
+      {props.nameRows.map(newRow => <ConceptNameRows newRow={newRow} key={newRow} {...props} />).reverse()}
     </tbody>
   </table>
 );

--- a/src/components/dictionaryConcepts/components/DescriptionTable.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionTable.jsx
@@ -12,7 +12,7 @@ const DescriptionTable = props => (
       </tr>
     </thead>
     <tbody>
-      {props.description.map(newRow => <DescriptionRow newRow={newRow} key={newRow} {...props} />)}
+      {props.description.map(newRow => <DescriptionRow newRow={newRow} key={newRow} {...props} />).reverse()}
     </tbody>
   </table>
 );


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix the row added after the user clicks Add Name/Synonym and Add Description buttons](https://issues.openmrs.org/browse/OCLOMRS-125)

# Summary:
Currently, when “Add name/synonym” or "Add descriptrion" buttons are clicked the row should be added to the bottom instead of the top of the list.
