### PR TITLE
OCLOMRS-127: Make the default datatype None on the create concept form

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -68,10 +68,9 @@ const CreateConceptForm = props => (
           className="form-control "
           onChange={props.handleChange}
         >
-          <option>N/A</option>
           <option>Numeric</option>
           <option>Text</option>
-          <option>None</option>
+          <option selected>None</option>
           <option>Document</option>
           <option>Date</option>
           <option>Time</option>

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -51,7 +51,7 @@ export class CreateConcept extends Component {
       notEditable: true,
       id: uuid(),
       concept_class: '',
-      datatype: '',
+      datatype: 'None',
       names: [],
       descriptions: [],
     };

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -60,7 +60,7 @@ describe('Test suite for dictionary concepts components', () => {
     });
     const conceptName = { target: { name: 'name', value: 'test concept' } };
     wrapper.find('#concept-name').simulate('change', conceptName);
-    const conceptDatatype = { target: { name: 'datatype', value: 'Text' } };
+    const conceptDatatype = { target: { name: 'datatype', value: '' } };
     wrapper.find('#datatype').simulate('change', conceptDatatype);
     wrapper.find('#toggleUUID').simulate('click');
     const uuid = { target: { name: 'id', value: '12345ft-007#' } };
@@ -103,10 +103,12 @@ describe('Test suite for dictionary concepts components', () => {
       newConcept,
       addedConcept: [{ added: true }],
     };
+    jest.useFakeTimers();
     const wrapper = shallow(<CreateConcept {...props} />);
     wrapper.setState({ searchInput: 'ciel' });
     wrapper.setProps(newProps);
     wrapper.unmount();
+    jest.runAllTimers();
   });
 
   it('should test mapStateToProps', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-127: Make the default datatype None on the create concept forme](https://issues.openmrs.org/browse/OCLOMRS-127)

# Summary:
Currently, the default datatype is "N/A". 
When selected the form prompts the user to enter a datatype. 
Since, "None" already exists on the list of datatypes and does the same thing as "N/A", we should Indicate "None" as the default datatype
