### PR TITLE
OCLOMRS-265: Change the versions table heading to say “Version(s)” instead of “Released Version”

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -154,7 +154,7 @@ const DictionaryDetailCard = (props) => {
             </ul>
           </fieldset>
           <fieldset>
-            <legend>Released Version</legend>
+            <legend>{releasedVersions.length > 1 ? 'Versions' : 'Version'}</legend>
             <div className="card" id="versionCard">
               <table>
                 <tbody>
@@ -196,7 +196,6 @@ const DictionaryDetailCard = (props) => {
         handleChange={handleChange}
         inputLength={inputLength}
       />
-
     </div>
   );
 };

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -144,6 +144,31 @@ describe('DictionaryOverview', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should render dictionary versions', () => {
+    const props = {
+      dictionary: [dictionary],
+      versions: [HeadVersion, versions],
+      dictionaryConcepts: [],
+      match: {
+        params: {
+          ownerType: 'testing',
+          owner: 'tester',
+          type: 'collection',
+          name: 'chris',
+        },
+      },
+      fetchDictionary: jest.fn(),
+      fetchVersions: jest.fn(),
+      fetchDictionaryConcepts: jest.fn(),
+    };
+    const wrapper = mount(<Provider store={store}>
+      <MemoryRouter>
+        <DictionaryOverview {...props} />
+      </MemoryRouter>
+    </Provider>);
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('should not render dictionary versions', () => {
     const props = {
       dictionary: [dictionary],


### PR DESCRIPTION
# JIRA TICKET NAME:
[Change the versions table heading to say “Version(s)” instead of “Released Version”](https://issues.openmrs.org/browse/OCLOMRS-265)

# Summary:
On a dictionary details page, the versions table heading should be “Version(s)” instead of “Released Version”.