### PR TITLE
OCLOMRS-287: Make the released versions table actions links look more distinct from each other

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
@@ -17,7 +17,7 @@ const DictionaryVersionsTable = (version) => {
     <tr id="versiontable">
       <td>{id}</td>
       <td>{ (new Date(updated_on)).toLocaleDateString('en-US', DATE_OPTIONS)}</td>
-      <td><a href={version_url}>Browse in OCL</a> <Link className="downloadConcepts" onClick={download} to="#">Download</Link> <Link className="subscription-link" onClick={() => { showSubModal(version_url); }} to="#">Subscription URL</Link></td>
+      <td><button type="button"><a href={version_url}>Browse in OCL</a></button><button type="button"><Link className="downloadConcepts" onClick={download} to="#">Download</Link></button><button type="button"><Link className="subscription-link" onClick={() => { showSubModal(version_url); }} to="#">Subscription URL</Link></button></td>
       <td className="d-none">
         <SubscriptionModal
           show={show}


### PR DESCRIPTION

# JIRA TICKET NAME:
[OCLOMRS-287: Make the released versions table actions links look more distinct from each other](https://issues.openmrs.org/browse/OCLOMRS-287)


# Summary:
There are three links in released versions table, but they appear as one link. After this the link should be distinctive.
