### PR TITLE
OCLOMRS-168: Subscribe to a released implementation dictionary

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -32,6 +32,8 @@ export class DictionaryOverview extends Component {
     super(props);
     this.state = {
       showEditModal: false,
+      showSubModal: false,
+      url: '',
     };
   }
   componentDidMount() {
@@ -79,8 +81,12 @@ export class DictionaryOverview extends Component {
   handleHide = () => this.setState({ showEditModal: false });
   handleShow = () => this.setState({ showEditModal: true });
 
+  handleHideSub = () => this.setState({ showSubModal: false });
+  handleShowSub = (url) => { this.setState({ showSubModal: true, url }); }
+
   render() {
     const { loader } = this.props;
+    const { url, showSubModal } = this.state;
     const cielConcepts = this.props.dictionaryConcepts.filter(concept => concept.owner === 'CIEL').length.toString();
     const customConcepts = this.props.dictionaryConcepts.filter(concept => concept.owner !== 'CIEL').length.toString();
     const diagnosisConcepts = this.props.dictionaryConcepts.filter(concept => concept.concept_class === 'diagnosis').length.toString();
@@ -108,6 +114,10 @@ export class DictionaryOverview extends Component {
               handleRelease={this.handleRelease}
               headVersion={headVersionIdObj}
               showEditModal={this.handleShow}
+              hideSubModal={this.handleHideSub}
+              showSubModal={this.handleShowSub}
+              subModal={showSubModal}
+              subUrl={url}
             />
             <EditDictionary
               show={this.state.showEditModal}

--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -29,6 +29,10 @@ const DictionaryDetailCard = (props) => {
     otherConcepts,
     headVersion,
     handleRelease,
+    hideSubModal,
+    showSubModal,
+    subModal,
+    subUrl,
   } = props;
 
   const username = localStorage.getItem('username');
@@ -180,7 +184,14 @@ const DictionaryDetailCard = (props) => {
           </tr>
           {releasedVersions.length >= 1 ? (
             releasedVersions.map(version => (
-              <DictionaryVersionsTable version={version} key={version.id} />
+              <DictionaryVersionsTable
+                version={version}
+                key={version.id}
+                hide={hideSubModal}
+                showSubModal={showSubModal}
+                show={subModal}
+                url={subUrl}
+              />
             ))
           ) : (
             <tr>
@@ -206,6 +217,10 @@ DictionaryDetailCard.propTypes = {
   procedureConcepts: PropTypes.string.isRequired,
   otherConcepts: PropTypes.string.isRequired,
   headVersion: PropTypes.number.isRequired,
+  hideSubModal: PropTypes.func.isRequired,
+  showSubModal: PropTypes.func.isRequired,
+  subModal: PropTypes.bool.isRequired,
+  subUrl: PropTypes.string.isRequired,
 };
 
 export default DictionaryDetailCard;

--- a/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import './styles/dictionary-modal.css';
+import SubscriptionModal from '../dictionary/common/SubscriptionModal';
 
 const DictionaryVersionsTable = (version) => {
   const {
@@ -7,18 +9,22 @@ const DictionaryVersionsTable = (version) => {
       id,
       updated_on,
       version_url,
-    },
+    }, hide, show, showSubModal, url,
   } = version;
   const DATE_OPTIONS = {
     weekday: 'long', year: 'numeric', month: 'short', day: 'numeric',
   };
-
   return (
     <tr id="versiontable">
       <td>{id}</td>
       <td>{ (new Date(updated_on)).toLocaleDateString('en-US', DATE_OPTIONS)}</td>
       <td>Yes</td>
-      <td><a href={version_url} >Browse in OCL</a> <a href="a">Subscription URL</a></td>
+      <td><a href={version_url}>Browse in OCL</a> <Link className="subscription-link" onClick={() => { showSubModal(version_url); }} to="#">Subscription URL</Link></td>
+      <SubscriptionModal
+        show={show}
+        click={hide}
+        url={url}
+      />
     </tr>
   );
 };

--- a/src/components/dashboard/components/dictionary/common/SubscriptionModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/SubscriptionModal.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Modal, FormGroup, FormControl } from 'react-bootstrap';
+
+const SubscriptionModal = (props) => {
+  const { show, click, url } = props;
+  const subUrl = `https://openconceptlab.org/${url}`;
+  return (
+    <div className="modal-container">
+      <Modal
+        show={show}
+        onHide={click}
+        dialogClassName="custom-modal"
+        className="modal-fade"
+      >
+        <Modal.Header>
+          <Modal.Title className="modal-heading">
+              Subscription URL
+          </Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
+          <FormGroup>
+            <FormControl
+              type="text"
+              id="subURL"
+              name="subUrl"
+              value={subUrl}
+              readOnly
+            />
+          </FormGroup>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <Button
+            className="btn-sm btn-outline-danger test-btn-cancel"
+            id="sub-cancel"
+            onClick={click}
+          >
+              Cancel
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </div>
+  );
+};
+
+SubscriptionModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  click: PropTypes.func.isRequired,
+  url: PropTypes.string.isRequired,
+};
+
+export default SubscriptionModal;

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { mount, shallow } from 'enzyme';
 import { DictionaryOverview } from '../../components/dashboard/components/dictionary/DictionaryContainer';
 import dictionary from '../__mocks__/dictionaries';
+import DictionaryDetailCard from '../../components/dashboard/components/dictionary/DictionaryDetailCard';
 import versions, { customVersion, HeadVersion } from '../__mocks__/versions';
 
 const store = createMockStore({
@@ -171,5 +172,39 @@ describe('DictionaryOverview', () => {
       <DictionaryOverview {...props} />
     </MemoryRouter>);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should handle opening of subscription modal', () => {
+    const props = {
+      dictionary: { dictionary },
+      versions: [versions, customVersion],
+      headVersion: [versions],
+      url: '',
+      dictionaryConcepts: [],
+      showEditModal: jest.fn(),
+      hideSubModal: jest.fn(),
+      showSubModal: jest.fn(),
+      handleRelease: jest.fn(),
+      match: {
+        params: {
+          ownerType: 'testing',
+          owner: 'chriskala',
+          type: 'collection',
+          name: 'chriskala',
+        },
+      },
+      fetchDictionary: jest.fn(),
+      fetchVersions: jest.fn(),
+      fetchDictionaryConcepts: jest.fn(),
+    };
+
+    const wrapper = mount(<Provider store={store}><MemoryRouter>
+      <DictionaryOverview {...props} />
+    </MemoryRouter></Provider>);
+    const spy = jest.spyOn(wrapper.find('DictionaryOverview').instance(), 'handleShowSub');
+    wrapper.instance().forceUpdate();
+    expect(wrapper.find('.subscription-link').at(0).exists()).toBe(true);
+    wrapper.find('.subscription-link').at(0).simulate('click');
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-168: Subscribe to a released implementation dictionary](https://issues.openmrs.org/browse/OCLOMRS-168)

# Summary:
Subscribe to a released implementation dictionary from a fresh OpenMRS installation of Platform + Legacy UI.

Currently, a user cannot subscribe to a released implementation of a dictionary.