### PR TITLE
OCLOMRS-273: Show a visual cue that a user is logging in as soon as they submit the login form

### DIFF
--- a/src/redux/actions/auth/authActions.js
+++ b/src/redux/actions/auth/authActions.js
@@ -4,6 +4,7 @@ import { login, loginFailed, loginStarted, logout } from './authActionCreators';
 const BASE_URL = 'https://api.qa.openconceptlab.org/';
 
 const loginAction = ({ username, password }) => async (dispatch) => {
+  dispatch(loginStarted());
   let response;
   try {
     const data = {
@@ -15,7 +16,6 @@ const loginAction = ({ username, password }) => async (dispatch) => {
     const loginResponse = await axios.post(loginUrl, data);
     const { token } = loginResponse.data;
     const headers = { Authorization: `Token ${token}` };
-    dispatch(loginStarted());
     const url = `${BASE_URL}/users/${username}/`;
     response = await axios.post(url, null, { headers });
     localStorage.setItem('token', `Token ${token}`);

--- a/src/tests/Login/actions/login.test.js
+++ b/src/tests/Login/actions/login.test.js
@@ -71,6 +71,10 @@ describe('Test suite for login action', () => {
 
     const expectedActions = [
       {
+        type: AUTHENTICATION_IN_PROGRESS,
+        loading: true,
+      },
+      {
         type: AUTHENTICATION_FAILED,
         payload: { errorMessage: 'Passwords did not match.' },
         loading: false,


### PR DESCRIPTION
# JIRA TICKET NAME:
[Show a visual cue that a user is logging in as soon as they submit the login form](https://issues.openmrs.org/browse/OCLOMRS-273)

# Summary:
At the moment, a loader is only shown after the server has responded and the login is successful. In the event that the network is a bit slow, a user might wonder if indeed they are logging in as there are no visual cues until the server responds.