### PR TITLE
OCLOMRS-315: Make the subscription modal background to be lighter

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import DictionaryVersionsTable from './DictionaryVersionsTable';
 import ReleaseVersionModal from './common/ReleaseVersionModal';
+import SubscriptionModal from './common/SubscriptionModal';
 
 const DictionaryDetailCard = (props) => {
   const {
@@ -231,10 +232,7 @@ Browse in traditional OCL
                       <DictionaryVersionsTable
                         version={version}
                         key={version.id}
-                        hide={hideSubModal}
                         showSubModal={showSubModal}
-                        show={subModal}
-                        url={subUrl}
                         download={download}
                       />
                     ))
@@ -260,6 +258,11 @@ Browse in traditional OCL
         versionId={versionId}
         versionDescription={versionDescription}
         inputLength={inputLength}
+      />
+      <SubscriptionModal
+        show={subModal}
+        click={hideSubModal}
+        url={subUrl}
       />
     </div>
   );

--- a/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import SubscriptionModal from './common/SubscriptionModal';
 
 const DictionaryVersionsTable = (version) => {
   const {
@@ -8,7 +7,7 @@ const DictionaryVersionsTable = (version) => {
       id,
       updated_on,
       version_url,
-    }, hide, show, showSubModal, url, download,
+    }, showSubModal, download,
   } = version;
   const DATE_OPTIONS = {
     weekday: 'long', year: 'numeric', month: 'short', day: 'numeric',
@@ -29,13 +28,6 @@ const DictionaryVersionsTable = (version) => {
         >
           Subscription URL
         </Link>
-      </td>
-      <td className="d-none">
-        <SubscriptionModal
-          show={show}
-          click={hide}
-          url={url}
-        />
       </td>
     </tr>
   );


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make the subscription modal background to be lighter](https://issues.openmrs.org/browse/OCLOMRS-315)

# Summary:
The modal background on the subscription modal is too dark because multiple modals get stacked on top of each other depending on the number of `subscription URL` links. This gives the modal background an effect that makes it appear to be dark. Only a single modal should be displayed.