### PR TITLE
OCLOMRS-291: Minimize the height of the select input

### DIFF
--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -236,10 +236,6 @@ input:-webkit-autofill:active {
   text-align: left;
 }
 
-select.form-control {
-  height: 3rem !important;
-}
-
 .concept-form-table .form-control:not(textarea) {
   height: 2.4rem !important;
   background: #fafafa;


### PR DESCRIPTION
# JIRA TICKET NAME:
[Minimize the height of the select input](https://issues.openmrs.org/browse/OCLOMRS-291)

# Summary:
In the application, the select input height is more than other input text elements of the form. This should be fixed.
