### PR TITLE
OCLOMRS-312: Resize the home page margin

### DIFF
--- a/src/styles/dashboard.scss
+++ b/src/styles/dashboard.scss
@@ -515,6 +515,9 @@ p{
   margin-left: -42px;
   margin-right: -42px;
 }
+.container{
+  max-width: 1300px;
+}
 
 @media (min-width: 576px){
 .offset-sm-1 {


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-312: Resize the home page margin](https://issues.openmrs.org/browse/OCLOMRS-312)

# Summary:
The home page margin is not aligned correctly. The margin should be consistent on the home page and all dictionaries