### PR TITLE
OCLOMRS-264: Refactor the navbar items bold styling to avoid repetition of strong tags

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -17,11 +17,9 @@ export class Navbar extends Component {
       <div>
         <Notification options={{ zIndex: 10000, top: '200px' }} />
         <nav className="navbar navbar-expand-lg navbar-light bg-dark">
-          <strong>
-            <a className="navbar-brand" href="/">
+          <a className="nav-link navbar-brand" href="/">
               OCL for OpenMRS
-            </a>
-          </strong>
+          </a>
           <button
             className="navbar-toggler"
             type="button"
@@ -41,9 +39,7 @@ export class Navbar extends Component {
                     className="nav-link text-white"
                     to="/home"
                   >
-                    <strong>
                       Home
-                    </strong>
                   </Link>
                 </li>
                 <li className="nav-item nav-link" >
@@ -51,9 +47,7 @@ export class Navbar extends Component {
                     className="nav-link text-white"
                     to="/dashboard/dictionaries"
                   >
-                    <strong>
                       All Dictionaries
-                    </strong>
                   </Link>
                 </li>
                 <li className="nav-item nav-link dropdown">
@@ -66,17 +60,12 @@ export class Navbar extends Component {
                     aria-haspopup="true"
                     aria-expanded="false"
                   >
-                    <span className="fa fa-user">
-                      <strong>
-                        {''} {localStorage.getItem('username') || this.props.user.username} {''}{' '}
-                      </strong>
-                    </span>
+                    <span className="fa fa-user" />
+                    {''} {localStorage.getItem('username') || this.props.user.username} {''}{' '}
                   </a>
                   <div className="dropdown-menu" aria-labelledby="navbarDropdown" id="navbarDropdown">
                     <Link className="dropdown-item nav-link" to="!#" onClick={this.logoutUser}>
-                      <strong>
                         Logout <i className="fa fa-sign-out" />
-                      </strong>
                     </Link>
                   </div>
                 </li>

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -19,6 +19,7 @@
   padding: 0rem 0rem;
   padding-right: .5rem !important;
   padding-left: .5rem !important;
+  font-weight: 700;
 }
 .navbar {
   padding: 0 1rem !important;


### PR DESCRIPTION
# JIRA TICKET NAME:
[Refactor the navbar items bold styling to avoid repetition of strong tags](https://issues.openmrs.org/browse/OCLOMRS-264)

# Summary:
IInitially, strong tags were used to make the navbar items to become bold. This led to the repetition of the code hence the styling will now be in sass thus increasing reusability and decreasing repetition of code.