### PR TITLE
OCLOMRS-302: Fix the edit dictionary modal

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -54,9 +54,7 @@ export class DictionaryOverview extends Component {
     this.props.fetchDictionary(url);
     this.props.fetchVersions(versionUrl);
 
-    const conceptsUrl = `
-      /${ownerType}/${owner}/collections/${name}/concepts/?q=&limit=0&page=1&verbose=true
-    `;
+    const conceptsUrl = `/${ownerType}/${owner}/collections/${name}/concepts/?q=&limit=0&page=1&verbose=true`;
     this.props.fetchDictionaryConcepts(conceptsUrl);
   }
 

--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -126,7 +126,7 @@ Dictionary
             </p>
             {owner === username && (
               <button
-                type="submit"
+                type="button"
                 className="btn btn-secondary"
                 id="editB"
                 onClick={showEditModal}


### PR DESCRIPTION
# JIRA TICKET NAME:
[ Fix the edit dictionary modal](https://issues.openmrs.org/browse/OCLOMRS-302)

# Summary:
For now, if a user clicks on edit dictionary button, the modal doesn't show up. This has to be fixed to work as expected and the modal form should have current dictionary details.