### PR TITLE
OCLOMRS-317: Make the released versions table actions links look more  distinct from each other

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
@@ -18,15 +18,11 @@ const DictionaryVersionsTable = (version) => {
       <td>{id === 'HEAD' ? 'Latest' : id}</td>
       <td>{ (new Date(updated_on)).toLocaleDateString('en-US', DATE_OPTIONS)}</td>
       <td>
-        <a href={version_url}>Browse in OCL</a>
+        <a className="btn btn-sm" href={version_url}>Browse in OCL</a>
         {' '}
-        <Link className="downloadConcepts" onClick={download} to="#">Download</Link>
+        <Link className="downloadConcepts btn btn-sm" onClick={download} to="#">Download</Link>
         {' '}
-        <Link
-          className="subscription-link"
-          onClick={() => { showSubModal(version_url); }}
-          to="#"
-        >
+        <Link className="subscription-link btn btn-sm" onClick={() => { showSubModal(version_url); }} to="#">
           Subscription URL
         </Link>
       </td>


### PR DESCRIPTION

# JIRA TICKET NAME:
[OCLOMRS-317: Make the released versions table actions links look more  distinct from each other](https://issues.openmrs.org/browse/OCLOMRS-317)

# Summary:
There are three links in released versions table, but they appear as one link. After this the link should be distinctive.