### PR TITLE
OCLOMRS-277: Fix subscription URL

### DIFF
--- a/src/components/dashboard/components/dictionary/common/SubscriptionModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/SubscriptionModal.jsx
@@ -4,7 +4,7 @@ import { Button, Modal, FormGroup, FormControl } from 'react-bootstrap';
 
 const SubscriptionModal = (props) => {
   const { show, click, url } = props;
-  const subUrl = `https://openconceptlab.org/${url}`;
+  const subUrl = `https://qa.openconceptlab.org${url}`;
   return (
     <div className="modal-container">
       <Modal


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-277: Fix subscription URL](https://issues.openmrs.org/browse/OCLOMRS-277)

# Summary:
Subscription URLs have double backslash and don’t work. After this fix there should be only on backslash and the url to be functional.
