### PR TITLE
OCLOMRS-305: Resize the logout button on the navbar

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -96,3 +96,7 @@
 #release-head {
   font-family: 'Roboto', sans-serif;
 }
+
+#navbarDropdown {
+  min-width: 100px !important;
+}


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-305: Resize the logout button on the navbar](https://issues.openmrs.org/browse/OCLOMRS-305)

# Summary:
Previously, the logout button stretches out of the navbar and it isn't appealing.
This was fixed in this PR. 