### PR TITLE
OCLOMRS-276: Fix placeholder text color

### DIFF
--- a/src/styles/all.scss
+++ b/src/styles/all.scss
@@ -1,3 +1,4 @@
+@import './custom_variables.scss';
 @import 'bootstrap/scss/bootstrap';
 @import './app';
 @import './bulk_concepts';

--- a/src/styles/custom_variables.scss
+++ b/src/styles/custom_variables.scss
@@ -1,0 +1,1 @@
+$input-placeholder-color: rgba(0,0,0,0.4);

--- a/src/styles/dashboard.scss
+++ b/src/styles/dashboard.scss
@@ -508,7 +508,7 @@ p{
 }
 
 #generalSearch::placeholder{
-  color: #f5f5f594;
+  color: #f5f5f5e3;
 }
 
 #container{


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-276: Fix placeholder text color](https://issues.openmrs.org/browse/OCLOMRS-276)

# Summary:
Placeholder text in fields is too dark and looks like an entry value. After this fix, it should be a lighter grey.