### PR TITLE
OCLOMRS-223: Fix the dashboard UI and remove the extra fields in the Dictionary overview

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryCard.jsx
@@ -17,7 +17,7 @@ const DictionaryCard = (dictionary) => {
   const ownerType = owner_type === 'Organization' ? 'org' : 'user';
   return (
     <div
-      className="col-12 col-sm-6 col-md-4 col-lg-3 p-3 card-link no-padding-top"
+      className="col-12 col-sm-6 col-md-4 col-lg-3 p-3 card-link"
       role="presentation"
       onClick={() => gotoDictionary(`/dictionaryOverview${url}`)}
     >

--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -46,7 +46,7 @@ const DictionaryDetailCard = (props) => {
   const releasedVersions = versions.filter(version => version.released === true);
 
   return (
-    <div className="container">
+    <div className="dictionaryDetails">
       <section className="backLink">
         <Link
           to="/dashboard"
@@ -125,23 +125,6 @@ const DictionaryDetailCard = (props) => {
               Go to concepts
             </Link>
           </fieldset>
-          <fieldset>
-            <legend>Concepts (HEAD version)</legend>
-            <p className="paragraph">Total Concepts: {active_concepts}</p>
-            <p className="points">Custom Concepts: {customConcepts}</p>
-            <p className="points">From CIEL: {cielConcepts}</p>
-            <p>By class:</p>
-            <p className="points">Diagnosis: {diagnosisConcepts}</p>
-            <p className="points">Procedure: {procedureConcepts}</p>
-            <p className="points">Others: {otherConcepts}</p>
-            <Link
-              className="btn btn-secondary"
-              id="conceptB"
-              to={`/concepts${owner_url}${short_code}/${name}/${default_locale}`}
-            >
-              Go to concepts
-            </Link>
-          </fieldset>
         </form>
         <form className="col-6 menu" id="actionsCard">
           <fieldset>
@@ -152,10 +135,6 @@ const DictionaryDetailCard = (props) => {
                   <i className="fas fa-external-link-alt" />
                   Browse in traditional OCL
                 </a>
-              </li>
-              <li>
-                <i className="far fa-copy" />
-                Copy concepts from another dictionary
               </li>
               {owner === username && !headVersion.released ? (
                 <li>

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -49,7 +49,7 @@ describe('DictionaryOverview', () => {
       </MemoryRouter>
     </Provider>);
     expect(wrapper.find('#headingDict')).toHaveLength(1);
-    expect(wrapper.find('.paragraph')).toHaveLength(6);
+    expect(wrapper.find('.paragraph')).toHaveLength(5);
     expect(wrapper.find('tr')).toHaveLength(2);
     expect(wrapper).toMatchSnapshot();
   });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix the dashboard UI and remove the extra fields in the Dictionary overview](https://issues.openmrs.org/browse/OCLOMRS-223)

# Summary:
Currently, there is a duplicate of 'Concepts (HEAD version)' fieldset on the Dictionary Overview Page, the 'Copy concepts from another dictionary' Action is irrelevant on the same page and should be removed.

The top padding of the concepts in the Dashboard UI is not right and should be fixed.