### PR TITLE
OCLOMRS-301: Enable saving of different languages for concept name

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -57,13 +57,14 @@ class ConceptNameRows extends Component {
   updateState() {
     const { newRow } = this.props;
     const defaultLocale = locale.find(
-      currentLocale => currentLocale.value === this.props.pathName.language,
+      currentLocale => currentLocale.value === newRow.locale,
     );
     this.setState({
       ...this.state,
       uuid: newRow.uuid || '',
       name: newRow.name || '',
       locale: newRow.locale || defaultLocale,
+      locale_full: defaultLocale,
       name_type: newRow.name_type || 'Fully Specified',
       locale_preferred: newRow.locale_preferred || 'Yes',
     });

--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -55,10 +55,14 @@ class DescriptionRow extends Component {
 
   updateState() {
     const { newRow } = this.props;
+    const defaultLocale = locale.find(
+      currentLocale => currentLocale.value === newRow.locale,
+    );
     this.setState({
       ...this.state,
       uuid: newRow.uuid,
       locale: newRow.locale || 'en',
+      locale_full: defaultLocale,
       description: newRow.description,
     });
   }


### PR DESCRIPTION
OCLOMRS-301: Enable saving of different languages for concept name

# JIRA TICKET NAME:
[OCLOMRS-301: Enable saving of different languages for concept name](https://issues.openmrs.org/browse/OCLOMRS-301)

# Summary:
- Fix concept locale being displayed on edit form.
