### PR TITLE
OCLOMRS-200: User should be able to release a new Dictionary version

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import './styles/dictionary-modal.css';
 import DictionaryVersionsTable from './DictionaryVersionsTable';
+import ReleaseVersionModal from '../dictionary/common/ReleaseVersionModal';
 
 const DictionaryDetailCard = (props) => {
   const {
@@ -33,6 +34,14 @@ const DictionaryDetailCard = (props) => {
     showSubModal,
     subModal,
     subUrl,
+    showVersionModal,
+    hideVersionModal,
+    openVersionModal,
+    handleCreateVersion,
+    handleChange,
+    versionId,
+    versionDescription,
+    inputLength,
   } = props;
 
   const username = localStorage.getItem('username');
@@ -90,7 +99,14 @@ const DictionaryDetailCard = (props) => {
               <b>Updated On</b>: {new Date(updated_on).toLocaleDateString('en-US', DATE_OPTIONS)}
             </p>
             {owner === username && (
-              <Link className="btn btn-secondary" id="editB" to="#" onClick={showEditModal}>
+              <Link
+                className="btn btn-secondary"
+                id="editB"
+                to="#"
+                onClick={showEditModal}
+                versionId={versionId}
+                versionDescription={versionDescription}
+              >
                 Edit
               </Link>
             )}
@@ -131,23 +147,28 @@ const DictionaryDetailCard = (props) => {
           <fieldset>
             <legend>Actions</legend>
             <ul>
-              <li>
-                <a href={traditionalUrl} target="_blank" rel="noopener noreferrer">
-                  <i className="fas fa-external-link-alt" />
-                  Browse in traditional OCL
-                </a>
-              </li>
-              {owner === username && !headVersion.released ? (
-                <li>
-                  <button type="button" onClick={handleRelease} className="fas fa-cloud-upload-alt">
-                    <span id="release-head"> Release HEAD as new version</span>
-                  </button>
-                </li>
-              ) : null}
+              <li><a href={traditionalUrl} target="_blank" rel="noopener noreferrer"><i className="fas fa-external-link-alt" />Browse in traditional OCL</a></li>
+              <li><i className="far fa-copy" />Copy concepts from another dictionary</li>
+              { owner === username && !headVersion.released ?
+                <li><button type="button" onClick={handleRelease} className="fas fa-cloud-upload-alt head"><span id="release-head"> Release HEAD as new version</span></button></li>
+            : null}
+
+              { owner === username ?
+                <li><button type="button" onClick={showVersionModal} className="fas fa-cloud-upload-alt version"><span id="release-head"> Release a new version</span></button> </li>
+            : null}
             </ul>
           </fieldset>
         </form>
       </div>
+
+      <ReleaseVersionModal
+        show={openVersionModal}
+        click={hideVersionModal}
+        handleCreateVersion={handleCreateVersion}
+        handleChange={handleChange}
+        inputLength={inputLength}
+      />
+
       <h3 align="left">Released Version</h3>
 
       <div className="card" id="versionCard">
@@ -197,6 +218,14 @@ DictionaryDetailCard.propTypes = {
   showSubModal: PropTypes.func.isRequired,
   subModal: PropTypes.bool.isRequired,
   subUrl: PropTypes.string.isRequired,
+  showVersionModal: PropTypes.func.isRequired,
+  hideVersionModal: PropTypes.func.isRequired,
+  openVersionModal: PropTypes.func.isRequired,
+  handleCreateVersion: PropTypes.func.isRequired,
+  handleChange: PropTypes.func.isRequired,
+  versionId: PropTypes.string.isRequired,
+  versionDescription: PropTypes.string.isRequired,
+  inputLength: PropTypes.number.isRequired,
 };
 
 export default DictionaryDetailCard;

--- a/src/components/dashboard/components/dictionary/common/ReleaseVersionModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/ReleaseVersionModal.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Button, Modal, FormGroup, FormControl } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+
+const ReleaseVersionModal = (props) => {
+  const {
+    show, click, handleCreateVersion, handleChange, versionId, versionDescription, inputLength,
+  } = props;
+  return (
+    <div className="modal-container">
+      <Modal
+        show={show}
+        onHide={click}
+        className="modal-fade"
+      >
+        <Modal.Header>
+          <Modal.Title className="modal-heading">
+              Release a new version
+          </Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
+          <FormGroup>
+            Version:
+            <FormControl
+              type="text"
+              id="versionId"
+              name="versionId"
+              value={versionId}
+              onChange={handleChange}
+              placeholder="Version Number"
+            />
+          </FormGroup>
+
+          <FormGroup style={{ marginTop: '12px' }}>
+            Description(Optional):
+            <FormControl
+              componentClass="textarea"
+              id="versionDescription"
+              name="versionDescription"
+              value={versionDescription}
+              onChange={handleChange}
+              placeholder="Version Description"
+            />
+          </FormGroup>
+        </Modal.Body>
+
+        <Modal.Footer>
+          {inputLength > 0 ?
+            <Button
+              className="btn-sm btn-outline-info version"
+              id="addDictionary"
+              onClick={handleCreateVersion}
+            >
+               Release
+            </Button> : <Button
+              className="btn-sm btn-outline-info version-disabled"
+              disabled
+            >
+               Release
+            </Button>}
+          <Button
+            className="btn-sm btn-outline-danger test-btn-cancel"
+            id="sub-cancel"
+            onClick={click}
+          >
+              Cancel
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </div>
+  );
+};
+
+ReleaseVersionModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  click: PropTypes.func.isRequired,
+  handleCreateVersion: PropTypes.func.isRequired,
+  handleChange: PropTypes.func.isRequired,
+  versionId: PropTypes.string.isRequired,
+  versionDescription: PropTypes.string.isRequired,
+  inputLength: PropTypes.number.isRequired,
+};
+
+export default ReleaseVersionModal;

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -11,6 +11,8 @@ import {
   dictionaryConceptsIsSuccess,
   realisingHeadSuccess,
   editDictionarySuccess,
+  creatingVersionsSuccess,
+  creatingVersionsError,
 } from './dictionaryActions';
 import { filterPayload } from '../../reducers/util';
 import api from './../../api';
@@ -162,5 +164,31 @@ export const releaseHead = (url, data) => (dispatch) => {
       .catch(error => {
         notify.show(`${error.response.data.__all__[0]}`, 'error', 6000);
       })
-    }
+};
+
+export const createVersion = (url, data) => (dispatch) => {
+  return api.dictionaries
+    .creatingVersion(url, data)
+    .then(
+      (payload) => {
+        dispatch(creatingVersionsSuccess(payload));
+        dispatch(creatingVersionsError(false));
+        notify.show(
+          `${payload.id} has successfully been released`,
+          'success', 6000,
+        );
+      })
+    .catch((error) => {
+      if(error.response.data.detail){
+        dispatch(creatingVersionsError(true));
+        notify.show(`${error.response.data.detail}`, 'error', 4000);
+      }
+      if(error.response.data.id){
+        dispatch(creatingVersionsError(true));
+        notify.show(`${error.response.data.id}`, 'error', 4000);
+      } else {
+        notify.show("Network Error. Please try again later!", 'error', 4000);
+      }
+    });
+};
 

--- a/src/redux/actions/dictionaries/dictionaryActions.js
+++ b/src/redux/actions/dictionaries/dictionaryActions.js
@@ -11,6 +11,8 @@ import {
   FETCH_DICTIONARY_CONCEPT,
   EDIT_DICTIONARY_SUCCESS,
   REMOVE_CONCEPT,
+  CREATING_RELEASED_VERSION,
+  CREATING_RELEASED_VERSION_FAILED,
   RELEASING_HEAD_VERSION,
 } from './../types';
 
@@ -82,4 +84,14 @@ export const realisingHeadSuccess = payload => ({
 export const editDictionarySuccess = response => ({
   type: EDIT_DICTIONARY_SUCCESS,
   payload: response,
+});
+
+export const creatingVersionsSuccess = payload => ({
+  type: CREATING_RELEASED_VERSION,
+  payload,
+});
+
+export const creatingVersionsError = payload => ({
+  type: CREATING_RELEASED_VERSION_FAILED,
+  payload,
 });

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -23,6 +23,8 @@ export const REMOVE_CONCEPT = '[concepts] remove concept';
 export const FETCHING_VERSIONS = '[dictionary] fetch versions of a dictionary';
 export const RELEASING_HEAD_VERSION = '[dictionary] releasing HEAD version of a dictionary';
 export const EDIT_DICTIONARY_SUCCESS = '[dictionary] edit dictionary success';
+export const CREATING_RELEASED_VERSION = '[dictionary] creating a released version of a dictionary';
+export const CREATING_RELEASED_VERSION_FAILED = '[dictionary] creating a released version of a dictionary failed';
 
 export const FILTER_BY_SOURCES = '[concepts] filter concepts by sources';
 export const FILTER_BY_CLASS = '[concepts] filter concepts by class';

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -53,6 +53,11 @@ export default {
       instance
         .get(`${data}`)
         .then(response => response.data),
+
+    creatingVersion: (url,data) => 
+      instance
+         .post(`${url}`, data)
+         .then(response => response.data),
     
     realisingHeadVersion: (url, data) =>
       instance

--- a/src/redux/reducers/dictionaryReducers.js
+++ b/src/redux/reducers/dictionaryReducers.js
@@ -5,11 +5,13 @@ import {
   CLEAR_DICTIONARY,
   FETCHING_VERSIONS,
   EDIT_DICTIONARY_SUCCESS,
+  CREATING_RELEASED_VERSION,
+  CREATING_RELEASED_VERSION_FAILED,
   RELEASING_HEAD_VERSION,
 } from '../actions/types';
 
 const initalState = {
-  versions: [], dictionaries: [], loading: false, dictionary: {}, isReleased: false,
+  versions: [], dictionaries: [], loading: false, dictionary: {}, isReleased: false, error: [],
 };
 
 export default (state = initalState, action) => {
@@ -48,6 +50,16 @@ export default (state = initalState, action) => {
       return {
         ...state,
         dictionary: action.payload,
+      };
+    case CREATING_RELEASED_VERSION:
+      return {
+        ...state,
+        isReleased: action.payload.released,
+      };
+    case CREATING_RELEASED_VERSION_FAILED:
+      return {
+        ...state,
+        error: action.payload,
       };
     default:
       return state;

--- a/src/tests/Dashboard/reducer/dictionaryReducers.test.js
+++ b/src/tests/Dashboard/reducer/dictionaryReducers.test.js
@@ -10,6 +10,8 @@ import {
   CLEAR_DICTIONARY,
   EDIT_DICTIONARY_SUCCESS,
   RELEASING_HEAD_VERSION,
+  CREATING_RELEASED_VERSION,
+  CREATING_RELEASED_VERSION_FAILED,
 } from '../../../redux/actions/types';
 import dictionaries from '../../__mocks__/dictionaries';
 import versions from '../../__mocks__/versions';
@@ -37,6 +39,7 @@ const state = {
   dictionaries: [],
   versions: [],
   dictionary: {},
+  error: [],
   loading: false,
   isReleased: false,
 };
@@ -96,6 +99,27 @@ describe('Test suite for dictionaries reducers', () => {
       },
     )).toEqual({ isReleased: true });
   });
+
+  it('should handle CREATING_RELEASED_VERSION', () => {
+    expect(dictionaryreducer(
+      { isReleased: false },
+      {
+        type: CREATING_RELEASED_VERSION,
+        payload: { released: true },
+      },
+    )).toEqual({ isReleased: true });
+  });
+
+  it('should handle CREATING_RELEASED_VERSION_FAILED', () => {
+    expect(dictionaryreducer(
+      { error: {} },
+      {
+        type: CREATING_RELEASED_VERSION_FAILED,
+        payload: { detatil: 'Duplicate Error' },
+      },
+    )).toEqual({ error: { detatil: 'Duplicate Error' } });
+  });
+
   it('should clear a dictionary', () => {
     expect(dictionaryreducer(
       { dictionary },
@@ -114,16 +138,6 @@ describe('Test suite for dictionaries reducers', () => {
     )).toEqual({ dictionary });
   });
 });
-it('should handle FETCHING_VERSIONS', () => {
-  expect(dictionaryreducer(
-    { versions: [] },
-    {
-      type: FETCHING_VERSIONS,
-      payload: [versions],
-    },
-  )).toEqual({ versions: [versions] });
-});
-
 describe('Test suite for dictionaries reducers', () => {
   it('should return inital state ADD_DICTIONARY', () => {
     expect(userReducer(

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -16,6 +16,7 @@ const store = createMockStore({
     sources: [],
   },
 });
+
 jest.mock('../../components/dashboard/components/dictionary/AddDictionary');
 describe('DictionaryOverview', () => {
   it('should render without any data', () => {
@@ -85,7 +86,7 @@ describe('DictionaryOverview', () => {
     </Provider>);
     const spy = jest.spyOn(wrapper.find('DictionaryOverview').instance(), 'handleRelease');
     wrapper.instance().forceUpdate();
-    wrapper.find('.fas.fa-cloud-upload-alt').simulate('click');
+    wrapper.find('.fas.fa-cloud-upload-alt.head').simulate('click');
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -208,6 +209,85 @@ describe('DictionaryOverview', () => {
     wrapper.instance().forceUpdate();
     expect(wrapper.find('.subscription-link').at(0).exists()).toBe(true);
     wrapper.find('.subscription-link').at(0).simulate('click');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle a new version release', () => {
+    const props = {
+      dictionary: [dictionary],
+      versions: [customVersion],
+      dictionaryConcepts: [dictionary],
+      isReleased: false,
+      hideVersionModal: jest.fn(),
+      showVersionModal: jest.fn(),
+      error: false,
+      inputLength: 4,
+      match: {
+        params: {
+          ownerType: 'users',
+          owner: 'nesh',
+          type: 'collection',
+          name: 'test',
+        },
+      },
+      fetchDictionary: jest.fn(),
+      fetchVersions: jest.fn(),
+      fetchDictionaryConcepts: jest.fn(),
+      releaseHead: jest.fn(),
+      createVersion: jest.fn(() => Promise.resolve(true)),
+    };
+    const event = {
+      preventDefault: jest.fn(),
+      target: {
+        value: 'v2.0',
+        name: 'versionId',
+      },
+    };
+
+    const wrapper = mount(<Provider store={store}>
+      <MemoryRouter><DictionaryOverview {...props} /></MemoryRouter></Provider>);
+    const spy = jest.spyOn(wrapper.find('DictionaryOverview').instance(), 'handleCreateVersion');
+    wrapper.find('.fas.fa-cloud-upload-alt.version').simulate('click');
+    wrapper.find('#versionId').at(0).simulate('change', event);
+    wrapper.find('.btn-sm.btn-outline-info.version').at(0).simulate('click');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handleChange', () => {
+    const props = {
+      dictionary: [dictionary],
+      versions: [customVersion],
+      dictionaryConcepts: [dictionary],
+      isReleased: false,
+      hideVersionModal: jest.fn(),
+      showVersionModal: jest.fn(),
+      error: null,
+      match: {
+        params: {
+          ownerType: 'testing',
+          owner: 'chriskala',
+          type: 'collection',
+          name: 'chris',
+        },
+      },
+      fetchDictionary: jest.fn(),
+      fetchVersions: jest.fn(),
+      fetchDictionaryConcepts: jest.fn(),
+      releaseHead: jest.fn(),
+      createVersion: jest.fn(),
+    };
+    const event = {
+      preventDefault: jest.fn(),
+      target: {
+        value: 'v2.0',
+        name: 'versionId',
+      },
+    };
+    const wrapper = mount(<Provider store={store}>
+      <MemoryRouter><DictionaryOverview {...props} /></MemoryRouter></Provider>);
+    const spy = jest.spyOn(wrapper.find('DictionaryOverview').instance(), 'handleChange');
+    wrapper.find('.fas.fa-cloud-upload-alt.version').simulate('click');
+    wrapper.find('#versionId').at(0).simulate('change', event);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/tests/__mocks__/versions.js
+++ b/src/tests/__mocks__/versions.js
@@ -32,3 +32,4 @@ export const HeadVersion = {
   extras: null,
   external_id: null,
 };
+


### PR DESCRIPTION
# JIRA TICKET NAME:
[User should be able to release a new Dictionary version](https://issues.openmrs.org/browse/OCLOMRS-200)

# Summary:
Currently, a user can only release the HEAD version of a dictionary. However, a user is required to create and release other versions of a dictionary. This issue enables a user to release other versions of a dictionary. 
