### PR TITLE
OCLOMRS-304: Add CIEL concepts in the add Bulk concept page

### DIFF
--- a/src/components/bulkConcepts/bulkConceptList.jsx
+++ b/src/components/bulkConcepts/bulkConceptList.jsx
@@ -3,21 +3,24 @@ import PropTypes from 'prop-types';
 import BulkConceptTable from './bulkConceptTable';
 import Loader from '../Loader';
 
-const BulkConceptList = ({ cielConcepts, fetching }) => {
+const BulkConceptList = ({ cielConcepts, fetching, handleSelect }) => {
   if (cielConcepts.length >= 1) {
     return (
       <table className="table table-bordered table-striped">
         <thead className="header text-white">
           <tr>
-            <th scope="col">concept ID</th>
-            <th scope="col">concept Name</th>
+            <th scope="col">Select</th>
+            <th scope="col">Name</th>
+            <th scope="col">Datatype</th>
+            <th scope="col">Source</th>
+            <th scope="col">ID</th>
           </tr>
 
         </thead>
         <tbody>
 
           {cielConcepts.map(concept => (
-            <BulkConceptTable concept={concept} key={concept.id} />
+            <BulkConceptTable concept={concept} key={concept.id} handleSelect={handleSelect} />
           ))}
         </tbody>
       </table>
@@ -41,5 +44,6 @@ BulkConceptList.propTypes = {
   cielConcepts: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string,
   })).isRequired,
+  handleSelect: PropTypes.func.isRequired,
 };
 export default BulkConceptList;

--- a/src/components/bulkConcepts/bulkConceptTable.jsx
+++ b/src/components/bulkConcepts/bulkConceptTable.jsx
@@ -5,12 +5,29 @@ const BulkConceptTable = (concept) => {
     concept: {
       id,
       display_name,
+      datatype,
+      sources,
+      url,
     },
+    handleSelect,
   } = concept;
   return (
     <tr className="concept-table">
-      <td>{id}</td>
+      <td>
+        <div className="custom-control custom-checkbox">
+          <input
+            type="checkbox"
+            className="table-check"
+            value={url}
+            onChange={handleSelect}
+          />
+        </div>
+      </td>
+
       <td>{display_name}</td>
+      <td>{datatype}</td>
+      <td>{sources}</td>
+      <td>{id}</td>
     </tr>
   );
 };

