### PR TITLE
OCLOMRS-156: User should be able to remove existing concepts from a dictionary

### DIFF
--- a/src/components/dictionaryConcepts/components/ActionButtons.jsx
+++ b/src/components/dictionaryConcepts/components/ActionButtons.jsx
@@ -3,31 +3,40 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
 const ActionButtons = ({
-  actionButtons, id, concept_class,
+  actionButtons, id, concept_class, showDeleteModal, version_url,
 }) => {
   const dictionaryPathName = localStorage.getItem('dictionaryPathName');
 
-  if (actionButtons) {
-    return (
-      <React.Fragment>
-        <Link
-          to={`${dictionaryPathName}/edit/${id}/${concept_class}`}
-        >
-        Edit
-        </Link>
-        <a className="dummy-link">
-        Delete
-        </a>
-      </React.Fragment>
-    );
-  }
-  return <a className="dummy-link">Remove</a>;
+  return (
+    <React.Fragment>
+      {actionButtons === true &&
+      <Link
+        className="btn btn-sm mb-1 actionButtons"
+        to={`${dictionaryPathName}/edit/${id}/${concept_class}`}
+      >
+      Edit
+      </Link>
+      }
+      <button
+        type="button"
+        className="btn btn-sm mb-1 actionButtons"
+        id="retireConcept"
+        data-toggle="modal"
+        data-target="#removeConceptModal"
+        onClick={() => { showDeleteModal(version_url); }}
+      >
+      Remove
+      </button>
+    </React.Fragment>
+  );
 };
 
 ActionButtons.propTypes = {
   actionButtons: PropTypes.bool.isRequired,
   id: PropTypes.string.isRequired,
   concept_class: PropTypes.string.isRequired,
+  showDeleteModal: PropTypes.func.isRequired,
+  version_url: PropTypes.string.isRequired,
 };
 
 export default ActionButtons;

--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -5,7 +5,9 @@ import Loader from '../../Loader';
 import RenderTable from './RenderTable';
 import { conceptsProps } from '../proptypes';
 
