### PR TITLE
OCLOMRS-173: Changes to create concept form options for Q-and-A concept

### DIFF
--- a/src/components/dictionaryConcepts/components/AnswersRow.jsx
+++ b/src/components/dictionaryConcepts/components/AnswersRow.jsx
@@ -1,0 +1,92 @@
+import React, { Component } from 'react';
+import autoBind from 'react-autobind';
+import PropTypes from 'prop-types';
+
+class AnswersRow extends Component {
+  static propTypes = {
+    newRow: PropTypes.object.isRequired,
+    addDataFromAnswer: PropTypes.func.isRequired,
+    removeAnswer: PropTypes.func.isRequired,
+    removeDataFromRow: PropTypes.func.isRequired,
+    existingConcept: PropTypes.object.isRequired,
+  }
+  constructor(props) {
+    super(props);
+    this.state = {
+      id: this.props.newRow.uuid,
+      answer: [],
+    };
+    autoBind(this);
+  }
+
+  componentDidMount() {
+    if (this.props.existingConcept) {
+      this.updateState();
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState !== this.state) {
+      this.sendToTopComponent();
+    }
+  }
+
+  updateState() {
+    const { newRow } = this.props;
+    this.setState({
+      ...this.state,
+      id: newRow.uuid,
+      answer: newRow.answer || '',
+    });
+  }
+
+  handleChange(event) {
+    const {
+      target: { value, name },
+    } = event;
+    this.setState(() => ({ [name]: value }));
+    this.sendToTopComponent();
+  }
+
+  sendToTopComponent() {
+    this.props.addDataFromAnswer(this.state);
+  }
+
+  handleRemove(event, id) {
+    event.preventDefault();
+    const { removeAnswer, removeDataFromRow } = this.props;
+    removeAnswer(id);
+    removeDataFromRow(id, 'answers');
+  }
+
+  render() {
+    return (
+      <tr>
+        <td>
+          <input
+            type="text"
+            className="form-control answer"
+            placeholder="eg. /orgs/Regenstrief/sources/loinc2/concepts/32700-7/"
+            name="answer"
+            value={this.state.answer}
+            onChange={this.handleChange}
+            id="concept-answer"
+            required
+          />
+        </td>
+        <td>
+          <a
+            href="#!"
+            className="concept-form-table-link answer"
+            id="remove-answer"
+            onClick={event => this.handleRemove(event, this.props.newRow.uuid)}
+          >
+            remove
+          </a>
+        </td>
+      </tr>
+    );
+  }
+}
+
+export default AnswersRow;

--- a/src/components/dictionaryConcepts/components/AnswersTable.jsx
+++ b/src/components/dictionaryConcepts/components/AnswersTable.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import AnswersRow from './AnswersRow';
+
+const AnswersTable = props => (
+  <table className="table table-striped table-bordered concept-form-table">
+    <thead className="header text-white">
+      <tr>
+        <th scope="col">To Concept URL</th>
+        <th scope="col">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {props.answer.map(newRow => (
+        <AnswersRow
+          newRow={{ uuid: newRow }}
+          key={newRow}
+          {...props}
+        />))}
+    </tbody>
+  </table>
+);
+
+AnswersTable.propTypes = {
+  answer: PropTypes.array.isRequired,
+};
+
+export default AnswersTable;

--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -1,21 +1,12 @@
 import React, { Component } from 'react';
 import autoBind from 'react-autobind';
 import Select from 'react-select';
