### PR TITLE
OCLOMRS-144: Populate the filter sidebar with concept classes and datatypes

### DIFF
--- a/src/components/bulkConcepts/component/ActionButtons.jsx
+++ b/src/components/bulkConcepts/component/ActionButtons.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default () => (
   <React.Fragment>
-    <button className="btn btn-sm mr-2 no-shadow bg-gray mb-1">Add concept</button>
-    <button className="btn btn-sm no-shadow bg-gray mb-1">Preview concept</button>
+    <button className="btn btn-sm mr-2 no-shadow bg-gray">Add concept</button>
+    <button className="btn btn-sm no-shadow bg-gray">Preview concept</button>
   </React.Fragment>
 );

--- a/src/components/bulkConcepts/component/SideNavItems.jsx
+++ b/src/components/bulkConcepts/component/SideNavItems.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SideNavItems = ({
+  listItem, handleChange, value, filterType,
+}) => (
+  <div className="custom-control custom-checkbox">
+    <input
+      type="checkbox"
+      className="custom-control-input"
+      name={[listItem, filterType]}
+      id={listItem}
+      data-own="stuff"
+      value={value}
+      onChange={handleChange}
+    />
+    <label className="custom-control-label bulk-concept-label" htmlFor={listItem}>
+      {listItem}
+    </label>
+  </div>
+);
+
+SideNavItems.propTypes = {
+  listItem: PropTypes.string.isRequired,
+  filterType: PropTypes.string.isRequired,
+  handleChange: PropTypes.func.isRequired,
+  value: PropTypes.string.isRequired,
+};
+
+export default SideNavItems;

--- a/src/components/bulkConcepts/component/Sidenav.jsx
+++ b/src/components/bulkConcepts/component/Sidenav.jsx
@@ -1,28 +1,54 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import SideNavItems from './SideNavItems';
 
-const Sidenav = () => (
-  <div className="col-12 col-md-3">
-    <div className="sidenav-container">
-      <div className="row">
-        <h6 className="sidenav-header">Classes</h6>
-      </div>
-      <div className="custom-control custom-checkbox">
-        <input type="checkbox" className="custom-control-input" />
-        <label className="custom-control-label bulk-concept-label" htmlFor="test">
-          lorem
-        </label>
-      </div>
-      <div className="row mt-3">
-        <h6 className="sidenav-header">Datatype</h6>
-      </div>
-      <div className="custom-control custom-checkbox">
-        <input type="checkbox" className="custom-control-input" />
-        <label className="custom-control-label bulk-concept-label" htmlFor="test">
-          lorem
-        </label>
+const Sidenav = (props) => {
+  const {
+    classes, datatypes, datatypeInput, classInput, handleChange,
+  } = props;
+  return (
+    <div className="col-12 col-md-3">
+      <div className="sidenav-container">
+        <div className="row">
+          <h6 className="sidenav-header">Datatypes</h6>
+        </div>
+        {datatypes.map(datatype => (
+          <SideNavItems
+            listItem={datatype}
+            key={datatype}
+            filterType="datatype"
+            value={datatypeInput}
+            handleChange={handleChange}
+          />
+        ))}
+        <div className="row mt-3">
+          <h6 className="sidenav-header">Classes</h6>
+        </div>
+        {classes.map(classItem => (
+          <SideNavItems
+            listItem={classItem}
+            key={classItem}
+            filterType="classes"
+            value={classInput}
+            handleChange={handleChange}
+          />
+        ))}
       </div>
     </div>
-  </div>
-);
+  );
+};
+
+Sidenav.propTypes = {
+  classes: PropTypes.array.isRequired,
+  datatypes: PropTypes.array.isRequired,
+  datatypeInput: PropTypes.string,
+  classInput: PropTypes.string,
+  handleChange: PropTypes.func.isRequired,
+};
+
+Sidenav.defaultProps = {
+  datatypeInput: '',
+  classInput: '',
+};
 
 export default Sidenav;

