### PR TITLE
OCLOMRS-19: User should be able to Update/Edit Dictionaries via the user interface

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -6,6 +6,7 @@ import './styles/dictionary-modal.css';
 import DictionaryDetailCard from './DictionaryDetailCard';
 import Loader from '../../../Loader';
 import { fetchDictionary } from '../../../../redux/actions/dictionaries/dictionaryActionCreators';
+import EditDictionary from './EditDictionary';
 
 export class DictionaryOverview extends Component {
   static propTypes = {
@@ -20,6 +21,13 @@ export class DictionaryOverview extends Component {
     fetchDictionary: propTypes.func.isRequired,
     loader: propTypes.bool.isRequired,
   };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      showEditModal: false,
+    };
+  }
   componentDidMount() {
     const {
       match: {
@@ -31,6 +39,10 @@ export class DictionaryOverview extends Component {
     const url = `/${ownerType}/${owner}/${type}/${name}/`;
     this.props.fetchDictionary(url);
   }
+
+  handleHide = () => this.setState({ showEditModal: false });
+  handleShow = () => this.setState({ showEditModal: true });
+
   render() {
     const { loader } = this.props;
     return (
@@ -42,6 +54,12 @@ export class DictionaryOverview extends Component {
       ) :
           <div className="dashboard-wrapper">
             <DictionaryDetailCard
+              dictionary={this.props.dictionary}
+              showEditModal={this.handleShow}
+            />
+            <EditDictionary
+              show={this.state.showEditModal}
+              handleHide={this.handleHide}
               dictionary={this.props.dictionary}
             />
           </div>

--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import './styles/dictionary-modal.css';
 
-const DictionaryDetailCard = (dictionary) => {
+const DictionaryDetailCard = (props) => {
   const {
     dictionary: {
       name, created_on, updated_on, public_access, owner, owner_type, active_concepts, description,
       owner_url, short_code, default_locale,
     },
-  } = dictionary;
+    showEditModal,
+  } = props;
+  const username = localStorage.getItem('username');
   const DATE_OPTIONS = {
     weekday: 'long', year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric',
   };
@@ -26,13 +29,16 @@ const DictionaryDetailCard = (dictionary) => {
           <p className="paragraph">Owner: { owner }({ owner_type })</p>
           <p className="paragraph">Created On: { (new Date(created_on)).toLocaleDateString('en-US', DATE_OPTIONS) }</p>
           <p className="paragraph">Updated On: { (new Date(updated_on)).toLocaleDateString('en-US', DATE_OPTIONS) }</p>
-          <Link
-            className="btn btn-secondary"
-            id="editB"
-            to="#"
-          >
-            { public_access }
-          </Link>
+          { owner === username &&
+            <Link
+              className="btn btn-secondary"
+              id="editB"
+              to="#"
+              onClick={showEditModal}
+            >
+            Edit
+            </Link>
+          }
         </fieldset>
         <fieldset>
           <legend>Concepts (HEAD version)</legend>
@@ -93,6 +99,11 @@ const DictionaryDetailCard = (dictionary) => {
     </div>
   </div>
   );
+};
+
+DictionaryDetailCard.propTypes = {
+  dictionary: PropTypes.object.isRequired,
+  showEditModal: PropTypes.object.isRequired,
 };
 
 export default DictionaryDetailCard;

--- a/src/components/dashboard/components/dictionary/EditDictionary.jsx
+++ b/src/components/dashboard/components/dictionary/EditDictionary.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import DictionaryModal from './common/DictionaryModal';
+import {
+  fetchingOrganizations,
+  editDictionary,
+} from '../../../../redux/actions/dictionaries/dictionaryActionCreators';
+import languages from './common/Languages';
+
+export class EditDictionary extends React.Component {
+
+  preSelectDefaultLocale = () => {
+    const { dictionary } = this.props;
+    for (let i = 0; i < languages.length; i++) { // eslint-disable-line
+      if (languages[i].value === dictionary.default_locale) {
+        return (<option value={languages[i].value} selected>
+          {languages[i].label}
+        </option>);
+      }
+    }
+    return null;
+  }
+
+  submit = (data) => {
+    const {
+      dictionary: {
+        url,
+      },
+    } = this.props;
+    return this.props.editDictionary(url, data);
+  }
+  render() {
+    return (
+      <DictionaryModal
+        title="Edit Dictionary"
+        buttonname="Update Dictionary"
+        show={this.props.show}
+        modalhide={this.props.handleHide}
+        submit={this.submit}
+        dictionary={this.props.dictionary}
+        preSelectDefaultLocale={this.preSelectDefaultLocale}
+        isEditingDictionary
+      />
+    );
+  }
+}
+EditDictionary.propTypes = {
+  handleHide: PropTypes.func.isRequired,
+  show: PropTypes.bool.isRequired,
+  editDictionary: PropTypes.func.isRequired,
+  dictionary: PropTypes.object.isRequired,
+};
+
+
+export default connect(null, {
+  fetchingOrganizations,
+  editDictionary,
+})(EditDictionary);

--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -27,6 +27,29 @@ export class DictionaryModal extends React.Component {
 
   componentDidMount() {
     this.props.fetchingOrganizations();
+    const { isEditingDictionary } = this.props;
+    if (isEditingDictionary) {
+      const {
+        dictionary: {
+          id, preffered_source, public_access, name, owner, description,
+          default_locale, repository_type,
+        },
+      } = this.props;
+      this.setState({ //eslint-disable-line
+        data: {
+          id,
+          preffered_sources: preffered_source,
+          public_access,
+          name,
+          owner,
+          description,
+          default_locale,
+          supported_locales: 'en, es',
+          repository_type,
+        },
+        errors: {},
+      });
+    }
   }
 
   onChange = (e) => {
@@ -47,6 +70,11 @@ export class DictionaryModal extends React.Component {
     if (Object.keys(errors).length === 0) {
       this.props
         .submit(this.state.data)
+        .then((response) => {
+          if (response) {
+            this.props.modalhide();
+          }      
+        })
         .catch((error) => {
           if (error.response) {
             this.setState({
@@ -84,6 +112,8 @@ export class DictionaryModal extends React.Component {
   render() {
     const { data, errors } = this.state;
     const { organizations } = this.props;
+    const { dictionary } = this.props;
+    const { isEditingDictionary } = this.props;
     return (
       <div className="col-sm-5">
         <Modal
@@ -117,6 +147,12 @@ export class DictionaryModal extends React.Component {
                     >
                       <option value="" />
                       <option value="1">CIEL (default source)</option>
+                      {
+                        isEditingDictionary &&
+                        <option value={dictionary.preffered_source} selected>
+                          {dictionary.preffered_source}
+                        </option>
+                      }
                     </FormControl>
                   </FormGroup>
 
@@ -131,12 +167,15 @@ export class DictionaryModal extends React.Component {
                       placeholder="English"
                       onChange={this.onChange}
                     >
+                      {isEditingDictionary &&
+                        this.props.preSelectDefaultLocale()
+                      }
                       {language &&
                       language.map(languages => (
                         <option value={languages.value} key={languages.value}>
                           { languages.label }
                         </option>
-                      ))}
+                      ))}                
                     </FormControl>
                   </FormGroup>
 
@@ -153,8 +192,11 @@ export class DictionaryModal extends React.Component {
                       value={data.public_access}
                     >
                       <option value="" />
-                      <option value="View">Private </option>
+                      {(isEditingDictionary && dictionary.public_access === 'View') &&
+                      <option value="View" selected>Private </option>
+                      }
                       <option value="Edit"> Public </option>
+                      <option value="View">Private </option>
                     </FormControl>
                   </FormGroup>
 
@@ -182,6 +224,9 @@ export class DictionaryModal extends React.Component {
                       onChange={this.onChange}
                       value={data.owner}
                     >
+                      {isEditingDictionary &&
+                      <option value={data.owner} selected>{data.owner}</option>
+                      }
                       { organizations && organizations.length !== 0 && <option value="" />}
                       <option value="Individual" style={{ textTransform: 'capitalize' }}> {localStorage.getItem('username')} (Yourself) </option>
                       {organizations &&
@@ -261,6 +306,7 @@ DictionaryModal.propTypes = {
   fetchingOrganizations: PropTypes.func.isRequired,
   submit: PropTypes.func.isRequired,
   organizations: PropTypes.shape,
+  dictionary: PropTypes.object.isRequired,
 };
 
 DictionaryModal.defaultProps = {

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -177,7 +177,8 @@ export class CreateConcept extends Component {
   addDataFromDescription(data) {
     const currentData = this.state.descriptions.filter(description => description.id === data.id);
     if (currentData.length) {
-      const newList = this.state.descriptions.map(description => (description.id === data.id ? data : description));
+      const newList = this.state.descriptions.map(description =>
+        (description.id === data.id ? data : description));
       this.setState(() => ({
         descriptions: newList,
       }));

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -6,6 +6,7 @@ import {
   isFetching,
   dictionaryIsSuccess,
   isErrored,
+  editDictionarySuccess,
 } from './dictionaryActions';
 import { filterPayload } from '../../reducers/util';
 import api from './../../api';
@@ -81,3 +82,18 @@ export const fetchDictionary = data => (dispatch) =>{
       dispatch(isFetching(false));
     });
   };
+
+  export const editDictionary = (url, data) => dispatch => {
+  return api.dictionaries
+    .editDictionary(url, data)
+    .then(payload => dispatch(
+      editDictionarySuccess(payload),
+      notify.show(
+        'Successfully updated dictionary',
+        'success', 6000,
+      ),
+    ))
+    .catch(error =>
+      notify.show(`${error.response.data.__all__[0]}`, 'error', 6000));
+    }
+

--- a/src/redux/actions/dictionaries/dictionaryActions.js
+++ b/src/redux/actions/dictionaries/dictionaryActions.js
@@ -1,4 +1,14 @@
-import { ADDING_DICTIONARY, FETCHING_ORGANIZATIONS, ADDING_DICTIONARY_FAILURE, FETCHING_DICTIONARIES, IS_FETCHING, CLEAR_DICTIONARIES, FETCHING_DICTIONARY, CLEAR_DICTIONARY } from './../types';
+import {
+  ADDING_DICTIONARY,
+  FETCHING_ORGANIZATIONS,
+  ADDING_DICTIONARY_FAILURE,
+  FETCHING_DICTIONARIES,
+  IS_FETCHING,
+  CLEAR_DICTIONARIES,
+  FETCHING_DICTIONARY,
+  CLEAR_DICTIONARY,
+  EDIT_DICTIONARY_SUCCESS,
+} from './../types';
 
 export const addDictionary = response => ({
   type: ADDING_DICTIONARY,
@@ -43,4 +53,9 @@ export const dictionaryIsSuccess = payload => ({
 export const clearDictionary = () => ({
   type: CLEAR_DICTIONARY,
   payload: {},
+});
+
+export const editDictionarySuccess = response => ({
+  type: EDIT_DICTIONARY_SUCCESS,
+  payload: response,
 });

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -19,6 +19,7 @@ export const FETCH_DICTIONARY_CONCEPT = '[concepts] fetch concepts of one dictio
 export const CLEAR_DICTIONARIES = '[dictionaries] clear dictionaries';
 export const FETCHING_DICTIONARY = '[dictionary] fetch dictionary';
 export const CLEAR_DICTIONARY = '[dictionary] clear dictionary';
+export const EDIT_DICTIONARY_SUCCESS = '[dictionary] edit dictionary success';
 
 export const FILTER_BY_SOURCES = '[concepts] filter concepts by sources';
 export const FILTER_BY_CLASS = '[concepts] filter concepts by class';

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -18,6 +18,11 @@ export default {
         .then(() => {
           return instance.post('user/sources/', data);
         }),
+    
+    editDictionary: (url, data) =>
+      instance
+        .put(url, data)
+        .then(response => response.data),
 
     fetchingDictionaries: () =>
       instance

--- a/src/redux/reducers/dictionaryReducers.js
+++ b/src/redux/reducers/dictionaryReducers.js
@@ -1,4 +1,10 @@
-import { FETCHING_DICTIONARIES, IS_FETCHING, FETCHING_DICTIONARY, CLEAR_DICTIONARY } from '../actions/types';
+import {
+  FETCHING_DICTIONARIES,
+  IS_FETCHING,
+  FETCHING_DICTIONARY,
+  CLEAR_DICTIONARY,
+  EDIT_DICTIONARY_SUCCESS,
+} from '../actions/types';
 
 const initalState = { dictionaries: [], loading: false, dictionary: {} };
 
@@ -23,6 +29,11 @@ export default (state = initalState, action) => {
       return {
         ...state,
         dictionary: {},
+      };
+    case EDIT_DICTIONARY_SUCCESS:
+      return {
+        ...state,
+        dictionary: action.payload,
       };
     default:
       return state;

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -13,24 +13,7 @@ describe('DictionaryOverview', () => {
     const wrapper = <MemoryRouter><DictionaryOverview {...props} /></MemoryRouter>;
     expect(wrapper).toMatchSnapshot();
   });
-  it('should render with dictionary data', () => {
-    const props = {
-      dictionary: [dictionary],
-      match: {
-        params: {
-          ownerType: 'testing',
-          owner: 'tester',
-          type: 'collection',
-          name: 'chris',
-        },
-      },
-      fetchDictionary: jest.fn(),
-    };
-    const wrapper = mount(<MemoryRouter><DictionaryOverview {...props} /></MemoryRouter>);
-    expect(wrapper.find('#headingDict')).toHaveLength(1);
-    expect(wrapper.find('.paragraph')).toHaveLength(5);
-    expect(wrapper).toMatchSnapshot();
-  });
+ 
   it('should render preloader spinner', () => {
     const props = {
       fetchDictionary: jest.fn(),

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
+import { Provider } from 'react-redux';
+import { createMockStore } from 'redux-test-utils'
 import { MemoryRouter } from 'react-router-dom';
 import { mount, shallow } from 'enzyme';
 import { DictionaryOverview } from '../../components/dashboard/components/dictionary/DictionaryContainer';
 import dictionary from '../__mocks__/dictionaries';
 
+const store = createMockStore({
+  organizations: {
+    organizations: [],
+  },
+});
 jest.mock('../../components/dashboard/components/dictionary/AddDictionary');
 describe('DictionaryOverview', () => {
   it('should render without any data', () => {
@@ -13,7 +20,24 @@ describe('DictionaryOverview', () => {
     const wrapper = <MemoryRouter><DictionaryOverview {...props} /></MemoryRouter>;
     expect(wrapper).toMatchSnapshot();
   });
- 
+  it('should render with dictionary data', () => {
+    const props = {
+      dictionary: [dictionary],
+      match: {
+        params: {
+          ownerType: 'testing',
+          owner: 'tester',
+          type: 'collection',
+          name: 'chris',
+        },
+      },
+      fetchDictionary: jest.fn(),
+    };
+    const wrapper = mount(<Provider store={store}><MemoryRouter><DictionaryOverview {...props} /></MemoryRouter></Provider>);
+    expect(wrapper.find('#headingDict')).toHaveLength(1);
+    expect(wrapper.find('.paragraph')).toHaveLength(5);
+    expect(wrapper).toMatchSnapshot();
+  });
   it('should render preloader spinner', () => {
     const props = {
       fetchDictionary: jest.fn(),

--- a/src/tests/Dictionary/EditDictionary.test.jsx
+++ b/src/tests/Dictionary/EditDictionary.test.jsx
@@ -30,44 +30,4 @@ describe('Test suite for Edit Dictionary', () => {
     const wrapper = shallow(<Provider store={store}><EditDictionary {...props} /></Provider>);
     expect(wrapper).toMatchSnapshot();
   });
-  /*const wrapper = shallow(<DictionaryModal {...props} />);
-  const preventDefault = { preventDefault: jest.fn() };
-  const toUpperCase = { toUpperCase: jest.fn() };
-  const then = { then: jest.fn() };
-
-  it('should take a snapshot', () => {
-    expect(wrapper).toMatchSnapshot();
-    expect(wrapper.instance().componentDidMount());
-  });
-  it('Test to find and click cancel and add dictionary buttons', () => {
-    expect(wrapper.find('#cancel').simulate('click'));
-    expect(wrapper.find('#addDictionary').simulate('click', preventDefault));
-    expect(wrapper.instance().validate(preventDefault));
-  });
-  it('Tests that the component changes state', () => {
-    wrapper.setState({ errors: {} });
-    expect(wrapper.state('errors')).toEqual({});
-  });
-
-  it('Opens and closes modal on trigger', () => {
-    expect(wrapper.find('#cancel').simulate('click'));
-  });
-
-  it('Sets the state of the component to the value of the input elements on change', () => {
-    wrapper.find('#dictionary_name').simulate('change', { target: { value: 'CIEL', name: 'name' } });
-    expect(wrapper.state().data.name).toEqual('CIEL');
-  });
-
-  it('Renders component that adds a dictionary', () => {
-    const data = {
-      dictionary: {
-        name: toUpperCase,
-        submit: then,
-        then: jest.fn(),
-      },
-    };
-    const component = shallow(<AddDictionary {...props} {...preventDefault} {...data} />);
-    expect(component).toMatchSnapshot();
-  });
-  */
 });

--- a/src/tests/Dictionary/EditDictionary.test.jsx
+++ b/src/tests/Dictionary/EditDictionary.test.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import { createMockStore } from 'redux-test-utils'
+import organizations from '../__mocks__/organizations';
+import dictionary from '../__mocks__/dictionaries';
+import { EditDictionary } from '../../components/dashboard/components/dictionary/EditDictionary';
+
+const props = {
+  title: 'Edit Dictionary',
+  buttonname: 'Update Dictionary',
+  show: true,
+  modalhide: jest.fn(),
+  submit: jest.fn(),
+  organizations: [organizations],
+  dictionary,
+  fetchingOrganizations: jest.fn(),
+  handleHide: jest.fn(),
+  name: jest.fn(),
+};
+
+const store = createMockStore({
+  organizations: {
+    organizations: [organizations],
+  },
+});
+
+describe('Test suite for Edit Dictionary', () => {
+  it('should render EditDictionary', () => {
+    const wrapper = shallow(<Provider store={store}><EditDictionary {...props} /></Provider>);
+    expect(wrapper).toMatchSnapshot();
+  });
+  /*const wrapper = shallow(<DictionaryModal {...props} />);
+  const preventDefault = { preventDefault: jest.fn() };
+  const toUpperCase = { toUpperCase: jest.fn() };
+  const then = { then: jest.fn() };
+
+  it('should take a snapshot', () => {
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.instance().componentDidMount());
+  });
+  it('Test to find and click cancel and add dictionary buttons', () => {
+    expect(wrapper.find('#cancel').simulate('click'));
+    expect(wrapper.find('#addDictionary').simulate('click', preventDefault));
+    expect(wrapper.instance().validate(preventDefault));
+  });
+  it('Tests that the component changes state', () => {
+    wrapper.setState({ errors: {} });
+    expect(wrapper.state('errors')).toEqual({});
+  });
+
+  it('Opens and closes modal on trigger', () => {
+    expect(wrapper.find('#cancel').simulate('click'));
+  });
+
+  it('Sets the state of the component to the value of the input elements on change', () => {
+    wrapper.find('#dictionary_name').simulate('change', { target: { value: 'CIEL', name: 'name' } });
+    expect(wrapper.state().data.name).toEqual('CIEL');
+  });
+
+  it('Renders component that adds a dictionary', () => {
+    const data = {
+      dictionary: {
+        name: toUpperCase,
+        submit: then,
+        then: jest.fn(),
+      },
+    };
+    const component = shallow(<AddDictionary {...props} {...preventDefault} {...data} />);
+    expect(component).toMatchSnapshot();
+  });
+  */
+});


### PR DESCRIPTION

# JIRA TICKET NAME:
[ User should be able to Update/Edit Dictionaries via the user interface](https://issues.openmrs.org/browse/OCLOMRS-19?jql=key%20in%20(OCLOMRS-19))

# Summary:
If the users create their dictionaries, they should be able to update or change their information in the dictionaries.
As a user, when I click the edit button on the dictionaries overview page, I should be able to edit the details for I dictionary.