### PR TITLE
OCLOMRS-205: Fix UUID bug that pops up while creating a custom concept

### DIFF
--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -185,12 +185,19 @@ export const createNewConcept = (data, dataUrl) => async (dispatch) => {
     dispatch(addConceptToDictionary(response.data.id, dataUrl));
     notify.show('creating concept, please wait...', 'warning', 3000);
   } catch (error) {
-    notify.show('concept could not be created, uuid must be unique', 'error', 3000);
     if (error.response) {
-      dispatch(isErrored(error.response.data, CREATE_NEW_CONCEPT));
+      const { response } = error;
+      notify.show(`An error occurred when creating a concept.
+ ${
+  Object.keys(response.data).map(e => response.data[e]).toString()
+} for ${
+  Object.keys(error.response.data).toString()
+}`, 'error', 3000);
       dispatch(isFetching(false));
+      return dispatch(isErrored(error.response.data, CREATE_NEW_CONCEPT));
     }
   }
+  return dispatch(isFetching(false));
 };
 
 export const fetchExistingConcept = conceptUrl => async (dispatch) => {

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -125,6 +125,7 @@ describe('Test suite for dictionary concept actions', () => {
     const expectedActions = [
       { type: IS_FETCHING, payload: true },
       { type: CREATE_NEW_CONCEPT, payload: newConcept },
+      { type: IS_FETCHING, payload: false },
     ];
 
     const store = mockStore(mockConceptStore);
@@ -144,8 +145,8 @@ describe('Test suite for dictionary concept actions', () => {
 
     const expectedActions = [
       { type: IS_FETCHING, payload: true },
-      { type: CREATE_NEW_CONCEPT, payload: 'bad request' },
       { type: IS_FETCHING, payload: false },
+      { type: CREATE_NEW_CONCEPT, payload: 'bad request' },
     ];
 
     const store = mockStore(mockConceptStore);


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix UUID bug that pops up while creating a custom concept](https://issues.openmrs.org/browse/OCLOMRS-205)

# Summary:
Fix the bug that displays an error message,"Concept could not be created, uuid must be unique", when a user wants to create a a custom concept.
