### PR TITLE
OCLOMRS-296: Fix the delete dictionary concept modal not showing

### DIFF
--- a/src/components/dictionaryConcepts/components/ActionButtons.jsx
+++ b/src/components/dictionaryConcepts/components/ActionButtons.jsx
@@ -21,8 +21,6 @@ const ActionButtons = ({
         type="button"
         className="btn btn-sm mb-1 actionButtons"
         id="retireConcept"
-        data-toggle="modal"
-        data-target="#removeConceptModal"
         onClick={() => { showDeleteModal(version_url); }}
       >
       Remove

--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -6,7 +6,8 @@ import RenderTable from './RenderTable';
 import { conceptsProps } from '../proptypes';
 
 const ConceptTable = ({
-  concepts, loading, org, locationPath, showDeleteModal, url, handleDelete,
+  concepts, loading, org, locationPath, showDeleteModal, url,
+  handleDelete, openDeleteModal, closeDeleteModal,
 }) => {
   if (loading) {
     return (
@@ -45,8 +46,9 @@ const ConceptTable = ({
                 showDeleteModal={showDeleteModal}
                 url={url}
                 handleDelete={handleDelete}
-              />
-            ))}
+                openDeleteModal={openDeleteModal}
+                closeDeleteModal={closeDeleteModal}
+              />))}
           </tbody>
         </table>
       </div>
@@ -72,7 +74,14 @@ ConceptTable.propTypes = {
   locationPath: PropTypes.object.isRequired,
   showDeleteModal: PropTypes.func.isRequired,
   handleDelete: PropTypes.func.isRequired,
-  url: PropTypes.string.isRequired,
+  url: PropTypes.string,
+  openDeleteModal: PropTypes.bool,
+  closeDeleteModal: PropTypes.func.isRequired,
+};
+
+ConceptTable.defaultProps = {
+  openDeleteModal: false,
+  url: '',
 };
 
 export default ConceptTable;

--- a/src/components/dictionaryConcepts/components/RemoveConcept.jsx
+++ b/src/components/dictionaryConcepts/components/RemoveConcept.jsx
@@ -1,63 +1,33 @@
 import React from 'react';
+import { Button, Modal, ModalHeader, ModalFooter } from 'reactstrap';
 import PropTypes from 'prop-types';
 
 const removeConcept = (props) => {
-  const { handleDelete } = props;
+  const { handleDelete, openDeleteModal, closeDeleteModal } = props;
   return (
     <div>
-      <div
-        className="container modal fade"
-        id="removeConceptModal"
-        tabIndex="-1"
-        role="dialog"
-        aria-labelledby="exampleModalLabel"
-        aria-hidden="true"
-      >
-        <div className="container modal-dialog" role="document">
-          <div className="modal-content">
-            <div className="modal-header">
-              <p className="modal-title" id="exampleModalLabel">
-                  Are you sure you want to Remove this Concept?
-              </p>
-              <button
-                type="button"
-                className="close"
-                data-dismiss="modal"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-            <div>
-              <form>
-                <div className="modal-footer" type="submit">
-                  <button
-                    type="button"
-                    className="btn btn-secondary"
-                    data-dismiss="modal"
-                  >
-                  Cancel
-                  </button>
-                  <button
-                    type="button"
-                    data-dismiss="modal"
-                    className="btn btn-danger"
-                    onClick={handleDelete}
-                  >
-                  Remove Concept
-                  </button>
-                </div>
-              </form>
-            </div>
-
-          </div>
-        </div>
-      </div>
+      <Button color="danger" onClick={closeDeleteModal}>Label</Button>
+      <Modal isOpen={openDeleteModal} toggle={closeDeleteModal}>
+        <ModalHeader toggle={closeDeleteModal}>
+        Are you sure you want to Remove this Concept?
+        </ModalHeader>
+        <ModalFooter>
+          <Button color="danger" onClick={handleDelete}>Remove concept</Button>{' '}
+          <Button color="secondary" onClick={closeDeleteModal}>Cancel</Button>
+        </ModalFooter>
+      </Modal>
     </div>
   );
 };
+
 removeConcept.propTypes = {
   handleDelete: PropTypes.func.isRequired,
+  closeDeleteModal: PropTypes.func.isRequired,
+  openDeleteModal: PropTypes.bool,
+};
+
+removeConcept.defaultProps = {
+  openDeleteModal: false,
 };
 
 export default removeConcept;

--- a/src/components/dictionaryConcepts/components/TableItem.jsx
+++ b/src/components/dictionaryConcepts/components/TableItem.jsx
@@ -17,6 +17,8 @@ const TableItem = (props) => {
     locationPath,
     handleDelete,
     url,
+    openDeleteModal,
+    closeDeleteModal,
   } = props;
   const renderButtons = username === owner || (owner === org.name && org.userIsMember);
   return (
@@ -37,6 +39,8 @@ const TableItem = (props) => {
             conceptUrl={url}
             conceptType={locationPath.type}
             handleDelete={handleDelete}
+            openDeleteModal={openDeleteModal}
+            closeDeleteModal={closeDeleteModal}
           />
         </td>
       </tr>

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -15,9 +15,7 @@ import {
   filterByClass,
   paginateConcepts,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
-import {
-  removeDictionaryConcept,
-} from '../../../redux/actions/dictionaries/dictionaryActionCreators';
+import { removeDictionaryConcept } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import { fetchMemberStatus } from '../../../redux/actions/user/index';
 
 export class DictionaryConcepts extends Component {
@@ -58,6 +56,7 @@ export class DictionaryConcepts extends Component {
       data: {
         references: [],
       },
+      openDeleteModal: false,
     };
     autoBind(this);
   }
@@ -66,14 +65,6 @@ export class DictionaryConcepts extends Component {
     setTimeout(this.fetchConcepts, 600);
     this.checkMembershipStatus(getUsername());
   }
-
-  handleDelete = () => {
-    const { data, collectionName, type } = this.state;
-    this.props
-      .removeDictionaryConcept(data, type, this.props.match.params.typeName, collectionName);
-  }
-
-  handleShowDelete = (url) => { this.setState({ data: { references: [url] }, versionUrl: url }); };
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     const {
@@ -180,6 +171,20 @@ export class DictionaryConcepts extends Component {
     }
   }
 
+  handleDelete = () => {
+    const { data, collectionName, type } = this.state;
+    this.props
+      .removeDictionaryConcept(data, type, this.props.match.params.typeName, collectionName);
+  }
+
+  handleShowDelete = (url) => {
+    this.setState({ data: { references: [url] }, versionUrl: url, openDeleteModal: true });
+  };
+
+  closeDeleteModal = () => {
+    this.setState({ openDeleteModal: false });
+  }
+
   render() {
     const {
       match: {
@@ -198,7 +203,7 @@ export class DictionaryConcepts extends Component {
       userIsMember,
     };
     const {
-      conceptsCount, searchInput, conceptOffset, conceptLimit,
+      conceptsCount, searchInput, conceptOffset, conceptLimit, openDeleteModal,
     } = this.state;
     localStorage.setItem('dictionaryPathName', pathname);
     return (
@@ -237,6 +242,8 @@ export class DictionaryConcepts extends Component {
               showDeleteModal={this.handleShowDelete}
               url={this.state.versionUrl}
               handleDelete={this.handleDelete}
+              openDeleteModal={openDeleteModal}
+              closeDeleteModal={this.closeDeleteModal}
             />
           </div>
         </section>

--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -127,8 +127,74 @@ describe('Test suite for dictionary concepts components', () => {
     </Provider>);
     expect(wrapper).toBeDefined();
     wrapper.find('.btn.btn-sm.mb-1.actionButtons').simulate('click');
-    wrapper.find('.btn.btn-danger').simulate('click');
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should change open and close delete modal', () => {
+    const props = {
+      match: {
+        params: {
+          typeName: 'dev-col',
+          type: 'orgs',
+          collectionName: 'dev-col',
+          dictionaryName: 'dev-col',
+        },
+      },
+      location: {
+        pathname: '/random/path',
+      },
+      fetchDictionaryConcepts: jest.fn(),
+      concepts: [concepts],
+      filteredClass: ['Diagnosis'],
+      filteredSources: ['CIEL'],
+      loading: false,
+      filterBySource: jest.fn(),
+      filterByClass: jest.fn(),
+      fetchMemberStatus: jest.fn(),
+      paginateConcepts: jest.fn(),
+      totalConceptCount: 20,
+      userIsMember: true,
+      removeDictionaryConcept: jest.fn(),
+    };
+    const wrapper = shallow(<DictionaryConcepts {...props} />);
+    wrapper.setState({ versionUrl: 'url' });
+    wrapper.update();
+    const instance = wrapper.instance();
+    instance.handleShowDelete();
+    expect(wrapper.state().openDeleteModal).toBe(true);
+    instance.closeDeleteModal();
+    expect(wrapper.state().openDeleteModal).toBe(false);
+  });
+
+  it('it should call the handle delete function', () => {
+    const props = {
+      match: {
+        params: {
+          typeName: 'dev-col',
+          type: 'orgs',
+          collectionName: 'dev-col',
+          dictionaryName: 'dev-col',
+        },
+      },
+      location: {
+        pathname: '/random/path',
+      },
+      fetchDictionaryConcepts: jest.fn(),
+      concepts: [concepts],
+      filteredClass: ['Diagnosis'],
+      filteredSources: ['CIEL'],
+      loading: false,
+      filterBySource: jest.fn(),
+      filterByClass: jest.fn(),
+      fetchMemberStatus: jest.fn(),
+      paginateConcepts: jest.fn(),
+      totalConceptCount: 20,
+      userIsMember: true,
+      removeDictionaryConcept: jest.fn(),
+    };
+    const wrapper = shallow(<DictionaryConcepts {...props} />);
+    const instance = wrapper.instance();
+    expect(instance.handleDelete()).toEqual(undefined);
   });
 
   it('should filter search result', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix the delete dictionary concept modal not showing](https://issues.openmrs.org/browse/OCLOMRS-296)

# Summary:
Currently, when a user clicks the "remove" button in the concepts table, only a backdrop shows. The backdrop also doesn't disappear unless the user the refreshes the application.