--- a/src/components/bulkConcepts/component/Paginations.jsx
+++ b/src/components/bulkConcepts/component/Paginations.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 
 const Paginations = props => (
   <div className="row mt-2 pagination-container">
-    <div className="space-between">
-      <p>
-        <i>
+    {props.totalConcepts > 1 ?
+      <div className="space-between">
+        <p>
         Showing
           {' '}
           {props.firstConceptIndex}
@@ -17,10 +17,9 @@ of
           {props.totalConcepts}
           {' '}
 concepts
-        </i>
-      </p>
-      <span className="paginate-controllers">
-        {props.currentPage > 1
+        </p>
+        <span className="paginate-controllers">
+          {props.currentPage > 1
           ? (
             <i
               className="fas fa-angle-double-left prev"
@@ -34,8 +33,8 @@ concepts
               role="presentation"
             />
           ) }
-        <span className="badge badge-light"><h6>{props.currentPage}</h6></span>
-        {props.currentPage < props.lastPage
+          <span className="badge badge-light"><h6>{props.currentPage}</h6></span>
+          {props.currentPage < props.lastPage
           ? (
             <i
               className="fas fa-angle-double-right nxt"
@@ -49,8 +48,8 @@ concepts
               role="presentation"
             />
           ) }
-      </span>
-    </div>
+        </span>
+      </div> : null}
   </div>
 );
 

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -188,7 +188,9 @@ export class DictionaryConcepts extends Component {
   render() {
     const {
       match: {
-        params: { type, typeName },
+        params: {
+          type, typeName, dictionaryName, collectionName,
+        },
       },
       location: { pathname },
       concepts,
@@ -213,7 +215,13 @@ export class DictionaryConcepts extends Component {
           <div className="col-12 col-md-2 pt-1">
             <h4>Concepts</h4>
           </div>
-          {hasPermission && <ConceptDropdown pathName={pathname} />}
+          {hasPermission && <ConceptDropdown
+            pathName={pathname}
+            type={type}
+            typeName={typeName}
+            dictionaryName={dictionaryName}
+            collectionName={collectionName}
+          />}
         </section>
 
         <section className="row mt-3">

--- a/src/redux/actions/bulkConcepts/index.js
+++ b/src/redux/actions/bulkConcepts/index.js
@@ -5,7 +5,7 @@ import { FETCH_CIEL_CONCEPTS, ADD_EXISTING_BULK_CONCEPTS } from '../types';
 
 const fetchCielConcepts = () => async (dispatch) => {
   dispatch(isFetching(true));
-  const url = 'orgs/CIEL/sources/CIEL/concepts/';
+  const url = 'orgs/CIEL/sources/CIEL/concepts/?limit=0';
   try {
     const response = await instance.get(url);
     dispatch(isSuccess(response.data, FETCH_CIEL_CONCEPTS));
@@ -17,21 +17,22 @@ const fetchCielConcepts = () => async (dispatch) => {
 };
 export default fetchCielConcepts;
 
-export const addExistingBulkConcepts = data => async (dispatch) => {
-  const typeName = localStorage.getItem('typeName');
-  const dictionaryId = localStorage.getItem('dictionaryId');
-  const userType = localStorage.getItem('type');
-  const url = `${userType}/${typeName}/collections/${dictionaryId}/references/`;
-  const payload = await instance.put(url, data);
-  dispatch(isSuccess(payload.data, ADD_EXISTING_BULK_CONCEPTS));
-  const justAddedConcepts = payload.data.filter(concept => concept.added).length;
-  const alreadyAddedConcepts = payload.data.length - justAddedConcepts;
-  notify.show(
-    `
-    Added ${justAddedConcepts} concept(s) skipped ${alreadyAddedConcepts} that were already added
-    `, 'success', 3000,
-  );
+export const addExistingBulkConcepts = conceptData => async (dispatch) => {
+  const { url, data } = conceptData;
+  try {
+    const payload = await instance.put(url, data);
+    dispatch(isSuccess(payload.data, ADD_EXISTING_BULK_CONCEPTS));
+    const existing = payload.data.filter(pay => pay.added === false);
+    if (existing.length > 0) {
+      notify.show(`Only ${payload.data.length - existing.length} of ${payload.data.length} concept(s) were added. Skipped ${existing.length} already added`, 'error', 3000);
+    } else {
+      notify.show(`${payload.data.length - existing.length} Concept(s) Added`, 'success', 3000);
+    }
+  } catch (error) {
+    notify.show(error, 'error', 3000);
+  }
 };
+
 
 export const addDictionaryReference = (conceptUrl, ownerUrl, dictionaryId) => async (dispatch) => {
   const url = `${ownerUrl}collections/${dictionaryId}/references/`;

--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -11,7 +11,7 @@ import {
 } from '../../types';
 
 export const fetchBulkConcepts = (source = 'CIEL') => async (dispatch) => {
-  const url = `orgs/${source}/sources/${source}/concepts/?limit=0&verbose=true`;
+  const url = `orgs/${source}/sources/${source}/concepts/?limit=0&&verbose=true`;
   dispatch(isFetching(true));
   try {
     const response = await instance.get(url);

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -1,5 +1,5 @@
 export default {
-  id: '146869',
+  id: '1468667',
   external_id: '146869AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
   concept_class: 'Diagnosis',
   datatype: 'N/A',
@@ -56,7 +56,7 @@ export const mockConcepts = (() => {
   const concepts = [];
   let i = 0;
   while (i < 30) {
-    const newConcept = { ...concept, version: String(i) };
+    const newConcept = { ...concept, id: String(i), version: String(i) };
     concepts.push(newConcept);
     i += 1;
   }

--- a/src/tests/bulkConcepts/actions/index.test.js
+++ b/src/tests/bulkConcepts/actions/index.test.js
@@ -3,9 +3,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import instance from '../../../config/axiosConfig';
-import {
-  FETCH_CIEL_CONCEPTS, IS_FETCHING, ADD_EXISTING_BULK_CONCEPTS,
-} from '../../../redux/actions/types';
+import { FETCH_CIEL_CONCEPTS, IS_FETCHING, ADD_EXISTING_BULK_CONCEPTS } from '../../../redux/actions/types';
 import
 fetchCielConcepts,
 { addExistingBulkConcepts, addDictionaryReference } from '../../../redux/actions/bulkConcepts';
@@ -121,4 +119,16 @@ describe('Test suite for ciel concepts actions', () => {
     return store.dispatch(addDictionaryReference(conceptUrl, ownerUrl, dictionaryId))
       .then(() => expect(store.getActions()).toEqual(expectedAction));
   });
+});
+it('dispatches an error when adding bulk concepts', () => {
+  moxios.wait(() => {
+    const request = moxios.requests.mostRecent();
+    request.reject({
+      status: 400,
+    });
+  });
+  const data = { expressions: ['/orgs/WHO/sources/ICD-10/concepts/A15.1/'] };
+  const store = mockStore({});
+  return store.dispatch(addExistingBulkConcepts(data))
+    .catch(() => expect(store.getActions()).toEqual(returnedAction));
 });

--- a/src/tests/bulkConcepts/addBulkConcepts.test.jsx
+++ b/src/tests/bulkConcepts/addBulkConcepts.test.jsx
@@ -5,8 +5,18 @@ import { Provider } from 'react-redux';
 import { createMockStore } from 'redux-test-utils';
 import Authenticated from '../__mocks__/fakeStore';
 import { AddBulkConcepts } from '../../components/bulkConcepts/addBulkConcepts';
+import { mockConcepts } from '../__mocks__/concepts';
 
 const store = createMockStore(Authenticated);
+const match = {
+  params: {
+    type: 'users',
+    typeName: 'mochu',
+    collectionName: 'andela',
+    language: 'en',
+    dictionaryName: 'WHO',
+  },
+};
 describe('Add Bulk Concepts', () => {
   beforeEach(() => {
     localStorage.setItem('dictionaryName', 'OpenMRS');
@@ -16,15 +26,7 @@ describe('Add Bulk Concepts', () => {
       fetchCielConcepts: jest.fn(),
       cielConcepts: [],
       isFetching: true,
-      match: {
-        params: {
-          type: 'users',
-          typeName: 'mochu',
-          collectionName: 'andela',
-          language: 'en',
-          dictionaryName: 'WHO',
-        },
-      },
+      match,
       addExistingBulkConcepts: jest.fn(),
     };
     const wrapper = mount(<MemoryRouter>
@@ -39,15 +41,7 @@ describe('Add Bulk Concepts', () => {
       fetchCielConcepts: jest.fn(),
       cielConcepts: [],
       isFetching: true,
-      match: {
-        params: {
-          type: 'users',
-          typeName: 'mochu',
-          collectionName: 'andela',
-          language: 'en',
-          dictionaryName: 'WHO',
-        },
-      },
+      match,
       addExistingBulkConcepts: jest.fn(),
     };
     const wrapper = mount(<MemoryRouter>
@@ -63,15 +57,7 @@ describe('Add Bulk Concepts', () => {
       addExistingBulkConcepts: jest.fn(),
       cielConcepts: [],
       isFetching: true,
-      match: {
-        params: {
-          type: 'users',
-          typeName: 'mochu',
-          collectionName: 'andela',
-          language: 'en',
-          dictionaryName: 'WHO',
-        },
-      },
+      match,
     };
     const wrapper = mount(<MemoryRouter>
       <Provider store={store}>
@@ -80,4 +66,109 @@ describe('Add Bulk Concepts', () => {
     </MemoryRouter>);
     wrapper.find('#btn-add-all').at(0).simulate('click');
   });
+});
+
+it('hanldleSelect is called and add concept', () => {
+  const props = {
+    fetchCielConcepts: jest.fn(),
+    addExistingBulkConcepts: jest.fn(),
+    cielConcepts: mockConcepts,
+    isFetching: true,
+    match,
+  };
+  const wrapper = mount(<MemoryRouter>
+    <Provider store={store}>
+      <AddBulkConcepts {...props} />
+    </Provider>
+  </MemoryRouter>);
+  const event = {
+    preventDefault: jest.fn(),
+    target: {
+      value: ['/users/michy/collections/test/concepts/'],
+      checked: true,
+    },
+  };
+  const spy = jest.spyOn(wrapper.find('AddBulkConcepts').instance(), 'handleSelect');
+  wrapper.instance().forceUpdate();
+  wrapper.find('#ciel').at(0).simulate('click');
+  wrapper.find('.table-check').at(0).simulate('change', event);
+  expect(spy).toHaveBeenCalledTimes(1);
+});
+it('hanldleSelect is called and remove a concept', () => {
+  const props = {
+    fetchCielConcepts: jest.fn(),
+    addExistingBulkConcepts: jest.fn(),
+    cielConcepts: mockConcepts,
+    isFetching: true,
+    match,
+  };
+  const wrapper = mount(<MemoryRouter>
+    <Provider store={store}>
+      <AddBulkConcepts {...props} />
+    </Provider>
+  </MemoryRouter>);
+  const event = {
+    preventDefault: jest.fn(),
+    target: {
+      value: ['/users/michy/collections/test/concepts/'],
+      checked: false,
+    },
+  };
+  const spy = jest.spyOn(wrapper.find('AddBulkConcepts').instance(), 'handleSelect');
+  wrapper.instance().forceUpdate();
+  wrapper.find('#ciel').at(0).simulate('click');
+  wrapper.find('.table-check').at(0).simulate('change', {
+    preventDefault: jest.fn(),
+    target: {
+      value: ['/users/michy/collections/test/concepts/'],
+      checked: true,
+    },
+  });
+  wrapper.find('.table-check').at(0).simulate('change', event);
+  expect(spy).toHaveBeenCalled();
+});
+it('it should call hanldleAddAll and add a concept', () => {
+  const props = {
+    fetchCielConcepts: jest.fn(),
+    addExistingBulkConcepts: jest.fn(),
+    cielConcepts: mockConcepts,
+    isFetching: true,
+    match,
+  };
+  const wrapper = mount(<MemoryRouter>
+    <Provider store={store}>
+      <AddBulkConcepts {...props} />
+    </Provider>
+  </MemoryRouter>);
+  const event = {
+    target: {
+      value: ['/users/michy/collections/test/concepts/'],
+      checked: true,
+    },
+  };
+  const spy = jest.spyOn(wrapper.find('AddBulkConcepts').instance(), 'handleAddAll');
+  wrapper.instance().forceUpdate();
+  wrapper.find('#ciel').at(0).simulate('click');
+  wrapper.find('.table-check').at(0).simulate('change', event);
+  wrapper.find('#btn-add-all').simulate('click');
+  expect(spy).toHaveBeenCalledTimes(1);
+});
+it('it calls hanldlePaginationClick', () => {
+  const props = {
+    fetchCielConcepts: jest.fn(),
+    addExistingBulkConcepts: jest.fn(),
+    cielConcepts: mockConcepts,
+    isFetching: true,
+    match,
+  };
+  const wrapper = mount(<MemoryRouter>
+    <Provider store={store}>
+      <AddBulkConcepts {...props} />
+    </Provider>
+  </MemoryRouter>);
+  const spy = jest.spyOn(wrapper.find('AddBulkConcepts').instance(), 'handlePaginationClick');
+  wrapper.instance().forceUpdate();
+  wrapper.find('#ciel').at(0).simulate('click');
+  wrapper.find('.fas.fa-angle-double-right.nxt').at(0).simulate('click');
+  expect(spy).toHaveBeenCalledTimes(1);
 });

--- a/src/tests/bulkConcepts/bulkConceptList.test.jsx
+++ b/src/tests/bulkConcepts/bulkConceptList.test.jsx
@@ -11,6 +11,7 @@ const store = createMockStore(Authenticated);
 describe('Bulk Concepts List', () => {
   const props = {
     fetchCielConcepts: jest.fn(),
+    handleSelect: jest.fn(),
     cielConcepts: [existingConcept],
     fetching: false,
   };


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-304: Add CIEL concepts in the add Bulk concept pagee](https://issues.openmrs.org/browse/OCLOMRS-304)

# Summary:
Currently, a user can only add all bulk CIEL concepts. This issue will enable a user to able to select the bulk concepts when adding in the add Bulk page.