### PR TITLE
OCLOMRS-148: Fix to select one of the supported locales when a dictionary is created in English or Spanish

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -6,7 +6,7 @@ const DictionaryDetailCard = (dictionary) => {
   const {
     dictionary: {
       name, created_on, updated_on, public_access, owner, owner_type, active_concepts, description,
-      owner_url, short_code, supported_locales,
+      owner_url, short_code, default_locale,
     },
   } = dictionary;
 
@@ -30,7 +30,7 @@ const DictionaryDetailCard = (dictionary) => {
             <Link
               className="btn btn-secondary"
               id="conceptB"
-              to={`/concepts${owner_url}${short_code}/${name}/${supported_locales}`}
+              to={`/concepts${owner_url}${short_code}/${name}/${default_locale}`}
             >
                 Go to concepts
             </Link>

--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -17,6 +17,7 @@ export class DictionaryModal extends React.Component {
         name: '',
         owner: '',
         description: '',
+        default_locale: 'en',
         supported_locales: 'en, es',
         repository_type: 'OpenMRSDictionary',
       },
@@ -68,8 +69,8 @@ export class DictionaryModal extends React.Component {
       errors.public_access =
         'Kindly select the Permissions for your dictionary';
     }
-    if (!data.supported_locales) {
-      errors.supported_locales = 'Kindly select your preferred locale';
+    if (!data.default_locale) {
+      errors.default_locale = 'Kindly select your preferred locale';
     }
     return errors;
   };
@@ -115,12 +116,12 @@ export class DictionaryModal extends React.Component {
 
                   <FormGroup style={{ marginTop: '12px' }}>
                     Preferred Language{''}
-                    {errors && <InlineError text={errors.supported_locales} />}
+                    {errors && <InlineError text={errors.default_locale} />}
                     <FormControl
                       componentClass="select"
                       type="text"
-                      name="supported_locales"
-                      id="supported_locales"
+                      name="default_locale"
+                      id="default_locale"
                       placeholder="English"
                       onChange={this.onChange}
                     >


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-148: Fix to select one of the supported locales when a dictionary is created in English or Spanish](https://issues.openmrs.org/browse/OCLOMRS-148)

# Summary:
Currently, when the user creates a dictionary with English or Spanish as the default language,both languages are saved as the supported locales which should not be the case.