### PR TITLE
OCLOMRS-306: Resize all dictionaries display and remove text area top padding

### DIFF
--- a/src/components/dashboard/components/dictionary/ListDictionaries.jsx
+++ b/src/components/dashboard/components/dictionary/ListDictionaries.jsx
@@ -17,7 +17,7 @@ const ListDictionaries = (props) => {
   if (dictionaries.length >= 1) {
     return (
       <div className="container">
-        <div className="row justify-content-center all-dictionaries">
+        <div className="row">
           {dictionaries.map(dictionary => (
             <Card dictionary={dictionary} key={dictionary.uuid} {...props} />
           ))}

--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -12,11 +12,6 @@
   padding-left: 5%;
 }
 
-.all-dictionaries {
-  margin-right: -8%;
-  margin-left: -8%;
-}
-
 body {
   background: rgba(230, 230, 230, 0.12);
 }
@@ -239,6 +234,10 @@ input:-webkit-autofill:active {
 .concept-form-table .form-control:not(textarea) {
   height: 2.4rem !important;
   background: #fafafa;
+}
+
+#concept-description {
+  padding-top: 0px !important;
 }
 
 .concept-form-table-link {


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-306: Resize all dictionaries display and remove text area top padding](https://issues.openmrs.org/browse/OCLOMRS-306)

# Summary:
1. Take a look at the home page dictionary display, change the dictionaries from the center display to one that follows each other.
2. Make the dictionaries in the all dictionaries navbar tab to appear the same way as the ones on the home page.
3. When creating a concept, remove the top padding on the description textarea
