### PR TITLE
OCLOMRS-299: Release version button should be one

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -196,31 +196,21 @@ Dictionary
 Browse in traditional OCL
                 </a>
               </li>
-              { owner === username && !headVersion.released
-                ? (
-                  <li>
-                    <button
-                      type="button"
-                      onClick={handleRelease}
-                      className="fas fa-cloud-upload-alt head"
-                    >
-                      <span id="release-head"> Release HEAD as new version</span>
-                    </button>
-                  </li>
-                )
-                : null}
-
               { owner === username
                 ? (
                   <li>
                     <button
                       type="button"
-                      onClick={showVersionModal}
-                      className="fas fa-cloud-upload-alt version"
+                      onClick={!headVersion.released ? handleRelease : showVersionModal}
+                      className="fas fa-cloud-upload-alt head"
+                      id="releaseVersion"
                     >
-                      <span id="release-head"> Release a new version</span>
+                      <span id="release-head">
+                        &nbsp;Release&nbsp;
+                        {!headVersion.released ? 'latest ' : null}
+                        version
+                      </span>
                     </button>
-                    {' '}
                   </li>
                 )
                 : null}

--- a/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
@@ -15,7 +15,7 @@ const DictionaryVersionsTable = (version) => {
   };
   return (
     <tr id="versiontable">
-      <td>{id}</td>
+      <td>{id === 'HEAD' ? 'Latest' : id}</td>
       <td>{ (new Date(updated_on)).toLocaleDateString('en-US', DATE_OPTIONS)}</td>
       <td>
         <a href={version_url}>Browse in OCL</a>

--- a/src/components/dashboard/components/dictionary/common/ReleaseVersionModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/ReleaseVersionModal.jsx
@@ -50,7 +50,7 @@ const ReleaseVersionModal = (props) => {
             ? (
               <Button
                 className="btn-sm btn-outline-info version"
-                id="addDictionary"
+                id="saveReleaseVersion"
                 onClick={handleCreateVersion}
               >
                Release

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -350,9 +350,9 @@ describe('DictionaryOverview', () => {
   it('should handle a new version release', () => {
     const props = {
       dictionary,
-      versions: [customVersion],
+      versions: [{ released: true, ...versions, customVersion }],
       dictionaryConcepts: [dictionary],
-      isReleased: false,
+      isReleased: true,
       hideVersionModal: jest.fn(),
       showVersionModal: jest.fn(),
       error: [],
@@ -384,16 +384,16 @@ describe('DictionaryOverview', () => {
       <MemoryRouter><DictionaryOverview {...props} /></MemoryRouter>
     </Provider>);
     const spy = jest.spyOn(wrapper.find('DictionaryOverview').instance(), 'handleCreateVersion');
-    wrapper.find('.fas.fa-cloud-upload-alt.version').simulate('click');
-    wrapper.find('#versionId').at(0).simulate('change', event);
-    wrapper.find('.btn-sm.btn-outline-info.version').at(0).simulate('click');
+    wrapper.find('#releaseVersion').simulate('click');
+    wrapper.find('Input #versionId').simulate('change', event);
+    wrapper.find('Button #saveReleaseVersion').simulate('click');
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('should handleChange', () => {
     const props = {
       dictionary,
-      versions: [customVersion],
+      versions: [{ released: true, ...versions, customVersion }],
       dictionaryConcepts: [dictionary],
       isReleased: false,
       hideVersionModal: jest.fn(),
@@ -426,8 +426,8 @@ describe('DictionaryOverview', () => {
       <MemoryRouter><DictionaryOverview {...props} /></MemoryRouter>
     </Provider>);
     const spy = jest.spyOn(wrapper.find('DictionaryOverview').instance(), 'handleChange');
-    wrapper.find('.fas.fa-cloud-upload-alt.version').simulate('click');
-    wrapper.find('#versionId').at(0).simulate('change', event);
+    wrapper.find('#releaseVersion').simulate('click');
+    wrapper.find('Input #versionId').simulate('change', event);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[Release version button should be one](https://issues.openmrs.org/browse/OCLOMRS-299)

# Summary:
On dictionary details page, there are two buttons to release version. Release version and release HEAD version, We should have one button instead and initially, it should say release Latest version instead of release HEAD version.