### PR TITLE
OCLOMRS-204: Concepts HEAD version card in an Implementation Dictionary owned by an Organisation should display live data

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -42,12 +42,11 @@ export class DictionaryOverview extends Component {
     } = this.props;
 
     const url = `/${ownerType}/${owner}/${type}/${name}/`;
-
     const versionUrl = `/${ownerType}/${owner}/${type}/${name}/versions/?verbose=true`;
     this.props.fetchDictionary(url);
     this.props.fetchVersions(versionUrl);
 
-    const conceptsUrl = `/users/${owner}/collections/${name}/concepts/?q=&limit=0&page=1&verbose=true`;
+    const conceptsUrl = `/${ownerType}/${owner}/collections/${name}/concepts/?q=&limit=0&page=1&verbose=true`;
     this.props.fetchDictionaryConcepts(conceptsUrl);
   }
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[Concepts HEAD version card in an Implementation Dictionary owned by an Organisation should display live data](https://issues.openmrs.org/browse/OCLOMRS-204)

# Summary:
Currently, an implementation dictionary owned/managed by an organisation is not displaying the correct details in regards to the number of concepts.

Therefore it should be able to display the correct live data.