### PR TITLE
OCLOMRS-289: Fix release version modal form

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -207,7 +207,7 @@ export class DictionaryOverview extends Component {
               handleChange={this.handleChange}
               handleCreateVersion={this.handleCreateVersion}
               versionId={this.state.versionId}
-              versionDescription={this.state.versionId}
+              versionDescription={this.state.versionDescription}
               inputLength={inputLength}
               download={this.download}
             />

--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -38,6 +38,8 @@ const DictionaryDetailCard = (props) => {
     openVersionModal,
     handleCreateVersion,
     handleChange,
+    versionDescription,
+    versionId,
     inputLength,
     download,
   } = props;
@@ -194,6 +196,8 @@ const DictionaryDetailCard = (props) => {
         click={hideVersionModal}
         handleCreateVersion={handleCreateVersion}
         handleChange={handleChange}
+        versionId={versionId}
+        versionDescription={versionDescription}
         inputLength={inputLength}
       />
     </div>
@@ -222,6 +226,8 @@ DictionaryDetailCard.propTypes = {
   handleChange: PropTypes.func.isRequired,
   inputLength: PropTypes.number.isRequired,
   download: PropTypes.func.isRequired,
+  versionDescription: PropTypes.string.isRequired,
+  versionId: PropTypes.string.isRequired,
 };
 
 export default DictionaryDetailCard;


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-289: Fix release version modal form](https://issues.openmrs.org/browse/OCLOMRS-289)

# Summary:
The release version form text inputs don't accept user text inputs. This should be fixed so that the user can enter custom version number and description