### PR TITLE
OCLOMRS-191: A user should be able to Release Dictionary HEAD as new version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ yarn-debug.log*
 yarn-error.log*
 public/index.html~HEAD
 yarn.lock
+package-lock.json
 
 #test snapshots
 **/__snapshots__/**

--- a/src/App.css
+++ b/src/App.css
@@ -87,3 +87,11 @@
   text-align: center;
   color: #0d1699;
 }
+
+.fa-cloud-upload-alt{
+  border-color: white;
+}
+
+#release-head {
+  font-family: 'Roboto', sans-serif;
+}

--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import './styles/dictionary-modal.css';
 import DictionaryVersionsTable from './DictionaryVersionsTable';
 
@@ -8,11 +8,13 @@ const DictionaryDetailCard = (props) => {
   const {
     dictionary: {
       name, created_on, updated_on, public_access, owner, owner_type, active_concepts, description,
-      owner_url, short_code, default_locale, url,
+      owner_url, short_code, default_locale, url
     }, versions, showEditModal, customConcepts, cielConcepts,
-    diagnosisConcepts, procedureConcepts, otherConcepts,
+    diagnosisConcepts, procedureConcepts, otherConcepts,  headVersion, handleRelease,
   } = props;
+
   const username = localStorage.getItem('username');
+
   const DATE_OPTIONS = {
     weekday: 'long', year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric',
   };
@@ -68,7 +70,9 @@ const DictionaryDetailCard = (props) => {
           <ul>
             <li><a href={traditionalUrl} target="_blank" rel="noopener noreferrer"><i className="fas fa-external-link-alt" />Browse in traditional OCL</a></li>
             <li><i className="far fa-copy" />Copy concepts from another dictionary</li>
-            <li><i className="fas fa-cloud-upload-alt" />Release HEAD as new version</li>
+            { owner === username && !headVersion.released ?
+              <li><button type="button" onClick={handleRelease} className="fas fa-cloud-upload-alt"><span id="release-head"> Release HEAD as new version</span></button></li>
+            : null}
           </ul>
         </fieldset>
       </form>
@@ -83,7 +87,6 @@ const DictionaryDetailCard = (props) => {
           <th>Released</th>
           <th>Actions</th>
         </tr>
-
         {releasedVersions.length >= 1 ?
           releasedVersions.map(version => (
             <DictionaryVersionsTable version={version} key={version.id} />
@@ -96,13 +99,15 @@ const DictionaryDetailCard = (props) => {
 
 DictionaryDetailCard.propTypes = {
   dictionary: PropTypes.object.isRequired,
+  versions: PropTypes.array.isRequired,
+  handleRelease: PropTypes.func.isRequired,
   showEditModal: PropTypes.object.isRequired,
   customConcepts: PropTypes.string.isRequired,
   cielConcepts: PropTypes.string.isRequired,
   diagnosisConcepts: PropTypes.string.isRequired,
   procedureConcepts: PropTypes.string.isRequired,
   otherConcepts: PropTypes.string.isRequired,
-  versions: PropTypes.array.isRequired,
+  headVersion: PropTypes.number.isRequired,
 };
 
 export default DictionaryDetailCard;

--- a/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
@@ -4,7 +4,7 @@ import './styles/dictionary-modal.css';
 const DictionaryVersionsTable = (version) => {
   const {
     version: {
-      version_external_id,
+      id,
       updated_on,
       version_url,
     },
@@ -15,7 +15,7 @@ const DictionaryVersionsTable = (version) => {
 
   return (
     <tr id="versiontable">
-      <td>{version_external_id}</td>
+      <td>{id}</td>
       <td>{ (new Date(updated_on)).toLocaleDateString('en-US', DATE_OPTIONS)}</td>
       <td>Yes</td>
       <td><a href={version_url} >Browse in OCL</a> <a href="a">Subscription URL</a></td>

--- a/src/components/dashboard/components/dictionary/styles/dictionary-modal.css
+++ b/src/components/dashboard/components/dictionary/styles/dictionary-modal.css
@@ -100,7 +100,7 @@
     text-align: left;
 }
 .menu li:hover {
-    background-color: #506096;
+    background-color: rgb(155, 165, 197);
 }
 h3 {
     font-weight: 900;

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -8,6 +8,7 @@ import {
   isErrored,
   fetchingVersions,
   dictionaryConceptsIsSuccess,
+  realisingHeadSuccess,
   editDictionarySuccess,
 } from './dictionaryActions';
 import { filterPayload } from '../../reducers/util';
@@ -109,6 +110,25 @@ export const fetchDictionaryConcepts = data => (dispatch) => {
       .catch((error) => {
         dispatch(isErrored(error.response.data));
         dispatch(isFetching(false));
+      });
+};
+
+export const releaseHead = (url, data) => (dispatch) => {
+  return api.dictionaries
+    .realisingHeadVersion(url, data)
+    .then(
+      (payload) => {
+        dispatch(realisingHeadSuccess(payload));
+        dispatch(isFetching(false));
+        notify.show(
+          'Head Version Successfully Released',
+          'success', 6000,
+        );
+      }
+    )
+    .catch(() => {
+      dispatch(isFetching(false));
+      notify.show("Network Error. Please try again later!", 'error', 6000);
       });
 };
   export const editDictionary = (url, data) => dispatch => {

--- a/src/redux/actions/dictionaries/dictionaryActions.js
+++ b/src/redux/actions/dictionaries/dictionaryActions.js
@@ -10,6 +10,7 @@ import {
   FETCHING_VERSIONS,
   FETCH_DICTIONARY_CONCEPT,
   EDIT_DICTIONARY_SUCCESS,
+  RELEASING_HEAD_VERSION,
 } from './../types';
 
 export const addDictionary = response => ({
@@ -64,6 +65,11 @@ export const clearDictionary = () => ({
 
 export const fetchingVersions = payload => ({
   type: FETCHING_VERSIONS,
+  payload,
+});
+
+export const realisingHeadSuccess = payload => ({
+  type: RELEASING_HEAD_VERSION,
   payload,
 });
 

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -20,6 +20,7 @@ export const CLEAR_DICTIONARIES = '[dictionaries] clear dictionaries';
 export const FETCHING_DICTIONARY = '[dictionary] fetch dictionary';
 export const CLEAR_DICTIONARY = '[dictionary] clear dictionary';
 export const FETCHING_VERSIONS = '[dictionary] fetch versions of a dictionary';
+export const RELEASING_HEAD_VERSION = '[dictionary] releasing HEAD version of a dictionary';
 export const EDIT_DICTIONARY_SUCCESS = '[dictionary] edit dictionary success';
 
 export const FILTER_BY_SOURCES = '[concepts] filter concepts by sources';

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -48,6 +48,11 @@ export default {
       instance
         .get(`${data}`)
         .then(response => response.data),
+    
+    realisingHeadVersion: (url, data) =>
+      instance
+        .put(url, data)
+        .then(response => response.data),
   },
   organizations: {
     fetchOrganizations: () =>

--- a/src/redux/reducers/dictionaryReducers.js
+++ b/src/redux/reducers/dictionaryReducers.js
@@ -5,10 +5,11 @@ import {
   CLEAR_DICTIONARY,
   FETCHING_VERSIONS,
   EDIT_DICTIONARY_SUCCESS,
+  RELEASING_HEAD_VERSION,
 } from '../actions/types';
 
 const initalState = {
-  versions: [], dictionaries: [], loading: false, dictionary: {},
+  versions: [], dictionaries: [], loading: false, dictionary: {}, isReleased: false,
 };
 
 export default (state = initalState, action) => {
@@ -32,6 +33,11 @@ export default (state = initalState, action) => {
       return {
         ...state,
         dictionary: action.payload,
+      };
+    case RELEASING_HEAD_VERSION:
+      return {
+        ...state,
+        isReleased: action.payload.released,
       };
     case CLEAR_DICTIONARY:
       return {

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -13,6 +13,7 @@ import {
   FETCHING_VERSIONS,
   FETCH_DICTIONARY_CONCEPT,
   FETCHING_ORGANIZATIONS,
+  RELEASING_HEAD_VERSION,
 } from '../../../redux/actions/types';
 import {
   fetchOrganizations,
@@ -28,10 +29,11 @@ import {
   fetchDictionary,
   fetchVersions,
   fetchDictionaryConcepts,
+  releaseHead,
   editDictionary,
 } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import dictionaries from '../../__mocks__/dictionaries';
-import versions from '../../__mocks__/versions';
+import versions, { HeadVersion } from '../../__mocks__/versions';
 import concepts from '../../__mocks__/concepts';
 
 jest.mock('react-notify-toast');
@@ -268,6 +270,46 @@ describe('Test for successful dictionaries fetch, failure and refresh', () => {
     ];
     const store = mockStore({ payload: {} });
     return store.dispatch(fetchVersions('/users/chriskala/collections/over/versions/')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should handle release version', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [HeadVersion],
+      });
+    });
+    const expectedActions = [
+      {
+        type: RELEASING_HEAD_VERSION, payload: [HeadVersion],
+      },
+      {
+        payload: false, type: '[ui] toggle spinner',
+      },
+    ];
+    const store = mockStore({ payload: {} });
+    return store.dispatch(releaseHead('/users/nesh/collections/test/HEAD/')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should handle release version network error', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        status: 599,
+      });
+    });
+    const expectedActions = [
+      {
+        payload: false, type: '[ui] toggle spinner',
+      },
+    ];
+    const store = mockStore({ payload: {} });
+    return store.dispatch(releaseHead('/users/nesh/collections/test/HEAD/')).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/src/tests/Dashboard/reducer/dictionaryReducers.test.js
+++ b/src/tests/Dashboard/reducer/dictionaryReducers.test.js
@@ -9,6 +9,7 @@ import {
   FETCHING_VERSIONS,
   CLEAR_DICTIONARY,
   EDIT_DICTIONARY_SUCCESS,
+  RELEASING_HEAD_VERSION,
 } from '../../../redux/actions/types';
 import dictionaries from '../../__mocks__/dictionaries';
 import versions from '../../__mocks__/versions';
@@ -18,6 +19,7 @@ describe('Test suite for vote reducer', () => {
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual(initialState);
   });
+
   it('should handle FETCHING_ORGANIZATIONS', () => {
     expect(reducer(
       {},
@@ -36,6 +38,7 @@ const state = {
   versions: [],
   dictionary: {},
   loading: false,
+  isReleased: false,
 };
 const dictionary = dictionaries;
 
@@ -43,6 +46,7 @@ describe('Test suite for dictionaries reducers', () => {
   it('should return initial state', () => {
     expect(dictionaryreducer(undefined, {})).toEqual(state);
   });
+
   it('should handle FETCH_DICTIONARIES', () => {
     expect(dictionaryreducer(
       { dictionaries: [] },
@@ -72,6 +76,26 @@ describe('Test suite for dictionaries reducers', () => {
       },
     )).toEqual({ dictionary: [dictionaries] });
   });
+
+  it('should handle FETCHING_VERSIONS', () => {
+    expect(dictionaryreducer(
+      { versions: [] },
+      {
+        type: FETCHING_VERSIONS,
+        payload: [versions],
+      },
+    )).toEqual({ versions: [versions] });
+  });
+
+  it('should handle RELEASING_HEAD_VERSION', () => {
+    expect(dictionaryreducer(
+      { isReleased: false },
+      {
+        type: RELEASING_HEAD_VERSION,
+        payload: { released: true },
+      },
+    )).toEqual({ isReleased: true });
+  });
   it('should clear a dictionary', () => {
     expect(dictionaryreducer(
       { dictionary },
@@ -99,15 +123,7 @@ it('should handle FETCHING_VERSIONS', () => {
     },
   )).toEqual({ versions: [versions] });
 });
-it('should handle FETCHING_VERSIONS', () => {
-  expect(dictionaryreducer(
-    { versions: [] },
-    {
-      type: FETCHING_VERSIONS,
-      payload: [versions],
-    },
-  )).toEqual({ versions: [versions] });
-});
+
 describe('Test suite for dictionaries reducers', () => {
   it('should return inital state ADD_DICTIONARY', () => {
     expect(userReducer(

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { mount, shallow } from 'enzyme';
 import { DictionaryOverview } from '../../components/dashboard/components/dictionary/DictionaryContainer';
 import dictionary from '../__mocks__/dictionaries';
-import versions from '../__mocks__/versions';
+import versions, { customVersion, HeadVersion } from '../__mocks__/versions';
 
 const store = createMockStore({
   organizations: {
@@ -45,6 +45,71 @@ describe('DictionaryOverview', () => {
     expect(wrapper.find('#headingDict')).toHaveLength(1);
     expect(wrapper.find('.paragraph')).toHaveLength(5);
     expect(wrapper.find('tr')).toHaveLength(2);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should handle HEAD version release', () => {
+    const props = {
+      dictionary: [dictionary],
+      versions: [customVersion],
+      dictionaryConcepts: [dictionary],
+      isReleased: false,
+      match: {
+        params: {
+          ownerType: 'testing',
+          owner: 'tester',
+          type: 'collection',
+          name: 'chris',
+        },
+      },
+      fetchDictionary: jest.fn(),
+      fetchVersions: jest.fn(),
+      fetchDictionaryConcepts: jest.fn(),
+      releaseHead: jest.fn(),
+    };
+
+    const wrapper = mount(<Provider store={store}><MemoryRouter><DictionaryOverview {...props} /></MemoryRouter></Provider>);
+    const spy = jest.spyOn(wrapper.find('DictionaryOverview').instance(), 'handleRelease');
+    wrapper.instance().forceUpdate();
+    wrapper.find('.fas.fa-cloud-upload-alt').simulate('click');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle componentWillUpdate in HEAD version release', () => {
+    const props = {
+      dictionary: [dictionary],
+      versions: [customVersion],
+      dictionaryConcepts: [dictionary],
+      isReleased: false,
+      match: {
+        params: {
+          ownerType: 'testing',
+          owner: 'tester',
+          type: 'collection',
+          name: 'chris',
+        },
+      },
+      fetchDictionary: jest.fn(),
+      fetchVersions: jest.fn(),
+      fetchDictionaryConcepts: jest.fn(),
+      releaseHead: jest.fn(),
+    };
+    const wrapper = mount(<Provider store={store}><MemoryRouter><DictionaryOverview {...props} /></MemoryRouter></Provider>);
+    const newProps = {
+      dictionary: [dictionary],
+      versions: [HeadVersion],
+      match: {
+        params: {
+          ownerType: 'testing',
+          owner: 'tester',
+          type: 'collection',
+          name: 'chris',
+        },
+      },
+      isReleased: true,
+      fetchVersions: jest.fn(),
+    };
+    wrapper.setProps(newProps);
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/tests/__mocks__/versions.js
+++ b/src/tests/__mocks__/versions.js
@@ -9,3 +9,26 @@ export default {
   version_url: '/users/chriskala/collections/over/HEAD/',
   url: '/users/chriskala/collections/over/',
 };
+export const customVersion = {
+  id: 'HEAD',
+  released: false,
+  retired: false,
+  description: 'test',
+  version_external_id: '1',
+  previous_version: null,
+  parent_version: null,
+  extras: null,
+  external_id: null,
+};
+
+export const HeadVersion = {
+  id: 'HEAD',
+  released: true,
+  retired: false,
+  description: 'test',
+  version_external_id: '1',
+  previous_version: null,
+  parent_version: null,
+  extras: null,
+  external_id: null,
+};


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-191: A user should be able to Release Dictionary HEAD as a new version
](https://issues.openmrs.org/browse/OCLOMRS-191)

# Summary:
Currently, a user is not able to release the HEAD (first) version of a dictionary. This issue should ensure that the owner of a dictionary can release its HEAD version.
