### PR TITLE
 OCLOMRS-131 : Change the functionality for the cancel button on the form and remove the back to dictionaries link

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import CreateConceptTable from './CreateConceptTable';
 import DescriptionTable from './DescriptionTable';
 import { classes } from './helperFunction';
@@ -102,11 +103,16 @@ const CreateConceptForm = props => (
         </div>
       </div>
       <div className="submit-button text-left">
-        <button className="btn btn-sm mr-1 col-2 bg-blue" type="submit">
-          Create
-        </button>
-        <button className="btn btn-sm btn-danger col-2" type="reset">
+        <Link
+          to={props.path}
+          className="collection-name small-text"
+        >
+          <button className="btn btn-sm mr-1 col-2 btn-danger" type="reset">
           Cancel
+          </button>
+        </Link>
+        <button className="btn btn-sm bg-blue col-2" type="submit">
+          Create
         </button>
       </div>
     </div>
@@ -122,6 +128,7 @@ CreateConceptForm.propTypes = {
     id: PropTypes.string,
   }).isRequired,
   concept: PropTypes.string.isRequired,
+  path: PropTypes.string.isRequired,
   toggleUUID: PropTypes.func.isRequired,
   handleChange: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import autoBind from 'react-autobind';
 import uuid from 'uuid/v4';
-import { Link } from 'react-router-dom';
 import { notify } from 'react-notify-toast';
 import PropTypes from 'prop-types';
 import CreateConceptForm from '../components/CreateConceptForm';
@@ -203,14 +202,6 @@ export class CreateConcept extends Component {
       <div className="container create-custom-concept">
         <div className="row create-concept-header">
           <div className="col-lg-12">
-            <div>
-              <Link
-                to={path}
-                className="collection-name small-text"
-              >
-                <i className="fas fa-chevron-left" /> Go back to {dictionaryName} dictionary
-              </Link>
-            </div>
             <h3>
               {dictionaryName}: Create a<span className="text-capitalize">{concept}</span> Concept <br />
             </h3>
@@ -229,6 +220,7 @@ export class CreateConcept extends Component {
                 removeDescription={this.removeDescription}
                 toggleUUID={this.handleUUID}
                 concept={concept}
+                path={path}
                 state={this.state}
                 handleChange={this.handleChange}
                 handleSelections={this.handleNameLocale}


### PR DESCRIPTION
# JIRA TICKET NAME:
[ OCLOMRS-131 : Change the functionality for the cancel button on the form and remove the back to dictionaries link](https://issues.openmrs.org/browse/OCLOMRS-131)

# Summary:
- “Back to the dictionary,” link functionality can be achieved by clicking the Cancel or the back button.
It is not relevant at the moment, therefore should be removed.