-const ConceptTable = ({ concepts, loading, org }) => {
+const ConceptTable = ({
+  concepts, loading, org, locationPath, showDeleteModal, url, handleDelete,
+}) => {
   if (loading) {
     return (
       <RenderTable
@@ -34,7 +36,16 @@ const ConceptTable = ({ concepts, loading, org }) => {
             </tr>
           </thead>
           <tbody>
-            {concepts.map(concept => <TableItem {...concept} key={concept.version} org={org} />)}
+            {concepts.map(concept =>
+              (<TableItem
+                {...concept}
+                key={concept.version}
+                org={org}
+                locationPath={locationPath}
+                showDeleteModal={showDeleteModal}
+                url={url}
+                handleDelete={handleDelete}
+              />))}
           </tbody>
         </table>
       </div>
@@ -57,6 +68,10 @@ ConceptTable.propTypes = {
   concepts: PropTypes.arrayOf(PropTypes.shape(conceptsProps)).isRequired,
   loading: PropTypes.bool.isRequired,
   org: PropTypes.object.isRequired,
+  locationPath: PropTypes.object.isRequired,
+  showDeleteModal: PropTypes.func.isRequired,
+  handleDelete: PropTypes.func.isRequired,
+  url: PropTypes.string.isRequired,
 };
 
 export default ConceptTable;

--- a/src/components/dictionaryConcepts/components/RemoveConcept.jsx
+++ b/src/components/dictionaryConcepts/components/RemoveConcept.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const removeConcept = (props) => {
+  const { handleDelete } = props;
+  return (
+    <div>
+      <div
+        className="container modal fade"
+        id="removeConceptModal"
+        tabIndex="-1"
+        role="dialog"
+        aria-labelledby="exampleModalLabel"
+        aria-hidden="true"
+      >
+        <div className="container modal-dialog" role="document">
+          <div className="modal-content">
+            <div className="modal-header">
+              <p className="modal-title" id="exampleModalLabel">
+                  Are you sure you want to Remove this Concept?
+              </p>
+              <button
+                type="button"
+                className="close"
+                data-dismiss="modal"
+                aria-label="Close"
+              >
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div>
+              <form>
+                <div className="modal-footer" type="submit">
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    data-dismiss="modal"
+                  >
+                  Cancel
+                  </button>
+                  <button
+                    type="button"
+                    data-dismiss="modal"
+                    className="btn btn-danger"
+                    onClick={handleDelete}
+                  >
+                  Remove Concept
+                  </button>
+                </div>
+              </form>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+removeConcept.propTypes = {
+  handleDelete: PropTypes.func.isRequired,
+};
+
+export default removeConcept;
+

--- a/src/components/dictionaryConcepts/components/SearchBar.jsx
+++ b/src/components/dictionaryConcepts/components/SearchBar.jsx
@@ -18,7 +18,7 @@ const SearchBar = ({
     <div className="row search-container">
       <div className="concept-search-wrapper col-12 col-md-5 col-sm-8">
         <i className="fa fa-search search-icons" aria-hidden="true" />
-        <form action="" onSubmit={submit}>
+        <form className="searchConcepts" action="" onSubmit={submit}>
           <input
             type="search"
             name="searchInput"

--- a/src/components/dictionaryConcepts/components/TableItem.jsx
+++ b/src/components/dictionaryConcepts/components/TableItem.jsx
@@ -2,25 +2,43 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ActionButtons from './ActionButtons';
 import { getUsername } from './helperFunction';
+import RemoveConcept from './RemoveConcept';
 
 const TableItem = (props) => {
   const username = getUsername();
   const {
-    id, concept_class, datatype, source, owner, display_name, org,
+    id,
+    concept_class,
+    datatype,
+    source,
+    owner,
+    display_name,
+    org,
+    locationPath,
+    handleDelete,
+    url,
   } = props;
   const renderButtons = username === owner || (owner === org.name && org.userIsMember);
-
   return (
-    <tr>
-      <th scope="row">{display_name}</th>
-      <td>{concept_class}</td>
-      <td>{datatype}</td>
-      <td>{source}</td>
-      <td>{id}</td>
-      <td>
-        <ActionButtons actionButtons={renderButtons} {...props} />
-      </td>
-    </tr>
+    <React.Fragment>
+      <tr>
+        <th scope="row">{display_name}</th>
+        <td>{concept_class}</td>
+        <td>{datatype}</td>
+        <td>{source}</td>
+        <td>{id}</td>
+        <td>
+          <ActionButtons actionButtons={renderButtons} {...props} />
+        </td>
+      </tr>
+      <RemoveConcept
+        collectionName={locationPath.collectionName}
+        conceptOwner={locationPath.typeName}
+        conceptUrl={url}
+        conceptType={locationPath.type}
+        handleDelete={handleDelete}
+      />
+    </React.Fragment>
   );
 };
 
@@ -32,6 +50,7 @@ TableItem.propTypes = {
   owner: PropTypes.string.isRequired,
   display_name: PropTypes.string.isRequired,
   org: PropTypes.object.isRequired,
+  locationPath: PropTypes.object.isRequired,
 };
 
 export default TableItem;

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -16,6 +16,7 @@ import {
   filterByClass,
   paginateConcepts,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
+import { removeDictionaryConcept } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import { fetchMemberStatus } from '../../../redux/actions/user/index';
 
 export class DictionaryConcepts extends Component {
@@ -42,6 +43,7 @@ export class DictionaryConcepts extends Component {
     totalConceptCount: PropTypes.number.isRequired,
     fetchMemberStatus: PropTypes.func.isRequired,
     userIsMember: PropTypes.func.isRequired,
+    removeDictionaryConcept: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -51,6 +53,10 @@ export class DictionaryConcepts extends Component {
       searchInput: '',
       conceptLimit: 10,
       conceptOffset: 0,
+      versionUrl: '',
+      data: {
+        references: [],
+      },
     };
     autoBind(this);
   }
@@ -160,6 +166,14 @@ export class DictionaryConcepts extends Component {
     }
   }
 
+  handleDelete = () => {
+    const { data, collectionName, type } = this.state;
+    this.props
+      .removeDictionaryConcept(data, type, this.props.match.params.typeName, collectionName);
+  }
+
+  handleShowDelete = (url) => { this.setState({ data: { references: [url] }, versionUrl: url }); };
+
   render() {
     const {
       match: {
@@ -213,6 +227,10 @@ export class DictionaryConcepts extends Component {
               concepts={concepts}
               loading={loading}
               org={org}
+              locationPath={this.props.match.params}
+              showDeleteModal={this.handleShowDelete}
+              url={this.state.versionUrl}
+              handleDelete={this.handleDelete}
             />
           </div>
         </section>
@@ -240,5 +258,6 @@ export default connect(
     filterByClass,
     paginateConcepts,
     fetchMemberStatus,
+    removeDictionaryConcept,
   },
 )(DictionaryConcepts);

--- a/src/components/dictionaryConcepts/style/index.css
+++ b/src/components/dictionaryConcepts/style/index.css
@@ -299,3 +299,8 @@ select.form-control {
 .create-custom-concept {
   margin-top: -5%;
 }
+
+#actionButtons {
+  background-color: Transparent;
+  cursor:pointer;
+}

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -6,6 +6,7 @@ import {
   isFetching,
   dictionaryIsSuccess,
   isErrored,
+  removeConcept,
   fetchingVersions,
   dictionaryConceptsIsSuccess,
   realisingHeadSuccess,
@@ -85,6 +86,23 @@ export const fetchDictionary = data => (dispatch) => {
       dispatch(isFetching(false));
     });
   };
+
+export const removeDictionaryConcept = (data, type, owner, collectionId) => dispatch => {
+  return api.dictionaries
+    .removeDictionaryConcept(data, type, owner, collectionId)
+    .then(
+      (payload) => { 
+      dispatch(removeConcept(data.references[0]));
+      notify.show(
+        'Successfully removed a concept from my dictionary',
+        'success', 1000
+      );
+    }
+    )
+    .catch(() => {
+      notify.show("Network Error. Please try again later!", 'error', 6000)
+      });
+    };
 
 export const fetchVersions = data => (dispatch) => {
   return api.dictionaries

--- a/src/redux/actions/dictionaries/dictionaryActions.js
+++ b/src/redux/actions/dictionaries/dictionaryActions.js
@@ -10,6 +10,7 @@ import {
   FETCHING_VERSIONS,
   FETCH_DICTIONARY_CONCEPT,
   EDIT_DICTIONARY_SUCCESS,
+  REMOVE_CONCEPT,
   RELEASING_HEAD_VERSION,
 } from './../types';
 
@@ -61,6 +62,11 @@ export const dictionaryConceptsIsSuccess = payload => ({
 export const clearDictionary = () => ({
   type: CLEAR_DICTIONARY,
   payload: {},
+});
+
+export const removeConcept = payload => ({
+  type: REMOVE_CONCEPT,
+  payload,
 });
 
 export const fetchingVersions = payload => ({

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -19,6 +19,7 @@ export const FETCH_DICTIONARY_CONCEPT = '[concepts] fetch concepts of one dictio
 export const CLEAR_DICTIONARIES = '[dictionaries] clear dictionaries';
 export const FETCHING_DICTIONARY = '[dictionary] fetch dictionary';
 export const CLEAR_DICTIONARY = '[dictionary] clear dictionary';
+export const REMOVE_CONCEPT = '[concepts] remove concept';
 export const FETCHING_VERSIONS = '[dictionary] fetch versions of a dictionary';
 export const RELEASING_HEAD_VERSION = '[dictionary] releasing HEAD version of a dictionary';
 export const EDIT_DICTIONARY_SUCCESS = '[dictionary] edit dictionary success';

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -38,6 +38,11 @@ export default {
       instance
         .get(`${data}`)
         .then(response => response.data),
+
+    removeDictionaryConcept: (data, type, owner, collectionId) =>
+      instance
+        .delete(`/${type}/${owner}/collections/${collectionId}/references/`, {data:data})
+        .then(response => response.data),
     
     fetchingVersions: (data) =>
       instance

--- a/src/redux/reducers/ConceptReducers.js
+++ b/src/redux/reducers/ConceptReducers.js
@@ -23,6 +23,7 @@ import {
   CLEAR_PREVIOUS_CONCEPT,
   EDIT_CONCEPT_CREATE_NEW_NAMES,
   EDIT_CONCEPT_REMOVE_ONE_NAME,
+  REMOVE_CONCEPT,
 } from '../actions/types';
 import {
   filterSources, filterClass, filterList, normalizeList, filterNames,
@@ -79,6 +80,12 @@ export default (state = initialState, action) => {
       return {
         ...state,
         paginatedConcepts: action.payload,
+      };
+    case REMOVE_CONCEPT:
+      return {
+        ...state,
+        paginatedConcepts: state.paginatedConcepts
+          .filter(concept => concept.version_url !== action.payload),
       };
     case TOTAL_CONCEPT_COUNT:
       return {

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -14,6 +14,7 @@ import {
   FETCH_DICTIONARY_CONCEPT,
   FETCHING_ORGANIZATIONS,
   RELEASING_HEAD_VERSION,
+  REMOVE_CONCEPT,
 } from '../../../redux/actions/types';
 import {
   fetchOrganizations,
@@ -22,6 +23,7 @@ import {
   isErrored,
   isSuccess,
   clearDictionary,
+  removeConcept,
 } from '../../../redux/actions/dictionaries/dictionaryActions';
 import {
   fetchDictionaries,
@@ -58,6 +60,19 @@ describe('Test for successful organizations fetch', () => {
   });
   it('should return action type and payload after dictionary creation', () => {
     expect(addDictionary(response)).toEqual(createDictionary);
+  });
+});
+
+describe('Test for successfully removing a Concept from a dictionary', () => {
+  const response = '/url';
+
+  const removeDictionaryConcept = {
+    type: REMOVE_CONCEPT,
+    payload: response,
+  };
+
+  it('should return action type and payload after removing a concept', () => {
+    expect(removeConcept(response)).toEqual(removeDictionaryConcept);
   });
 });
 

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -486,6 +486,117 @@ export const mockConceptStore = {
   },
 };
 
+export const paginatedConcepts = {
+  concepts: [
+    {
+      type: 'Concept',
+      uuid: '8d492ee0-c2cc-11de-8d13-0010c6dffd02',
+      id: '12845003',
+      external_id: '12845003',
+
+      concept_class: 'Laboratory Procedure',
+      retired: false,
+
+      names: [
+        {
+          type: 'ConceptName',
+          uuid: 'akdiejf93jf939f9',
+          external_id: '14',
+          name: 'Malaria smear',
+          locale: 'en',
+          locale_preferred: 'true',
+          name_type: 'Designated Preferred Name',
+        },
+        {
+          type: 'ConceptName',
+          uuid: 'akdiejf93jf939f9',
+          external_id: '176',
+          name: 'Malaria smear (procedure)',
+          locale: 'en',
+          name_type: 'Full Form of Descriptor',
+        },
+      ],
+
+      source: 'SNOMED-CT',
+      owner: 'IHTSDO',
+      owner_type: 'Organization',
+
+      version: '73jifjibL83',
+
+      url: '/orgs/IHTSDO/sources/SNOMED-CT/concepts/12845003/',
+      version_url: '/orgs/IHTSDO/sources/SNOMED-CT/concepts/12845003/73jifjibL83/',
+      source_url: '/orgs/IHTSDO/sources/SNOMED-CT/',
+      owner_url: '/orgs/IHTSDO/',
+      mappings_url: '/orgs/IHTSDO/sources/SNOMED-CT/concepts/12845003/mappings/',
+
+      versions: 1,
+
+      created_on: '2008-01-14T04:33:35Z',
+      created_by: 'johndoe',
+      updated_on: '2008-01-14T04:33:35Z',
+      updated_by: 'johndoe',
+
+      extras: {
+        UMLS_CUI: 'C0200703',
+        ISPRIMITIVE: '1',
+      },
+    },
+    {
+      type: 'Concept',
+      uuid: '8d492ee0-c2cc-11de-8d13-0010c6dffd02',
+      id: '12845003',
+      external_id: '12845003',
+
+      concept_class: 'Laboratory Procedure',
+      retired: false,
+
+      names: [
+        {
+          type: 'ConceptName',
+          uuid: 'akdiejf93jf939f9',
+          external_id: '14',
+          name: 'Malaria smear',
+          locale: 'en',
+          locale_preferred: 'true',
+          name_type: 'Designated Preferred Name',
+        },
+        {
+          type: 'ConceptName',
+          uuid: 'akdiejf93jf939f9',
+          external_id: '176',
+          name: 'Malaria smear (procedure)',
+          locale: 'en',
+          name_type: 'Full Form of Descriptor',
+        },
+      ],
+
+      source: 'SNOMED-CT',
+      owner: 'IHTSDO',
+      owner_type: 'Organization',
+
+      version: '73jifjibL83',
+
+      url: '/orgs/IHTSDO/sources/SNOMED-CT/concepts/12845003/',
+      version_url: '/orgs/IHTSDO/sources/SNOMED-CT/concepts/12845003/73jifjibL83/',
+      source_url: '/orgs/IHTSDO/sources/SNOMED-CT/',
+      owner_url: '/orgs/IHTSDO/',
+      mappings_url: '/orgs/IHTSDO/sources/SNOMED-CT/concepts/12845003/mappings/',
+
+      versions: 1,
+
+      created_on: '2008-01-14T04:33:35Z',
+      created_by: 'johndoe',
+      updated_on: '2008-01-14T04:33:35Z',
+      updated_by: 'johndoe',
+
+      extras: {
+        UMLS_CUI: 'C0200703',
+        ISPRIMITIVE: '1',
+      },
+    },
+  ],
+};
+
 export const newConcept = {
   type: 'Concept',
   uuid: '8d492ee0-c2cc-11de-8d13-0010c6dffd02',

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -26,6 +26,7 @@ import {
   EDIT_CONCEPT_REMOVE_ONE_NAME,
   UPDATE_CONCEPT,
   FETCH_EXISTING_CONCEPT_ERROR,
+  REMOVE_CONCEPT,
 } from '../../../redux/actions/types';
 import {
   fetchDictionaryConcepts,
@@ -47,6 +48,7 @@ import {
   removeNameForEditConcept,
   updateConcept,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
+import { removeDictionaryConcept } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import concepts, {
   mockConceptStore,
   newConcept,
@@ -134,6 +136,53 @@ describe('Test suite for dictionary concept actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
+
+  it('should handle REMOVE_CONCEPT', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: newConcept.version_url,
+      });
+    });
+
+    const expectedActions = [
+      { type: REMOVE_CONCEPT, payload: newConcept.version_url },
+    ];
+
+    const store = mockStore(mockConceptStore);
+    const data = { references: ['/orgs/IHTSDO/sources/SNOMED-CT/concepts/12845003/73jifjibL83/'] };
+    const type = 'users';
+    const owner = 'alexmochu';
+    const collectionId = 'Tech';
+    return store.dispatch(removeDictionaryConcept(data, type, owner, collectionId)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should handle REMOVE_CONCEPT network error', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        status: 599,
+        response: newConcept.version_url,
+      });
+    });
+
+    const expectedActions = [
+      { type: REMOVE_CONCEPT, payload: newConcept.version_url },
+    ];
+
+    const store = mockStore(mockConceptStore);
+    const data = { references: ['/orgs/IHTSDO/sources/SNOMED-CT/concepts/12845003/73jifjibL83/'] };
+    const type = 'users';
+    const owner = 'alexmochu';
+    const collectionId = 'Tech';
+    return store.dispatch(removeDictionaryConcept(data, type, owner, collectionId)).catch(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
   it('should handle error in CREATE_NEW_CONCEPT', () => {
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();

--- a/src/tests/dictionaryConcepts/components/ActionButtons.test.jsx
+++ b/src/tests/dictionaryConcepts/components/ActionButtons.test.jsx
@@ -6,12 +6,22 @@ const props = {
   actionButtons: true,
   id: '1',
   concept_class: 'drug',
-  url: '/url',
+  version_url: '/url',
+  showDeleteModal: jest.fn(),
 };
 
 describe('Test suite for ActionButton', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(<ActionButtons {...props} />);
+  });
+
   it('should render ActionButton Component', () => {
-    const wrapper = shallow(<ActionButtons {...props} />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should call the showDeleteModal', () => {
+    wrapper.find('#retireConcept').simulate('click');
+    expect(props.showDeleteModal).toBeCalled();
   });
 });

--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import { createMockStore } from 'redux-test-utils';
+import { Provider } from 'react-redux';
 import expect from 'expect';
 import Router from 'react-mock-router';
 
@@ -9,6 +11,11 @@ import {
 } from '../../../components/dictionaryConcepts/containers/DictionaryConcepts';
 import concepts, { multipleConceptsMockStore } from '../../__mocks__/concepts';
 
+const store = createMockStore({
+  organizations: {
+    organizations: [],
+  },
+});
 describe('Test suite for dictionary concepts components', () => {
   it('should render component without breaking', () => {
     const props = {
@@ -34,9 +41,9 @@ describe('Test suite for dictionary concepts components', () => {
       filterByClass: jest.fn(),
       fetchMemberStatus: jest.fn(),
     };
-    const wrapper = mount(<Router>
+    const wrapper = mount(<Provider store={store}><Router>
       <DictionaryConcepts {...props} />
-    </Router>);
+    </Router></Provider>);
     expect(wrapper.find('h2.text-capitalize').text()).toEqual('dev-col Dictionary');
 
     expect(wrapper).toMatchSnapshot();
@@ -63,10 +70,47 @@ describe('Test suite for dictionary concepts components', () => {
     </Router>);
     const event = { target: { name: 'searchInput', value: 'ciel' } };
     wrapper.find('#search-concept').simulate('change', event);
-    wrapper.find('form').simulate('submit', {
+    wrapper.find('.searchConcepts').simulate('submit', {
       preventDefault: () => {},
     });
   });
+
+  it('should remove a dictionary concept', () => {
+    const props = {
+      match: {
+        params: {
+          typeName: 'dev-col',
+          collectionName: 'coreconcepts',
+          type: 'users',
+          dictionaryName: 'coreconcepts',
+        },
+      },
+      location: {
+        pathname: '/random/path',
+      },
+      fetchDictionaryConcepts: jest.fn(),
+      concepts: [concepts],
+      filteredClass: ['Diagnosis'],
+      filteredSources: ['CIEL'],
+      loading: false,
+      totalConceptCount: 11,
+      filterBySource: jest.fn(),
+      filterByClass: jest.fn(),
+      paginateConcepts: jest.fn(),
+      fetchMemberStatus: jest.fn(),
+      userIsMember: jest.fn(),
+      removeDictionaryConcept: jest.fn(),
+    };
+
+    const wrapper = mount(<Provider store={store}><Router>
+      <DictionaryConcepts {...props} />
+    </Router></Provider>);
+    expect(wrapper).toBeDefined();
+    wrapper.find('.btn.btn-sm.mb-1.actionButtons').simulate('click');
+    wrapper.find('.btn.btn-danger').simulate('click');
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('should filter search result', () => {
     const props = {
       match: {
@@ -83,9 +127,9 @@ describe('Test suite for dictionary concepts components', () => {
       filteredSources: ['CIEL'],
       loading: false,
     };
-    const wrapper = mount(<Router>
+    const wrapper = mount(<Provider store={store}><Router>
       <DictionaryConcepts {...props} />
-    </Router>);
+    </Router></Provider>);
     const event = { target: { name: 'CIEL', checked: true, value: 'ciel' } };
     wrapper.find('#CIEL').simulate('change', event);
     wrapper.find('#Diagnosis').simulate('change', event);

--- a/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
@@ -1,6 +1,6 @@
 import deepFreeze from 'deep-freeze';
 import reducer from '../../../redux/reducers/ConceptReducers';
-import concepts, { newConcept, existingConcept } from '../../__mocks__/concepts';
+import concepts, { newConcept, existingConcept, paginatedConcepts } from '../../__mocks__/concepts';
 import {
   FETCH_DICTIONARY_CONCEPT,
   FILTER_BY_SOURCES,
@@ -22,6 +22,7 @@ import {
   CLEAR_PREVIOUS_CONCEPT,
   EDIT_CONCEPT_CREATE_NEW_NAMES,
   EDIT_CONCEPT_REMOVE_ONE_NAME,
+  REMOVE_CONCEPT,
 } from '../../../redux/actions/types';
 
 let state;
@@ -32,6 +33,7 @@ beforeEach(() => {
     concepts: [],
     loading: false,
     dictionaryConcepts: [],
+    paginatedConcepts: [paginatedConcepts.concepts],
     filteredSources: [],
     filteredClass: [],
     filteredList: [],
@@ -252,6 +254,23 @@ describe('Test suite for single dictionary concepts', () => {
       totalConceptCount: action.payload,
     });
   });
+
+  it('should handle REMOVE_CONCEPT', () => {
+    action = {
+      type: REMOVE_CONCEPT,
+      payload: '/URL',
+    };
+
+    deepFreeze(state);
+    deepFreeze(action);
+
+    expect(reducer(state, action)).toEqual({
+      ...state,
+      paginatedConcepts: state.paginatedConcepts
+        .filter(concept => concept.version_url !== action.payload),
+    });
+  });
+
   it('should handle FETCH_EXISTING_CONCEPT', () => {
     action = {
       type: FETCH_EXISTING_CONCEPT,


### PR DESCRIPTION
# JIRA TICKET NAME:
[User should be able to remove existing concepts from a dictionary](https://issues.openmrs.org/browse/OCLOMRS-156)

# Summary:
Currently, the Remove Concepts link in the Dictionary concepts overview page is not working and has no functionality.
Therefore the Remove Concepts link should remove a concept from the dictionary when clicked.