### PR TITLE
OCLOMRS-229 : The Released version fieldset should be below the Actions fieldset

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -158,28 +158,16 @@ const DictionaryDetailCard = (props) => {
             : null}
             </ul>
           </fieldset>
-        </form>
-      </div>
-
-      <ReleaseVersionModal
-        show={openVersionModal}
-        click={hideVersionModal}
-        handleCreateVersion={handleCreateVersion}
-        handleChange={handleChange}
-        inputLength={inputLength}
-      />
-
-      <h3 align="left">Released Version</h3>
-
-      <div className="card" id="versionCard">
-        <table>
-          <tr>
-            <th>Version</th>
-            <th>Date</th>
-            <th>Released</th>
-            <th>Actions</th>
-          </tr>
-          {releasedVersions.length >= 1 ? (
+          <fieldset>
+            <legend>Released Version</legend>
+            <div className="card" id="versionCard">
+              <table>
+                <tr>
+                  <th>Version</th>
+                  <th>Date</th>
+                  <th>Actions</th>
+                </tr>
+                {releasedVersions.length >= 1 ? (
             releasedVersions.map(version => (
               <DictionaryVersionsTable
                 version={version}
@@ -197,8 +185,20 @@ const DictionaryDetailCard = (props) => {
               </td>
             </tr>
           )}
-        </table>
+              </table>
+            </div>
+          </fieldset>
+        </form>
       </div>
+
+      <ReleaseVersionModal
+        show={openVersionModal}
+        click={hideVersionModal}
+        handleCreateVersion={handleCreateVersion}
+        handleChange={handleChange}
+        inputLength={inputLength}
+      />
+
     </div>
   );
 };

--- a/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
@@ -18,7 +18,6 @@ const DictionaryVersionsTable = (version) => {
     <tr id="versiontable">
       <td>{id}</td>
       <td>{ (new Date(updated_on)).toLocaleDateString('en-US', DATE_OPTIONS)}</td>
-      <td>Yes</td>
       <td><a href={version_url}>Browse in OCL</a> <Link className="subscription-link" onClick={() => { showSubModal(version_url); }} to="#">Subscription URL</Link></td>
       <SubscriptionModal
         show={show}


### PR DESCRIPTION
# JIRA TICKET NAME:
[The Released version fieldset should be below the Actions fieldset](https://issues.openmrs.org/browse/OCLOMRS-229)

# Summary:
The released version should be below the action fieldset and also be wrapped in a fieldset. This is to utilize the space below the action fieldset.