--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -7,7 +7,10 @@ import SideNav from '../component/Sidenav';
 import SearchBar from '../component/SearchBar';
 import ConceptTable from '../component/ConceptTable';
 import Paginations from '../component/Paginations';
-import { fetchBulkConcepts } from '../../../redux/actions/concepts/addBulkConcepts';
+import {
+  fetchBulkConcepts,
+  addToFilterList,
+} from '../../../redux/actions/concepts/addBulkConcepts';
 
 import { conceptsProps } from '../../dictionaryConcepts/proptypes';
 
@@ -16,19 +19,40 @@ export class BulkConceptsPage extends Component {
     fetchBulkConcepts: PropTypes.func.isRequired,
     concepts: PropTypes.arrayOf(PropTypes.shape(conceptsProps)).isRequired,
     loading: PropTypes.bool.isRequired,
+    datatypes: PropTypes.array.isRequired,
+    classes: PropTypes.array.isRequired,
+    addToFilterList: PropTypes.func.isRequired,
   };
 
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      datatypeInput: '',
+      classInput: '',
+    };
   }
 
   componentDidMount() {
     this.props.fetchBulkConcepts();
   }
 
+  handleFilter = (event) => {
+    const {
+      target: { name },
+    } = event;
+    const targetName = name.split(',');
+    if (targetName[1] === 'datatype') {
+      this.props.addToFilterList(targetName[0], 'datatype');
+    } else {
+      this.props.addToFilterList(targetName[0], 'classes');
+    }
+  };
+
   render() {
-    const { concepts, loading } = this.props;
+    const {
+      concepts, loading, datatypes, classes,
+    } = this.props;
+    const { datatypeInput, classInput } = this.state;
     return (
       <div className="container custom-dictionary-concepts bulk-concepts mt-3">
         <section className="row">
@@ -37,7 +61,13 @@ export class BulkConceptsPage extends Component {
           </div>
         </section>
         <section className="row mt-3">
-          <SideNav />
+          <SideNav
+            datatypes={datatypes}
+            classes={classes}
+            dataTypeValue={datatypeInput}
+            classValue={classInput}
+            handleChange={this.handleFilter}
+          />
           <div className="col-10 col-md-9 bulk-concept-wrapper">
             <SearchBar />
             <Paginations totalConcepts={concepts.length} />
@@ -52,9 +82,11 @@ export class BulkConceptsPage extends Component {
 export const mapStateToProps = state => ({
   concepts: state.bulkConcepts.bulkConcepts,
   loading: state.concepts.loading,
+  datatypes: state.bulkConcepts.datatypes,
+  classes: state.bulkConcepts.classes,
 });
 
 export default connect(
   mapStateToProps,
-  { fetchBulkConcepts },
+  { fetchBulkConcepts, addToFilterList },
 )(BulkConceptsPage);

--- a/src/components/bulkConcepts/styles/index.css
+++ b/src/components/bulkConcepts/styles/index.css
@@ -17,11 +17,11 @@
 
 .bg-gray {
   background: gainsboro;
-  color: #4f6196;
+  color: #5c6273
 }
 
 .bg-gray:hover {
-  background: #4f6196;
+  background: #5c6273;
   color: white; 
 }
 
@@ -31,9 +31,11 @@
 
 .bulk-concepts .sidenav-container {
   padding: .5rem 2rem;
+  border-radius: .4rem;
 }
 
 .bulk-concept-label {
+  cursor: pointer;
   font-size: 1rem;
   margin-top: -.23rem;
 }
@@ -49,10 +51,12 @@
 }
 
 .bulk-concepts .paginate-controllers {
-    margin: 0 1.2rem 0 2rem;
+  margin: 0 1.2rem 0 2rem;
+    
 }
 
 .bulk-concepts .paginate-controllers i {
   font-size: .8rem;
-  margin-top: .4rem;
+  padding: .85rem 1rem;
+  transition: background-color 400ms ease-in-out;  
 }

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -41,3 +41,6 @@ export const FETCH_USER_ORGANIZATION = '[user] fetch_user_organization';
 export const FETCH_CIEL_CONCEPTS = '[concepts] fetch_ciel_concepts';
 export const FETCH_BULK_CONCEPTS = '[concept] fetch_bulk_concepts';
 export const ADD_EXISTING_BULK_CONCEPTS = '[concept] add_existing_bulk_concepts';
+export const ADD_TO_DATATYPE_LIST = '[concept] add_to_datatype_list';
+export const ADD_TO_CLASS_LIST = '[concept] add_to_class_list';
+export const FETCH_FILTERED_CONCEPTS = '[concept] fetch_filtered_concepts';

--- a/src/redux/reducers/bulkConceptReducer.js
+++ b/src/redux/reducers/bulkConceptReducer.js
@@ -1,7 +1,17 @@
-import { FETCH_BULK_CONCEPTS } from '../actions/types';
+import {
+  FETCH_BULK_CONCEPTS,
+  ADD_TO_DATATYPE_LIST,
+  ADD_TO_CLASS_LIST,
+  FETCH_FILTERED_CONCEPTS,
+} from '../actions/types';
+import { getDatatypes, filterClass, normalizeList } from './util';
 
 const userInitialState = {
   bulkConcepts: [],
+  datatypes: [],
+  classes: [],
+  datatypeList: [],
+  classList: [],
 };
 const bulkConcepts = (state = userInitialState, action) => {
   switch (action.type) {
@@ -9,6 +19,23 @@ const bulkConcepts = (state = userInitialState, action) => {
       return {
         ...state,
         bulkConcepts: action.payload,
+        datatypes: getDatatypes(action.payload),
+        classes: filterClass(action.payload),
+      };
+    case FETCH_FILTERED_CONCEPTS:
+      return {
+        ...state,
+        bulkConcepts: action.payload,
+      };
+    case ADD_TO_DATATYPE_LIST:
+      return {
+        ...state,
+        datatypeList: normalizeList(action.payload, [action.payload, ...state.datatypeList]),
+      };
+    case ADD_TO_CLASS_LIST:
+      return {
+        ...state,
+        classList: normalizeList(action.payload, [action.payload, ...state.classList]),
       };
     default:
       return state;

--- a/src/redux/reducers/util.js
+++ b/src/redux/reducers/util.js
@@ -1,5 +1,19 @@
 import { countBy } from 'lodash';
 
+
+export const getDatatypes = (concepts) => {
+  const datatypes = [];
+  if (Array.isArray(concepts)) {
+    concepts.map((concept) => {
+      if (!datatypes.includes(concept.datatype)) {
+        return datatypes.push(concept.datatype);
+      }
+      return null;
+    });
+  }
+  return datatypes;
+};
+
 export const filterSources = (concepts) => {
   const filteredSources = [];
   if (Array.isArray(concepts)) {

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -259,6 +259,10 @@ export const mockConceptStore = {
     sourceList: [],
     classList: [],
   },
+  bulkConcepts: {
+    datatypeList: [],
+    classList: [],
+  },
 };
 
 export const newConcept = {

--- a/src/tests/bulkConcepts/actions/bulkConcept.test.js
+++ b/src/tests/bulkConcepts/actions/bulkConcept.test.js
@@ -3,14 +3,24 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import instance from '../../../config/axiosConfig';
-import { IS_FETCHING, FETCH_BULK_CONCEPTS } from '../../../redux/actions/types';
-import { fetchBulkConcepts } from '../../../redux/actions/concepts/addBulkConcepts';
-import concepts from '../../__mocks__/concepts';
+import {
+  IS_FETCHING,
+  FETCH_BULK_CONCEPTS,
+  ADD_TO_DATATYPE_LIST,
+  ADD_TO_CLASS_LIST,
+  FETCH_FILTERED_CONCEPTS,
+} from '../../../redux/actions/types';
+import {
+  fetchBulkConcepts,
+  addToFilterList,
+  fetchFilteredConcepts,
+} from '../../../redux/actions/concepts/addBulkConcepts';
+import concepts, { mockConceptStore } from '../../__mocks__/concepts';
 
 jest.mock('react-notify-toast');
 const mockStore = configureStore([thunk]);
 
-describe('Test suite for addBulkConcepts actions', () => {
+describe('Test suite for addBulkConcepts async actions', () => {
   beforeEach(() => {
     moxios.install(instance);
   });
@@ -59,5 +69,130 @@ describe('Test suite for addBulkConcepts actions', () => {
     return store.dispatch(fetchBulkConcepts()).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
+  });
+  it('should handle FETCH_FILTERED_CONCEPTS with no filters', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [concepts],
+      });
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_FILTERED_CONCEPTS, payload: [concepts] },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    const store = mockStore(mockConceptStore);
+
+    return store.dispatch(fetchFilteredConcepts()).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should handle FETCH_FILTERED_CONCEPTS with datatype filters', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [concepts],
+      });
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_FILTERED_CONCEPTS, payload: [concepts] },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    const store = mockStore({ bulkConcepts: { datatypeList: ['text'], classList: [] } });
+
+    return store.dispatch(fetchFilteredConcepts()).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should handle FETCH_FILTERED_CONCEPTS with classes filters', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [concepts],
+      });
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_FILTERED_CONCEPTS, payload: [concepts] },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    const store = mockStore({ bulkConcepts: { datatypeList: [], classList: ['classList'] } });
+
+    return store.dispatch(fetchFilteredConcepts()).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should handle FETCH_FILTERED_CONCEPTS with both classes and datatype filters', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [concepts],
+      });
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_FILTERED_CONCEPTS, payload: [concepts] },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    const store = mockStore({ bulkConcepts: { datatypeList: ['text'], classList: ['classList'] } });
+
+    return store.dispatch(fetchFilteredConcepts()).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should handle error in FETCH_FILTERED_CONCEPTS', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 400,
+        response: 'bad request',
+      });
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    const store = mockStore(mockConceptStore);
+
+    return store.dispatch(fetchFilteredConcepts()).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+});
+
+describe('test suite for addBulkConcepts synchronous action creators', () => {
+  it('should handle ADD_TO_DATATYPE_LIST', () => {
+    const store = mockStore(mockConceptStore);
+    const expectedActions = [
+      { type: ADD_TO_DATATYPE_LIST, payload: 'text' },
+      { payload: true, type: '[ui] toggle spinner' },
+    ];
+    store.dispatch(addToFilterList('text', 'datatype'));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+  it('should handle ADD_TO_CLASS_LIST', () => {
+    const store = mockStore(mockConceptStore);
+    const expectedActions = [
+      { type: ADD_TO_CLASS_LIST, payload: 'drug' },
+      { payload: true, type: '[ui] toggle spinner' },
+    ];
+    store.dispatch(addToFilterList('drug', 'class'));
+    expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -15,6 +15,9 @@ describe('Test suite for BulkConceptsPage component', () => {
       fetchBulkConcepts: jest.fn(),
       concepts: [],
       loading: true,
+      datatypes: [],
+      classes: [],
+      addToFilterList: jest.fn(),
     };
     const wrapper = mount(<Router>
       <BulkConceptsPage {...props} />
@@ -28,6 +31,9 @@ describe('Test suite for BulkConceptsPage component', () => {
       fetchBulkConcepts: jest.fn(),
       concepts: [],
       loading: false,
+      datatypes: [],
+      classes: [],
+      addToFilterList: jest.fn(),
     };
     const wrapper = mount(<Router>
       <BulkConceptsPage {...props} />
@@ -39,6 +45,9 @@ describe('Test suite for BulkConceptsPage component', () => {
       fetchBulkConcepts: jest.fn(),
       concepts: [concepts],
       loading: false,
+      datatypes: [],
+      classes: [],
+      addToFilterList: jest.fn(),
     };
     const wrapper = mount(<Router>
       <BulkConceptsPage {...props} />
@@ -46,14 +55,34 @@ describe('Test suite for BulkConceptsPage component', () => {
     expect(wrapper.find('#table-body').text()).toBeTruthy();
   });
 
+  it('should filter search result', () => {
+    const props = {
+      fetchBulkConcepts: jest.fn(),
+      concepts: [concepts],
+      loading: false,
+      datatypes: ['text'],
+      classes: ['Diagnosis'],
+      addToFilterList: jest.fn(),
+    };
+    const wrapper = mount(<Router>
+      <BulkConceptsPage {...props} />
+    </Router>);
+    const event = { target: { name: 'Diagnosis, classes', checked: true } };
+    const event2 = { target: { name: 'Diagnosis, datatype', checked: true } };
+    wrapper.find('#text').simulate('change', event2);
+    wrapper.find('#Diagnosis').simulate('change', event);
+  });
+
   it('should test mapStateToProps', () => {
     const initialState = {
       concepts: {
         loading: false,
       },
-      bulkConcepts: { bulkConcepts: [] },
+      bulkConcepts: { bulkConcepts: [], datatypes: [], classes: [] },
     };
     expect(mapStateToProps(initialState).concepts).toEqual([]);
+    expect(mapStateToProps(initialState).datatypes).toEqual([]);
+    expect(mapStateToProps(initialState).classes).toEqual([]);
     expect(mapStateToProps(initialState).loading).toEqual(false);
   });
 });

--- a/src/tests/bulkConcepts/reducer/index.test.js
+++ b/src/tests/bulkConcepts/reducer/index.test.js
@@ -1,13 +1,24 @@
 import deepFreeze from 'deep-freeze';
 import reducer from '../../../redux/reducers/bulkConceptReducer';
-import { FETCH_BULK_CONCEPTS } from '../../../redux/actions/types';
-import concepts from '../../__mocks__/concepts';
+import {
+  FETCH_BULK_CONCEPTS,
+  ADD_TO_DATATYPE_LIST,
+  ADD_TO_CLASS_LIST,
+  FETCH_FILTERED_CONCEPTS,
+} from '../../../redux/actions/types';
+import concepts, { multipleConceptsMockStore } from '../../__mocks__/concepts';
 
 let state;
 let action;
 
 beforeEach(() => {
-  state = { bulkConcepts: [] };
+  state = {
+    bulkConcepts: [],
+    datatypes: [],
+    classes: [],
+    datatypeList: [],
+    classList: [],
+  };
   action = {};
 });
 
@@ -20,6 +31,50 @@ describe('Test suite for bulkConcepts reducer', () => {
     action = {
       type: FETCH_BULK_CONCEPTS,
       payload: [concepts],
+    };
+
+    deepFreeze(state);
+    deepFreeze(action);
+
+    expect(reducer(state, action)).toEqual({
+      ...state,
+      classes: ['Diagnosis'],
+      datatypes: ['N/A'],
+      bulkConcepts: action.payload,
+    });
+  });
+  it('should handle ADD_TO_DATATYPE_LIST', () => {
+    action = {
+      type: ADD_TO_DATATYPE_LIST,
+      payload: 'Text',
+    };
+
+    deepFreeze(state);
+    deepFreeze(action);
+
+    expect(reducer(state, action)).toEqual({
+      ...state,
+      datatypeList: ['Text'],
+    });
+  });
+  it('should handle ADD_TO_CLASS_LIST', () => {
+    action = {
+      type: ADD_TO_CLASS_LIST,
+      payload: 'Diagnosis',
+    };
+
+    deepFreeze(state);
+    deepFreeze(action);
+
+    expect(reducer(state, action)).toEqual({
+      ...state,
+      classList: ['Diagnosis'],
+    });
+  });
+  it('should handle FETCH_FILTERED_CONCEPTS', () => {
+    action = {
+      type: FETCH_FILTERED_CONCEPTS,
+      payload: [multipleConceptsMockStore],
     };
 
     deepFreeze(state);


### PR DESCRIPTION

# JIRA TICKET NAME:
[Populate the filter sidebar with concept classes and datatype](https://issues.openmrs.org/browse/OCLOMRS-144)

# Summary:
As a user, I want to see pre-populated side navigation bar to filter concepts either by classes or by datatype.
