### PR TITLE
OCLOMRS-266: Fix input search box

### DIFF
--- a/src/styles/bulk_concepts.scss
+++ b/src/styles/bulk_concepts.scss
@@ -31,7 +31,7 @@ legend.scheduler-border {
 #search {
   border: none;
   background: inherit;
-  line-height: 4rem;
+  line-height: normal;
   height: 2rem;
   outline: none;
   box-shadow: none;


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix input search box](https://issues.openmrs.org/browse/OCLOMRS-266)

# Summary:
In the Safari browser, in the input search box, the entry text is being hidden. This should be fixed to work across all browsers.
