### PR TITLE
OCLOMRS-259 : Copy concepts from another dictionary action should be removed from the dictionary overview

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -147,7 +147,6 @@ const DictionaryDetailCard = (props) => {
             <legend>Actions</legend>
             <ul>
               <li><a href={traditionalUrl} target="_blank" rel="noopener noreferrer"><i className="fas fa-external-link-alt" />Browse in traditional OCL</a></li>
-              <li><i className="far fa-copy" />Copy concepts from another dictionary</li>
               { owner === username && !headVersion.released ?
                 <li><button type="button" onClick={handleRelease} className="fas fa-cloud-upload-alt head"><span id="release-head"> Release HEAD as new version</span></button></li>
             : null}


### PR DESCRIPTION
# JIRA TICKET NAME:
[Copy concepts from another dictionary action should be removed from the dictionary overview](https://issues.openmrs.org/browse/OCLOMRS-259)

# Summary:
Copy concepts from another dictionary action should be removed from dictionary overview page since it's being implemented when creating a new dictionary. [HERE](https://github.com/openmrs/openmrs-ocl-client/pull/146)