### PR TITLE
OCLOMRS-203: While creating a concept the preferred type should be changed

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -106,6 +106,9 @@ class ConceptNameRows extends Component {
           >
             <option />
             <option>Fully Specified</option>
+            <option>Synonym</option>
+            <option>Search Term</option>
+
           </select>
         </td>
         <th scope="row" className="concept-language">


### PR DESCRIPTION
# JIRA TICKET NAME:
[While creating a concept the preferred type should be changed](https://issues.openmrs.org/browse/OCLOMRS-203)

# Summary:
Currently, while creating a concept the preferred type can only be a Fully specified name. However, the preferred type can either be a Fully specified name, a synonym or a search term. This issue adds the other two options.
