### PR TITLE
OCLOMRS-142: Implement the logic for adding the retrieved CIEL concepts to a dictionary

### DIFF
--- a/src/components/bulkConcepts/addBulkConcepts.jsx
+++ b/src/components/bulkConcepts/addBulkConcepts.jsx
@@ -2,17 +2,22 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import './style.css';
-import fetchCielConcepts from '../../redux/actions/bulkConcepts';
+import fetchCielConcepts, { addExistingBulkConcepts } from '../../redux/actions/bulkConcepts';
 import BulkConceptList from '../bulkConcepts/bulkConceptList';
 
 export class AddBulkConcepts extends Component {
   static propTypes = {
     fetchCielConcepts: PropTypes.func.isRequired,
+    addExistingBulkConcepts: PropTypes.func.isRequired,
     cielConcepts: PropTypes.arrayOf(PropTypes.shape({
       id: PropTypes.string,
     })).isRequired,
     isFetching: PropTypes.bool.isRequired,
   };
+  handleAddAll=() => {
+    const expressions = this.props.cielConcepts.map(concept => concept.url);
+    this.props.addExistingBulkConcepts({ data: { expressions } });
+  }
   handleCielClick=() => {
     this.props.fetchCielConcepts();
   }
@@ -97,7 +102,7 @@ export class AddBulkConcepts extends Component {
               Back
             </button>
           </a>{' '}
-          <button type="button" className="btn btn-primary">
+          <button type="button" className="btn btn-primary" id="btn-add-all"onClick={this.handleAddAll}>
             <i className="fa fa-plus" /> Add All
           </button>
         </div>
@@ -112,5 +117,5 @@ export const mapStateToProps = state => ({
 });
 export default connect(
   mapStateToProps,
-  { fetchCielConcepts },
+  { fetchCielConcepts, addExistingBulkConcepts },
 )(AddBulkConcepts);

--- a/src/redux/actions/bulkConcepts/index.js
+++ b/src/redux/actions/bulkConcepts/index.js
@@ -1,6 +1,7 @@
+import { notify } from 'react-notify-toast';
 import instance from '../../../config/axiosConfig';
 import { isSuccess, isErrored, isFetching } from '../globalActionCreators';
-import { FETCH_CIEL_CONCEPTS } from '../types';
+import { FETCH_CIEL_CONCEPTS, ADD_EXISTING_BULK_CONCEPTS } from '../types';
 
 const fetchCielConcepts = () => async (dispatch) => {
   dispatch(isFetching(true));
@@ -15,4 +16,16 @@ const fetchCielConcepts = () => async (dispatch) => {
   }
 };
 export default fetchCielConcepts;
+
+export const addExistingBulkConcepts = data => async (dispatch) => {
+  const typeName = localStorage.getItem('typeName');
+  const dictionaryId = localStorage.getItem('dictionaryId');
+  const userType = localStorage.getItem('type');
+  const url = `${userType}/${typeName}/collections/${dictionaryId}/references/`;
+  const payload = await instance.put(url, data);
+  dispatch(isSuccess(payload.data, ADD_EXISTING_BULK_CONCEPTS));
+  const justAddedConcepts = payload.data.filter(concept => concept.added).length;
+  const alreadyAddedConcepts = payload.data.length - justAddedConcepts;
+  notify.show(`Added ${justAddedConcepts} concept(s) skipped ${alreadyAddedConcepts} that were already added`, 'success', 3000);
+};
 

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -40,3 +40,4 @@ export const FETCH_USER_DICTIONARY = '[dictionary] fetch_user_dictionary';
 export const FETCH_USER_ORGANIZATION = '[user] fetch_user_organization';
 export const FETCH_CIEL_CONCEPTS = '[concepts] fetch_ciel_concepts';
 export const FETCH_BULK_CONCEPTS = '[concept] fetch_bulk_concepts';
+export const ADD_EXISTING_BULK_CONCEPTS = '[concept] add_existing_bulk_concepts';

--- a/src/tests/bulkConcepts/actions/index.test.js
+++ b/src/tests/bulkConcepts/actions/index.test.js
@@ -3,11 +3,12 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import instance from '../../../config/axiosConfig';
-import { FETCH_CIEL_CONCEPTS, IS_FETCHING } from '../../../redux/actions/types';
-import fetchCielConcepts from '../../../redux/actions/bulkConcepts';
+import { FETCH_CIEL_CONCEPTS, IS_FETCHING, ADD_EXISTING_BULK_CONCEPTS } from '../../../redux/actions/types';
+import fetchCielConcepts, { addExistingBulkConcepts } from '../../../redux/actions/bulkConcepts';
 import cielConcepts from '../../__mocks__/concepts';
 
 const mockStore = configureStore([thunk]);
+jest.mock('react-notify-toast');
 
 describe('Test suite for ciel concepts actions', () => {
   beforeEach(() => {
@@ -58,7 +59,24 @@ describe('Test suite for ciel concepts actions', () => {
     return store.dispatch(fetchCielConcepts())
       .then(() => expect(store.getActions()).toEqual(returnedAction));
   });
+  it('dispatches ADD_EXISTING_BULK_CONCEPTS  action type on respose from server', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [{ data: { data: [{ added: true }] } }],
+      });
+    });
 
+    const returnedAction = [{
+      type: ADD_EXISTING_BULK_CONCEPTS,
+      payload: [{ data: { data: [{ added: true }] } }],
+    }];
+    const data = { expressions: ['/orgs/WHO/sources/ICD-10/concepts/A15.1/'] };
+    const store = mockStore({});
+    return store.dispatch(addExistingBulkConcepts(data))
+      .then(() => expect(store.getActions()).toEqual(returnedAction));
+  });
   it('dispatches an error message when a response is errored', () => {
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();

--- a/src/tests/bulkConcepts/addBulkConcepts.test.jsx
+++ b/src/tests/bulkConcepts/addBulkConcepts.test.jsx
@@ -34,4 +34,18 @@ describe('Add Bulk Concepts', () => {
     </MemoryRouter>);
     wrapper.find('#ciel').at(0).simulate('click');
   });
+  it('calls the handleClick function when the Add all button is clicked', () => {
+    const props = {
+      fetchCielConcepts: jest.fn(),
+      addExistingBulkConcepts: jest.fn(),
+      cielConcepts: [],
+      isFetching: true,
+    };
+    const wrapper = mount(<MemoryRouter>
+      <Provider store={store}>
+        <AddBulkConcepts {...props} />
+      </Provider>
+    </MemoryRouter>);
+    wrapper.find('#btn-add-all').at(0).simulate('click');
+  });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-142: Implement the logic for adding the retrieved CIEL concepts to a dictionary](https://issues.openmrs.org/browse/OCLOMRS-142)

# Summary:
- This is the logic that is executed when you click the Add All button on the bulk concept page.