-import 'react-select/dist/react-select';
 import PropTypes from 'prop-types';
 import locale from '../../dashboard/components/dictionary/common/Languages';
 
 class ConceptNameRows extends Component {
   static propTypes = {
-    newRow: PropTypes.shape({
-      id: PropTypes.string,
-      uuid: PropTypes.string.isRequired,
-      name: PropTypes.string,
-      locale: PropTypes.string,
-      locale_full: PropTypes.string,
-      locale_preferred: PropTypes.bool,
-      name_type: PropTypes.string,
-    }),
+    newRow: PropTypes.object.isRequired,
     addDataFromRow: PropTypes.func.isRequired,
     removeRow: PropTypes.func.isRequired,
     removeDataFromRow: PropTypes.func.isRequired,
@@ -24,6 +15,7 @@ class ConceptNameRows extends Component {
   };
 
   static defaultProps = {
+    // eslint-disable-next-line react/default-props-match-prop-types
     newRow: {
       id: '',
       name: '',

--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import CreateConceptTable from './CreateConceptTable';
 import DescriptionTable from './DescriptionTable';
+import AnswersTable from './AnswersTable';
 import { classes } from './helperFunction';
 
 const CreateConceptForm = props => (
@@ -121,6 +122,19 @@ const CreateConceptForm = props => (
           <option>Coded</option>
         </select>
       </div>
+
+      {props.concept.toString().trim() === 'question' ?
+        <div className="form-group answer">
+          <div className="row col-12 custom-concept-list">
+            <h6 className="text-left section-header">Answers</h6>
+            <AnswersTable {...props} />
+            <a href="#!" className="text-left add-more-answers" id="add-more-answers" onClick={props.addAnswer}>
+            Add a new answer mapping
+            </a>
+          </div>
+        </div>
+      : null}
+
       <div className="form-group">
         <div className="row col-12 custom-concept-list">
           <h6 className="text-left section-header">Names</h6>
@@ -169,6 +183,8 @@ CreateConceptForm.propTypes = {
   editable: PropTypes.bool.isRequired,
   isEditConcept: PropTypes.bool,
   existingConcept: PropTypes.object,
+  addAnswer: PropTypes.func.isRequired,
+  answer: PropTypes.array.isRequired,
 };
 
 CreateConceptForm.defaultProps = {

--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import Select from 'react-select';
-import 'react-select/dist/react-select';
 import autoBind from 'react-autobind';
 import PropTypes from 'prop-types';
 import uuid from 'uuid/v4';

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -12,6 +12,8 @@ import {
   removeDescription,
   clearSelections,
   createNewConcept,
+  addNewAnswer,
+  removeAnswer,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 
 export class CreateConcept extends Component {
@@ -43,6 +45,9 @@ export class CreateConcept extends Component {
       descriptions: PropTypes.array,
     }).isRequired,
     addedConcept: PropTypes.array.isRequired,
+    addNewAnswer: PropTypes.func.isRequired,
+    removeAnswer: PropTypes.func.isRequired,
+    answer: PropTypes.array.isRequired,
   };
   constructor(props) {
     super(props);
@@ -53,6 +58,7 @@ export class CreateConcept extends Component {
       datatype: 'None',
       names: [],
       descriptions: [],
+      answers: [],
     };
 
     autoBind(this);
@@ -67,6 +73,7 @@ export class CreateConcept extends Component {
     const concept = conceptType || '';
     this.props.createNewName();
     this.props.addNewDescription();
+    this.props.addNewAnswer();
     // eslint-disable-next-line
     this.setState({ concept_class: concept });
   }
@@ -112,6 +119,13 @@ export class CreateConcept extends Component {
   removeDescription(event, id) {
     event.preventDefault();
     this.props.removeDescription(id);
+  }
+
+  addNewAnswer() {
+    this.props.addNewAnswer();
+  }
+  removeAnswer(id) {
+    this.props.removeAnswer(id);
   }
 
   handleUUID(event) {
@@ -190,6 +204,22 @@ export class CreateConcept extends Component {
     }
   }
 
+  addDataFromAnswer(data) {
+    const currentAnswer = this.state.answers.filter(answer => answer.id === data.id);
+    if (currentAnswer.length) {
+      const newList = this.state.answers.map(answer => (
+        answer.id === data.id ? data : answer
+      ));
+      this.setState(() => ({
+        answers: newList,
+      }));
+    } else {
+      this.setState(prevState => ({
+        answers: [...prevState.answers, data],
+      }));
+    }
+  }
+
   render() {
     const {
       match: {
@@ -232,6 +262,10 @@ export class CreateConcept extends Component {
                 addDataFromDescription={this.addDataFromDescription}
                 removeDataFromRow={this.removeDataFromRow}
                 pathName={this.props.match.params}
+                addAnswer={this.addNewAnswer}
+                answer={this.props.answer}
+                addDataFromAnswer={this.addDataFromAnswer}
+                removeAnswer={this.removeAnswer}
               />
             </div>
           </div>
@@ -246,6 +280,7 @@ export const mapStateToProps = state => ({
   description: state.concepts.description,
   newConcept: state.concepts.newConcept,
   addedConcept: state.concepts.addConceptToDictionary,
+  answer: state.concepts.answer,
 });
 export default connect(
   mapStateToProps,
@@ -256,5 +291,7 @@ export default connect(
     removeDescription,
     clearSelections,
     createNewConcept,
+    addNewAnswer,
+    removeAnswer,
   },
 )(CreateConcept);

--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -17,6 +17,8 @@ import {
   clearPreviousConcept,
   createNewNameForEditConcept,
   removeNameForEditConcept,
+  addNewAnswer,
+  removeAnswer,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 
 export class EditConcept extends Component {
@@ -45,6 +47,9 @@ export class EditConcept extends Component {
     removeNameForEditConcept: PropTypes.func.isRequired,
     existingConcept: PropTypes.object.isRequired,
     updateConcept: PropTypes.func.isRequired,
+    answer: PropTypes.array.isRequired,
+    addNewAnswer: PropTypes.func.isRequired,
+    removeAnswer: PropTypes.func.isRequired,
   };
   constructor(props) {
     super(props);
@@ -55,6 +60,7 @@ export class EditConcept extends Component {
       datatype: 'None',
       names: [],
       descriptions: [],
+      answers: [],
       isEditConcept: true,
     };
     this.conceptUrl = '';
@@ -114,6 +120,13 @@ export class EditConcept extends Component {
   removeDescription(event, descriptionRow) {
     event.preventDefault();
     this.props.removeDescriptionForEditConcept(descriptionRow.uuid);
+  }
+
+  addNewAnswer() {
+    this.props.addNewAnswer();
+  }
+  removeAnswer(id) {
+    this.props.removeAnswer(id);
   }
 
   handleUUID(event) {
@@ -184,6 +197,22 @@ export class EditConcept extends Component {
     }
   }
 
+  addDataFromAnswer(data) {
+    const currentAnswer = this.state.answers.filter(answer => answer.id === data.id);
+    if (currentAnswer.length) {
+      const newList = this.state.answers.map(answer => (
+        answer.id === data.id ? data : answer
+      ));
+      this.setState(() => ({
+        answers: newList,
+      }));
+    } else {
+      this.setState(prevState => ({
+        answers: [...prevState.answers, data],
+      }));
+    }
+  }
+
   render() {
     const {
       match: {
@@ -230,6 +259,10 @@ export class EditConcept extends Component {
                 pathName={this.props.match.params}
                 existingConcept={existingConcept}
                 isEditConcept={this.state.isEditConcept}
+                answer={this.props.answer}
+                addDataFromAnswer={this.addDataFromAnswer}
+                addAnswer={this.addNewAnswer}
+                removeAnswer={this.removeAnswer}
               />
               }
             </div>
@@ -246,6 +279,7 @@ export const mapStateToProps = state => ({
   newConcept: state.concepts.newConcept,
   addedConcept: state.concepts.addConceptToDictionary,
   existingConcept: state.concepts.existingConcept,
+  answer: state.concepts.answer,
 });
 export default connect(
   mapStateToProps,
@@ -262,5 +296,7 @@ export default connect(
     clearPreviousConcept,
     createNewNameForEditConcept,
     removeNameForEditConcept,
+    addNewAnswer,
+    removeAnswer,
   },
 )(EditConcept);

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -23,6 +23,8 @@ import {
   CLEAR_PREVIOUS_CONCEPT,
   EDIT_CONCEPT_CREATE_NEW_NAMES,
   EDIT_CONCEPT_REMOVE_ONE_NAME,
+  REMOVE_ONE_ANSWER_MAPPING,
+  ADD_NEW_ANSWER_MAPPING,
 } from '../types';
 import {
   isFetching,
@@ -93,6 +95,16 @@ export const addDescriptionForEditConcept = () => (dispatch) => {
 export const removeDescriptionForEditConcept = id => (dispatch) => {
   const payload = id;
   dispatch({ type: EDIT_CONCEPT_REMOVE_ONE_DESCRIPTION, payload });
+};
+
+export const addNewAnswer = () => (dispatch) => {
+  const payload = uuid();
+  dispatch({ type: ADD_NEW_ANSWER_MAPPING, payload });
+};
+
+export const removeAnswer = id => (dispatch) => {
+  const payload = id;
+  dispatch({ type: REMOVE_ONE_ANSWER_MAPPING, payload });
 };
 
 export const clearSelections = () => (dispatch) => {

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -36,6 +36,8 @@ export const FETCH_NEXT_CONCEPTS = '[concepts] fetch_next_concepts';
 export const TOTAL_CONCEPT_COUNT = '[concepts] total_concept_count';
 export const USER_IS_MEMBER = '[user] user_is_member';
 export const USER_IS_NOT_MEMBER = '[user] user_is_not__member';
+export const ADD_NEW_ANSWER_MAPPING = '[concepts] add_new_answer_mapping';
+export const REMOVE_ONE_ANSWER_MAPPING = '[concepts] remove_one_answer_mapping';
 
 export const ADD_EXISTING_CONCEPTS = '[concepts] add_existing_concepts';
 export const SEARCH_RESULTS = '[searchResults] search';

--- a/src/redux/reducers/ConceptReducers.js
+++ b/src/redux/reducers/ConceptReducers.js
@@ -24,6 +24,8 @@ import {
   EDIT_CONCEPT_CREATE_NEW_NAMES,
   EDIT_CONCEPT_REMOVE_ONE_NAME,
   REMOVE_CONCEPT,
+  ADD_NEW_ANSWER_MAPPING,
+  REMOVE_ONE_ANSWER_MAPPING,
 } from '../actions/types';
 import {
   filterSources, filterClass, filterList, normalizeList, filterNames,
@@ -44,6 +46,7 @@ const initialState = {
   hasMore: false,
   newName: [],
   description: [],
+  answer: [],
   newConcept: {},
   addConceptToDictionary: [],
   paginatedConcepts: [],
@@ -139,6 +142,16 @@ export default (state = initialState, action) => {
       return {
         ...state,
         description: filterNames(action.payload, state.description),
+      };
+    case ADD_NEW_ANSWER_MAPPING:
+      return {
+        ...state,
+        answer: [...state.answer, action.payload],
+      };
+    case REMOVE_ONE_ANSWER_MAPPING:
+      return {
+        ...state,
+        answer: filterNames(action.payload, state.answer),
       };
     case CLEAR_FORM_SELECTIONS:
       return {

--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -329,3 +329,10 @@ select.form-control {
   background-color: Transparent;
   cursor:pointer;
 }
+
+.add-more-answers{
+  color: #4f6196;
+  text-decoration: none !important;
+  cursor: pointer !important;
+  font-size: .8rem;
+}

--- a/src/tests/Dashboard/reducer/conceptReducer.test.js
+++ b/src/tests/Dashboard/reducer/conceptReducer.test.js
@@ -18,6 +18,7 @@ const initialState = {
   description: [],
   newConcept: {},
   addConceptToDictionary: [],
+  answer: [],
   paginatedConcepts: [],
   totalConceptCount: 0,
   existingConcept: {

--- a/src/tests/__mocks__/answers.js
+++ b/src/tests/__mocks__/answers.js
@@ -1,0 +1,7 @@
+export default [{
+  from_concept_url: '/orgs/Columbia/sources/CIEL/concepts/161426/',
+}, {
+
+  from_concept_url: '/orgs/Columbia/sources/CIEL/concepts/161426566/',
+
+}];

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -27,6 +27,8 @@ import {
   UPDATE_CONCEPT,
   FETCH_EXISTING_CONCEPT_ERROR,
   REMOVE_CONCEPT,
+  REMOVE_ONE_ANSWER_MAPPING,
+  ADD_NEW_ANSWER_MAPPING,
 } from '../../../redux/actions/types';
 import {
   fetchDictionaryConcepts,
@@ -47,6 +49,8 @@ import {
   createNewNameForEditConcept,
   removeNameForEditConcept,
   updateConcept,
+  addNewAnswer,
+  removeAnswer,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import { removeDictionaryConcept } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import concepts, {
@@ -484,6 +488,19 @@ describe('test suite for synchronous action creators', () => {
     const store = mockStore(mockConceptStore);
     const expectedActions = [{ type: CLEAR_FORM_SELECTIONS, payload: [] }];
     store.dispatch(clearSelections());
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+  it('should handle ADD_NEW_ANSWER_MAPPING', () => {
+    const store = mockStore(mockConceptStore);
+    const expectedActions = [{ type: ADD_NEW_ANSWER_MAPPING, payload: 1 }];
+    store.dispatch(addNewAnswer());
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+  it('should handle REMOVE_ONE_ANSWER_MAPPING', () => {
+    const store = mockStore(mockConceptStore);
+    const expectedActions = [{ type: REMOVE_ONE_ANSWER_MAPPING, payload: '123y' }];
+    const id = '123y';
+    store.dispatch(removeAnswer(id));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/src/tests/dictionaryConcepts/components/AnswersRow.test.jsx
+++ b/src/tests/dictionaryConcepts/components/AnswersRow.test.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import AnswersRow from '../../../components/dictionaryConcepts/components/AnswersRow';
+import answers from '../../__mocks__/answers';
+import { existingConcept } from '../../__mocks__/concepts';
+
+const props = {
+  pathName: {
+    language: 'en',
+  },
+  answer: answers,
+  addNewAnswer: jest.fn(),
+  removeAnswer: jest.fn(),
+  removeDataFromRow: jest.fn(),
+  addDataFromAnswer: jest.fn(),
+  existingConcept: {
+    existingConcept,
+  },
+  newConcept: [],
+  names: [],
+  newRow: {
+    uuid: 4566,
+  },
+
+};
+
+describe('Test suite for AnswersRows ', () => {
+  it('should render AnswersRows  Component', () => {
+    const wrapper = shallow(<AnswersRow {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should handle remove', () => {
+    const fakeEvent = { preventDefault: () => {} };
+    const wrapper = shallow(<AnswersRow {...props} />);
+    const spy = jest.spyOn(wrapper.instance(), 'handleRemove');
+    wrapper.find('.concept-form-table-link.answer').simulate('click', fakeEvent);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should handle change on the text input', () => {
+    const wrapper = shallow(<AnswersRow {...props} />);
+    const spy = jest.spyOn(wrapper.instance(), 'handleChange');
+    wrapper.setState({
+      names: [],
+      description: [],
+      answer: [],
+    });
+    const event = {
+      target: {
+        value: '/users/nesh/sources/test/concepts/2140db25-4d4a-4804-90cc-6fd8328dfe9e/',
+      },
+    };
+    wrapper.find('input.form-control.answer').at(0).simulate('change', event);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should handle componentDidUpdate', () => {
+    const newState = {
+      answer: '/test/test/',
+    };
+    const wrapper = shallow(<AnswersRow {...props} />);
+    const spy = jest.spyOn(wrapper.instance(), 'sendToTopComponent');
+    wrapper.setProps(props);
+    wrapper.setState(newState);
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/tests/dictionaryConcepts/components/AnswersTable.test.jsx
+++ b/src/tests/dictionaryConcepts/components/AnswersTable.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import AnswersTable from
+  '../../../components/dictionaryConcepts/components/AnswersTable';
+import answers from '../../__mocks__/answers';
+
+const props = {
+  answer: answers,
+  addDataFromAnswer: jest.fn(),
+  removeAnswer: jest.fn(),
+  removeDataFromRow: jest.fn(),
+  existingConcept: {},
+};
+
+describe('Test suite for AnswersTable', () => {
+  it('should render DescriptionTable Component', () => {
+    const wrapper = shallow(<AnswersTable {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/tests/dictionaryConcepts/components/CreateConceptForm.test.jsx
+++ b/src/tests/dictionaryConcepts/components/CreateConceptForm.test.jsx
@@ -10,7 +10,6 @@ describe('Test suite for CreateConceptForm', () => {
       },
       addDescription: jest.fn(),
       handleNewName: jest.fn(),
-      concept: 'dummy',
       path: '',
       toggleUUID: jest.fn(),
       handleChange: jest.fn(),
@@ -18,12 +17,15 @@ describe('Test suite for CreateConceptForm', () => {
       editable: false,
       nameRows: [],
       description: [],
+      addAnswer: jest.fn(),
+      answer: [],
       match: {
         params: {
           conceptType: '',
           dictionaryName: '',
         },
       },
+      concept: 'Diagnosis',
     };
     const wrapper = shallow(<CreateConceptForm {...props} />);
     expect(wrapper).toMatchSnapshot();
@@ -44,6 +46,8 @@ describe('Test suite for CreateConceptForm', () => {
       editable: false,
       nameRows: [],
       description: [],
+      addAnswer: jest.fn(),
+      answer: [],
     };
     const wrapper = shallow(<CreateConceptForm {...props} />);
     expect(wrapper.find('select.set')).toHaveLength(1);
@@ -65,9 +69,34 @@ describe('Test suite for CreateConceptForm', () => {
       editable: false,
       nameRows: [],
       description: [],
+      addAnswer: jest.fn(),
+      answer: [],
     };
     const wrapper = shallow(<CreateConceptForm {...props} />);
     expect(wrapper.find('select.symptom-finding')).toHaveLength(1);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render form for question concept class', () => {
+    const props = {
+      state: {
+        id: '1',
+      },
+      concept: 'question',
+      addDescription: jest.fn(),
+      handleNewName: jest.fn(),
+      path: '',
+      toggleUUID: jest.fn(),
+      handleChange: jest.fn(),
+      handleSubmit: jest.fn(),
+      editable: false,
+      addAnswer: jest.fn(),
+      answer: [],
+      nameRows: [],
+      description: [],
+    };
+    const wrapper = shallow(<CreateConceptForm {...props} />);
+    expect(wrapper.find('.form-group.answer')).toHaveLength(1);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -14,7 +14,7 @@ describe('Test suite for dictionary concepts components', () => {
   const props = {
     match: {
       params: {
-        conceptType: 'diagnosis',
+        conceptType: 'question',
         collectionName: 'dev-col',
         type: 'users',
         typeName: 'emasys',
@@ -24,17 +24,22 @@ describe('Test suite for dictionary concepts components', () => {
     history: {
       push: jest.fn(),
     },
+    existingConcept: [],
     createNewName: jest.fn(),
+    answer: [12343],
     addNewDescription: jest.fn(),
     clearSelections: jest.fn(),
     removeNewName: jest.fn(),
     removeDescription: jest.fn(),
     createNewConcept: jest.fn(),
+    addNewAnswer: jest.fn(),
+    removeAnswer: jest.fn(),
+    addDataFromAnswer: jest.fn(),
     newName: ['1'],
     description: ['1'],
     newConcept: {
       id: '1',
-      concept_class: 'diagnosis',
+      concept_class: 'question',
       datatype: 'Text',
       names: [],
       descriptions: [],
@@ -49,7 +54,7 @@ describe('Test suite for dictionary concepts components', () => {
     const wrapper = mount(<Router>
       <CreateConcept {...props} />
     </Router>);
-    expect(wrapper.find('h3').text()).toEqual(': Create a diagnosis Concept ');
+    expect(wrapper.find('h3').text()).toEqual(': Create a question Concept ');
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -97,6 +102,7 @@ describe('Test suite for dictionary concepts components', () => {
     wrapper.find('#remove-description').simulate('click');
     wrapper.find('#remove-name').simulate('click');
     wrapper.find('#concept-description').simulate('change', conceptDescription);
+    wrapper.find('.text-left.add-more-answers').simulate('click');
     wrapper.find('#createConceptForm').simulate('submit', {
       preventDefault: () => {},
     });
@@ -114,6 +120,34 @@ describe('Test suite for dictionary concepts components', () => {
     wrapper.setProps(newProps);
     wrapper.unmount();
     jest.runAllTimers();
+  });
+
+
+  it('should handle add-more-answers', () => {
+    const wrapper = mount(<Router>
+      <CreateConcept {...props} />
+    </Router>);
+    wrapper.find('.add-more-answers').simulate('click');
+    expect(props.addNewAnswer).toHaveBeenCalled();
+  });
+
+  it('should handle remove-answers', () => {
+    const wrapper = mount(<Router>
+      <CreateConcept {...props} />
+    </Router>);
+    wrapper.find('.concept-form-table-link.answer').simulate('click');
+    expect(props.removeAnswer).toHaveBeenCalled();
+  });
+
+  it('should handle add data from answer', () => {
+    const wrapper = mount(<Router>
+      <CreateConcept {...props} />
+    </Router>);
+
+    const spy = jest.spyOn(wrapper.find('CreateConcept').instance(), 'addDataFromAnswer');
+    const conceptAnswer = { target: { name: 'answer', value: 'test concept' } };
+    wrapper.find('#concept-answer').simulate('change', conceptAnswer);
+    expect(spy).toHaveBeenCalled();
   });
 
   it('should test mapStateToProps', () => {

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -16,7 +16,7 @@ describe('Test suite for dictionary concepts components', () => {
   const props = {
     match: {
       params: {
-        conceptType: 'diagnosis',
+        conceptType: 'question',
         collectionName: 'dev-col',
         type: 'users',
         typeName: 'emmabaye',
@@ -38,8 +38,11 @@ describe('Test suite for dictionary concepts components', () => {
     addDescriptionForEditConcept: jest.fn(),
     removeNameForEditConcept: jest.fn(),
     updateConcept: jest.fn(),
+    addNewAnswer: jest.fn(),
+    removeAnswer: jest.fn(),
     newName: ['1'],
     description: ['1'],
+    answer: ['78'],
     existingConcept: {
       names: [{
         uuid: '1234',
@@ -50,12 +53,13 @@ describe('Test suite for dictionary concepts components', () => {
         name: 'dummy',
       }],
     },
+    newRow: '1234',
   };
   it('should render without breaking', () => {
     const wrapper = mount(<Router>
       <EditConcept {...props} />
     </Router>);
-    expect(wrapper.find('h3').text()).toEqual(': Edit a diagnosis Concept ');
+    expect(wrapper.find('h3').text()).toEqual(': Edit a question Concept ');
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -104,6 +108,31 @@ describe('Test suite for dictionary concepts components', () => {
     wrapper.find('#remove-name').simulate('click');
     expect(props.removeNameForEditConcept).toHaveBeenCalled();
   });
+
+  it('should handle add-more-answers', () => {
+    const wrapper = mount(<Router>
+      <EditConcept {...props} />
+    </Router>);
+    wrapper.find('.add-more-answers').simulate('click');
+    expect(props.addNewAnswer).toHaveBeenCalled();
+  });
+
+  it('should handle remove-answers', () => {
+    const wrapper = mount(<Router>
+      <EditConcept {...props} />
+    </Router>);
+    wrapper.find('.concept-form-table-link.answer').simulate('click');
+    expect(props.removeAnswer).toHaveBeenCalled();
+  });
+
+  it('should handle add data from answer', () => {
+    const wrapper = mount(<Router>
+      <EditConcept {...props} />
+    </Router>);
+    const conceptAnswer = { target: { name: 'answer', value: 'test concept' } };
+    wrapper.find('#concept-answer').simulate('change', conceptAnswer);
+  });
+
   it('it should handle submit event', () => {
     const wrapper = mount(<Router>
       <EditConcept {...props} />

--- a/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
@@ -23,6 +23,8 @@ import {
   EDIT_CONCEPT_CREATE_NEW_NAMES,
   EDIT_CONCEPT_REMOVE_ONE_NAME,
   REMOVE_CONCEPT,
+  ADD_NEW_ANSWER_MAPPING,
+  REMOVE_ONE_ANSWER_MAPPING,
 } from '../../../redux/actions/types';
 
 let state;
@@ -43,6 +45,7 @@ beforeEach(() => {
     classList: [],
     newName: ['456'],
     description: ['456'],
+    answer: ['123y'],
     newConcept: {},
     addConceptToDictionary: [],
     existingConcept: {
@@ -168,6 +171,7 @@ describe('Test suite for single dictionary concepts', () => {
       description: ['456', '123'],
     });
   });
+
   it('should handle REMOVE_ONE_DESCRIPTION', () => {
     action = {
       type: REMOVE_ONE_DESCRIPTION,
@@ -385,6 +389,36 @@ describe('Test suite for single dictionary concepts', () => {
         ...state.existingConcept,
         names: [],
       },
+    });
+  });
+
+  it('should handle ADD_NEW_ANSWER_MAPPING', () => {
+    action = {
+      type: ADD_NEW_ANSWER_MAPPING,
+      payload: '123',
+    };
+
+    deepFreeze(state);
+    deepFreeze(action);
+
+    expect(reducer(state, action)).toEqual({
+      ...state,
+      answer: ['123y', '123'],
+    });
+  });
+
+  it('should handle REMOVE_ONE_ANSWER_MAPPING', () => {
+    action = {
+      type: REMOVE_ONE_ANSWER_MAPPING,
+      payload: '123',
+    };
+
+    deepFreeze(state);
+    deepFreeze(action);
+
+    expect(reducer(state, action)).toEqual({
+      ...state,
+      answer: ['123y'],
     });
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Changes to create concept form options for Q-and-A concept](https://issues.openmrs.org/browse/OCLOMRS-173)

# Summary:
When a user selects to create Q-and-A concept they should be able to specify the answers
