### PR TITLE
OCLOMRS-188 : The Concepts HEAD version card should display live data

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -5,7 +5,7 @@ import '../../styles/index.css';
 import './styles/dictionary-modal.css';
 import DictionaryDetailCard from './DictionaryDetailCard';
 import Loader from '../../../Loader';
-import { fetchDictionary } from '../../../../redux/actions/dictionaries/dictionaryActionCreators';
+import { fetchDictionary, fetchDictionaryConcepts } from '../../../../redux/actions/dictionaries/dictionaryActionCreators';
 
 export class DictionaryOverview extends Component {
   static propTypes = {
@@ -17,8 +17,10 @@ export class DictionaryOverview extends Component {
     dictionary: propTypes.arrayOf(propTypes.shape({
       dictionaryName: propTypes.string,
     })).isRequired,
+    dictionaryConcepts: propTypes.array.isRequired,
     fetchDictionary: propTypes.func.isRequired,
     loader: propTypes.bool.isRequired,
+    fetchDictionaryConcepts: propTypes.func.isRequired,
   };
   componentDidMount() {
     const {
@@ -29,10 +31,18 @@ export class DictionaryOverview extends Component {
       },
     } = this.props;
     const url = `/${ownerType}/${owner}/${type}/${name}/`;
+    const conceptsUrl = `/users/${owner}/collections/${name}/concepts/?q=&limit=0&page=1&verbose=true`;
     this.props.fetchDictionary(url);
+    this.props.fetchDictionaryConcepts(conceptsUrl);
   }
   render() {
     const { loader } = this.props;
+    const cielConcepts = this.props.dictionaryConcepts.filter(concept => concept.owner === 'CIEL').length.toString();
+    const customConcepts = this.props.dictionaryConcepts.filter(concept => concept.owner !== 'CIEL').length.toString();
+    const diagnosisConcepts = this.props.dictionaryConcepts.filter(concept => concept.concept_class === 'diagnosis').length.toString();
+    const procedureConcepts = this.props.dictionaryConcepts.filter(concept => concept.concept_class === 'procedure').length.toString();
+    const otherConcepts = this.props.dictionaryConcepts.filter(concept => concept.concept_class !== 'diagnosis' && concept.concept_class !== 'procedure').length.toString();
+
     return (
       <div className="dashboard-wrapper">
         {loader ? (
@@ -43,6 +53,12 @@ export class DictionaryOverview extends Component {
           <div className="dashboard-wrapper">
             <DictionaryDetailCard
               dictionary={this.props.dictionary}
+              cielConcepts={cielConcepts}
+              customConcepts={customConcepts}
+              diagnosisConcepts={diagnosisConcepts}
+              procedureConcepts={procedureConcepts}
+              otherConcepts={otherConcepts}
+
             />
           </div>
       }
@@ -52,6 +68,13 @@ export class DictionaryOverview extends Component {
 }
 export const mapStateToProps = state => ({
   dictionary: state.dictionaries.dictionary,
+  dictionaryConcepts: state.concepts.dictionaryConcepts,
   loader: state.dictionaries.loading,
 });
-export default connect(mapStateToProps, { fetchDictionary })(DictionaryOverview);
+export default connect(
+  mapStateToProps,
+  {
+    fetchDictionaryConcepts,
+    fetchDictionary,
+  },
+)(DictionaryOverview);

--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -12,7 +12,6 @@ const DictionaryDetailCard = (dictionary) => {
   const DATE_OPTIONS = {
     weekday: 'long', year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric',
   };
-
   return (<div className="dictionaryDetails">
     <h1 id="headingDict" align="left">{ name } Dictionary</h1>
     <hr />
@@ -37,11 +36,12 @@ const DictionaryDetailCard = (dictionary) => {
         <fieldset>
           <legend>Concepts (HEAD version)</legend>
           <p className="paragraph">Total Concepts: { active_concepts }</p>
-          <p className="points">Custom Concepts: 5</p>
-          <p className="points">From CIEL: 1229</p>
+          <p className="points">Custom Concepts: {dictionary.customConcepts}</p>
+          <p className="points">From CIEL: {dictionary.cielConcepts}</p>
           <p>By class:</p>
-          <p className="points">Diagnoses: 1000</p>
-          <p className="points">Procedure: 124</p>
+          <p className="points">Diagnosis: {dictionary.diagnosisConcepts}</p>
+          <p className="points">Procedure: {dictionary.procedureConcepts}</p>
+          <p className="points">Others: {dictionary.otherConcepts}</p>
           <Link
             className="btn btn-secondary"
             id="conceptB"

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -6,6 +6,7 @@ import {
   isFetching,
   dictionaryIsSuccess,
   isErrored,
+  dictionaryConceptsIsSuccess,
 } from './dictionaryActions';
 import { filterPayload } from '../../reducers/util';
 import api from './../../api';
@@ -71,13 +72,28 @@ export const searchDictionaries = searchItem => (dispatch) => {
     });
 };
 
-export const fetchDictionary = data => (dispatch) =>{
+export const fetchDictionary = data => (dispatch) => {
   dispatch(isFetching(true));
   return api.dictionaries
     .fetchDictionary(data)
     .then(
-      (payload) =>{
+      (payload) => {
       dispatch(dictionaryIsSuccess(payload));
       dispatch(isFetching(false));
     });
   };
+
+export const fetchDictionaryConcepts = data => (dispatch) => {
+  dispatch(isFetching(true));
+  return api.dictionaries
+    .fetchDictionaryConcepts(data)
+    .then(
+      (payload) => {
+      dispatch(dictionaryConceptsIsSuccess(payload));
+      dispatch(isFetching(false));
+      })
+      .catch((error) => {
+        dispatch(isErrored(error.response.data));
+        dispatch(isFetching(false));
+      });
+};

--- a/src/redux/actions/dictionaries/dictionaryActions.js
+++ b/src/redux/actions/dictionaries/dictionaryActions.js
@@ -1,4 +1,4 @@
-import { ADDING_DICTIONARY, FETCHING_ORGANIZATIONS, ADDING_DICTIONARY_FAILURE, FETCHING_DICTIONARIES, IS_FETCHING, CLEAR_DICTIONARIES, FETCHING_DICTIONARY, CLEAR_DICTIONARY } from './../types';
+import { ADDING_DICTIONARY, FETCHING_ORGANIZATIONS, ADDING_DICTIONARY_FAILURE, FETCHING_DICTIONARIES, IS_FETCHING, CLEAR_DICTIONARIES, FETCHING_DICTIONARY, CLEAR_DICTIONARY, FETCH_DICTIONARY_CONCEPT } from './../types';
 
 export const addDictionary = response => ({
   type: ADDING_DICTIONARY,
@@ -37,6 +37,11 @@ export const clearDictionaries = () => ({
 
 export const dictionaryIsSuccess = payload => ({
   type: FETCHING_DICTIONARY,
+  payload,
+});
+
+export const dictionaryConceptsIsSuccess = payload => ({
+  type: FETCH_DICTIONARY_CONCEPT,
   payload,
 });
 

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -33,6 +33,11 @@ export default {
       instance
         .get(`${data}`)
         .then(response => response.data),
+
+    fetchDictionaryConcepts: (data) =>
+      instance
+        .get(`${data}`)
+        .then(response => response.data),
   },
   organizations: {
     fetchOrganizations: () =>

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -5,7 +5,7 @@ import instance from '../../../config/axiosConfig';
 import {
   FETCHING_ORGANIZATIONS,
   ADDING_DICTIONARY, FETCHING_DICTIONARIES, IS_FETCHING, CLEAR_DICTIONARIES,
-  FETCHING_DICTIONARY, CLEAR_DICTIONARY,
+  FETCHING_DICTIONARY, CLEAR_DICTIONARY, FETCH_DICTIONARY_CONCEPT,
 } from '../../../redux/actions/types';
 import {
   fetchOrganizations,
@@ -19,8 +19,10 @@ import {
   fetchDictionaries,
   searchDictionaries,
   fetchDictionary,
+  fetchDictionaryConcepts,
 } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import dictionaries from '../../__mocks__/dictionaries';
+import concepts from '../../__mocks__/concepts';
 
 const mockStore = configureStore([thunk]);
 
@@ -112,6 +114,25 @@ describe('Test suite for dictionary actions', () => {
     ];
     const store = mockStore({ payload: {} });
     return store.dispatch(fetchDictionary('/users/chriskala/collections/over/')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should return concepts in a dictionary', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [concepts],
+      });
+    });
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_DICTIONARY_CONCEPT, payload: [concepts] },
+      { type: IS_FETCHING, payload: false },
+    ];
+    const store = mockStore({ payload: {} });
+    return store.dispatch(fetchDictionaryConcepts('/users/chriskala/collections/over/')).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -16,6 +16,7 @@ describe('DictionaryOverview', () => {
   it('should render with dictionary data', () => {
     const props = {
       dictionary: [dictionary],
+      dictionaryConcepts: [dictionary],
       match: {
         params: {
           ownerType: 'testing',
@@ -25,6 +26,7 @@ describe('DictionaryOverview', () => {
         },
       },
       fetchDictionary: jest.fn(),
+      fetchDictionaryConcepts: jest.fn(),
     };
     const wrapper = mount(<MemoryRouter><DictionaryOverview {...props} /></MemoryRouter>);
     expect(wrapper.find('#headingDict')).toHaveLength(1);


### PR DESCRIPTION
# JIRA TICKET NAME:
[The Concepts HEAD version card should display live data](https://issues.openmrs.org/browse/OCLOMRS-188)

# Summary:
Currently, the Concepts (HEAD version) fieldset in the Dictionary overview page is displaying dummy data. 
Therefore the Dictionary overview page should display live data on the fieldset mentioned above.
