### PR TITLE
OCLOMRS-193: A user should be able to add concepts in an Organisation Dictionary

### DIFF
--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -152,7 +152,6 @@ export class DictionaryConcepts extends Component {
       filteredSources,
       loading,
     } = this.props;
-    const username = typeName === getUsername();
     const {
       conceptsCount, searchInput, conceptOffset, conceptLimit,
     } = this.state;
@@ -164,7 +163,7 @@ export class DictionaryConcepts extends Component {
           <div className="col-12 col-md-2 pt-1">
             <h4>Concepts</h4>
           </div>
-          {username && <ConceptDropdown pathName={pathname} />}
+          <ConceptDropdown pathName={pathname} />
         </section>
 
         <section className="row mt-3">


### PR DESCRIPTION
# JIRA TICKET NAME:
[A user should be able to add concepts in an Organisation Dictionary](https://issues.openmrs.org/browse/OCLOMRS-193)

# Summary:
Currently, when a User navigates to the concepts display page of an Organisation dictionary he/she cannot be be able to add new concepts. This should not be the case since the functionality is already there.
Therefore the a User should be able to add new concepts to an Organisation dictionary.
