### PR TITLE
Use a standard tooltip for short code in new dictionary form

### DIFF
--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -330,9 +330,7 @@ export class DictionaryModal extends React.Component {
                       name="id"
                       onChange={this.onChange}
                       value={data.id}
-                      placeholder="e.g Community-MCH, Only Alphanumeric Characters
-                      Allowed"
-                      data-tip="Mnemonic used to identify the collection in the URL (usually an acronym e.g. Community-MCH)"
+                      placeholder="Mnemonic used to identify the collection in the URL (an acronym e.g. Community-MCH)"
                       required
                       disabled={isEditingDictionary !== true ? isEditingDictionary : true}
                     />


### PR DESCRIPTION
# JIRA TICKET NAME:
[Use a standard tooltip for shortcode in new dictionary form](https://issues.openmrs.org/browse/OCLOMRS-269)

# Summary:
Tooltip for short code while creating a new dictionary doesn’t work like tooltips usually do. Any of the following are pretty standard, so one of these standard approaches has to be used:

- Write it out as plain text next to the label
- Write it as the placeholder text when the field is empty
- Have a visible icon that you can hover over, and this displays a tooltip
- Help text is displayed as a tooltip when the field is focused

(right now it does a tooltip when you hover over the field, but there’s no icon, and it doesn’t pop up if the field gets focus via a keyboard tab). Also this tooltip should say that it cannot be changed after creating the dictionary