### PR TITLE
OCLOMRS 267: Change the table header to say “Release Date” instead of just date

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -160,7 +160,7 @@ const DictionaryDetailCard = (props) => {
                 <tbody>
                   <tr>
                     <th>Version</th>
-                    <th>Date</th>
+                    <th>Release Date</th>
                     <th>Actions</th>
                   </tr>
                   {releasedVersions.length >= 1 ? (


### PR DESCRIPTION
# JIRA TICKET NAME:
[Change the table header to say “Release Date” instead of just date](https://issues.openmrs.org/browse/OCLOMRS-267)

# Summary:
Change the table header to say “Release Date” instead of just date, and make the actions look more distinct from each other. E.g. browse should have an icon like it does in the Actions section in the top right