### PR TITLE
OCLOMRS-228:Change the UI on the pages to start with create then cancel

### DIFF
--- a/src/components/bulkConcepts/component/PreviewCard.jsx
+++ b/src/components/bulkConcepts/component/PreviewCard.jsx
@@ -22,11 +22,8 @@ const PreviewCard = ({ concept, closeModal, addConcept }) => {
       <CardBody title="Description" body={descriptions[0].description} />
       <CardBody title="Mappings" body={mapping} />
       <div className="buttons text-right mt-3">
-        <button className="btn btn-sm btn-danger no-shadow mr-2" onClick={closeModal}>
-          Close
-        </button>
         <button
-          className="btn btn-sm btn-success no-shadow"
+          className="btn btn-sm btn-success no-shadow mr-2"
           id="add-concept"
           onClick={() => {
             addConcept(url, display_name);
@@ -34,6 +31,9 @@ const PreviewCard = ({ concept, closeModal, addConcept }) => {
           }}
         >
           Add
+        </button>
+        <button className="btn btn-sm btn-danger no-shadow" onClick={closeModal}>
+          Close
         </button>
       </div>
     </div>

--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -140,17 +140,14 @@ const CreateConceptForm = props => (
         </div>
       </div>
       <div className="submit-button text-left">
-        <Link
-          to={props.path}
-          className="collection-name small-text"
-        >
-          <button className="btn btn-sm mr-1 col-2 btn-danger" type="reset">
-          Cancel
+        <button className="btn btn-sm bg-blue col-2 mr-1" type="submit">
+          {props.isEditConcept ? 'Update' : 'Create' }
+        </button>
+        <Link to={props.path} className="collection-name small-text">
+          <button className="btn btn-sm  col-2 btn-danger" type="reset">
+            Cancel
           </button>
         </Link>
-        <button className="btn btn-sm bg-blue col-2" type="submit">
-          {props.isEditConcept ? 'Update' : 'Create'}
-        </button>
       </div>
     </div>
   </form>


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-228: Change the UI on the pages to start with create then cancel](https://issues.openmrs.org/browse/OCLOMRS-228)

# Summary:
The cancel button came before the create button. This is not a good practice. Therefore, this ticket was to ensure the create or add button comes before cancel or close button