### PR TITLE
OCLOMRS-285: Make the Hamburger button on the mobile view more visible

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -29,6 +29,10 @@
   background-color: rgba(0, 0, 0, 0.856) !important;
 }
 
+.navbar-light .navbar-toggler-icon {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(255,255,255, 1)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E");
+}
+
 @media only screen and (max-width: 992px) {
   .nav-item.nav-link:hover {
     color: #ccc !important;


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make the Hamburger button on the mobile view more visible](https://issues.openmrs.org/browse/OCLOMRS-285)

# Summary:
The Hamberger button that appears on smaller screen sizes has no contrast with the navbar background color (both of them are black). This makes it hard for a user to easily realize its presence. Use of a white Hamberger button would fix this issue.