### PR TITLE
Dictionary cards should be the same across the application

### DIFF
--- a/src/components/userDasboard/container/UserDashboard.jsx
+++ b/src/components/userDasboard/container/UserDashboard.jsx
@@ -57,11 +57,11 @@ export class UserDashboard extends Component {
     } = this.props;
     const dictionary = public_collections === 1 ? 'dictionary' : 'dictionaries';
     return (
-      <div className="container-fluid mt-5">
+      <div className="container">
         <Title title="Home" />
         <AddDictionary show={this.state.show} handleHide={this.handleHide} />
         <div className="row justify-content-center">
-          <div className="col-11 user-info">
+          <div className="col-12 user-info">
             <div className="row">
               <div className="greetings">
                 <h5>Welcome {name}</h5>
@@ -75,7 +75,9 @@ export class UserDashboard extends Component {
               />
             </div>
           </div>
-          <div className="col-11 user-dictionary-wrapper">
+        </div>
+        <div className="row">
+          <div className="col-12 user-dictionary-wrapper">
             <div className="row">
               <div className="greetings col-12 d-flex justify-content-between">
                 <h3>Your {dictionary}</h3>
@@ -92,7 +94,7 @@ export class UserDashboard extends Component {
               <div className="line-divider" />
             </div>
             <div className="row justify-content-center">
-              <div className="col-11">
+              <div className="col-12">
                 <CardWrapper
                   dictionaries={userDictionary}
                   fetching={loading}

--- a/src/styles/user_dashboard.scss
+++ b/src/styles/user_dashboard.scss
@@ -46,9 +46,9 @@
 .line-divider {
   display: inline-block;
   height: .3rem;
-  width: 5rem;
+  width: 8rem;
   background: #343a40;
-  margin-left: 1.7rem;
+  margin-left: 1rem;
   border-radius: 100rem;
   -webkit-border-radius: 100rem;
   -moz-border-radius: 100rem;

--- a/src/styles/utils.scss
+++ b/src/styles/utils.scss
@@ -224,9 +224,6 @@ a{
 .p-4 {
     padding: 1px !important;
 }
-.p-3 {
-    padding: 4px !important;
-}
 
 .p-2 {
     padding: 2px !important;


### PR DESCRIPTION
# JIRA TICKET NAME:
[Dictionary cards should be the same across the application](https://issues.openmrs.org/browse/OCLOMRS-249)

# Summary:
The dictionary cards don't look the same for both homepage and dictionaries page, this has to be fixed. Regarding dictionary cards, divider line on home page that is in dictionaries section has to be aligned with the dictionary cards.
