### PR TITLE
OCLOMRS-271: Fix bad UX issues while escaping the create new dictionary form modal

### DIFF
--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -56,9 +56,7 @@ export class DictionaryModal extends React.Component {
     if (Object.keys(errors).length === 0) {
       this.props
         .submit(this.state.data)
-        .then(() => {
-          this.props.modalhide();
-        })
+        .then(() => this.hideModal())
         .catch((error) => {
           if (error.response) {
             this.setState({
@@ -169,6 +167,26 @@ export class DictionaryModal extends React.Component {
     return errors;
   };
 
+  hideModal = () => {
+    this.setState({
+      data: {
+        id: '',
+        preferred_source: 'CIEL',
+        public_access: 'View',
+        name: '',
+        owner: '',
+        description: '',
+        default_locale: 'en',
+        supported_locales: '',
+        repository_type: 'OpenMRSDictionary',
+        conceptUrl: '',
+      },
+      errors: {},
+      supportedLocalesOptions: [],
+    });
+    this.props.modalhide();
+  }
+
   render() {
     const { data, errors } = this.state;
     const {
@@ -180,10 +198,11 @@ export class DictionaryModal extends React.Component {
       <div>
         <Modal
           isOpen={this.props.show}
-          onClosed={this.props.modalhide}
+          onClosed={this.hideModal}
           className="modal-lg"
+          backdrop="static"
         >
-          <ModalHeader className="modal-heading">
+          <ModalHeader className="modal-heading" toggle={this.hideModal}>
             {this.props.title}
           </ModalHeader>
           {errors && <InlineError text={this.errors} />}
@@ -373,7 +392,7 @@ export class DictionaryModal extends React.Component {
             <Button
               className="btn btn-outline-danger test-btn-cancel"
               id="cancel"
-              onClick={this.props.modalhide}
+              onClick={this.hideModal}
             >
               Cancel
             </Button>


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix bad UX issues while escaping the create new dictionary form modal](https://issues.openmrs.org/browse/OCLOMRS-271)

# Summary:
Bad UX: Create a new dictionary, and add another language. The multi-select widget remains open, so I press Esc (thinking this will close the multi-select) but this closes the entire modal popup and discards my info. Even clicking outside of the modal in the gray area closes it and discards the form. This is bad UX for a form in a modal. Instead, the modal should only be dismissable via the Cancel button at the bottom of the form.

In fact, the form is not entirely cleared when closing the form (either via Cancel or clicking outside the modal): the Visibility and Dictionary Name fields stay filled, but the Other Languages multi-select is cleared. If the form is canceled, all data should be discarded.