### PR TITLE
OCLOMRS-243: Short code input field should be disabled when editing dictionary.

### DIFF
--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -316,6 +316,7 @@ export class DictionaryModal extends React.Component {
                       placeholder="e.g Community-MCH, Only Alphanumeric Characters
                       Allowed"
                       required
+                      disabled={isEditingDictionary !== true ? isEditingDictionary : true}
                     />
                   </FormGroup>
                   <FormGroup style={{ marginTop: '12px' }}>


### PR DESCRIPTION

# JIRA TICKET NAME:
[Short code input field should be disabled when editing dictionary.](https://issues.openmrs.org/browse/OCLOMRS-243)

# Summary:
User should not be able to edit the short code field when editing a dictionary.