### PR TITLE
OCLOMRS-318: Create a custom error message when fetching dictionaries when offline

### DIFF
--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -18,6 +18,9 @@ import { filterPayload } from '../../reducers/util';
 import { addDictionaryReference } from '../bulkConcepts';
 import api from '../../api';
 
+const showNetworkError = () => (
+  notify.show('Network Error. Please try again later!', 'error', 6000));
+
 /* eslint-disable */
 export const createDictionary = data => async dispatch =>
   api.dictionaries
@@ -68,7 +71,8 @@ export const fetchDictionaries = () => (dispatch) => {
       dispatch(isFetching(false));
     })
     .catch((error) => {
-      dispatch(isErrored(error.response.data));
+      error.response ? dispatch(isErrored(error.response.data)):
+      showNetworkError();
       dispatch(isFetching(false));
     });
 };
@@ -102,7 +106,7 @@ export const removeDictionaryConcept = (data, type, owner, collectionId) => disp
   return api.dictionaries
     .removeDictionaryConcept(data, type, owner, collectionId)
     .then(
-      (payload) => { 
+      (payload) => {
       dispatch(removeConcept(data.references[0]));
       notify.show(
         'Successfully removed a concept from my dictionary',
@@ -137,7 +141,8 @@ export const fetchDictionaryConcepts = data => (dispatch) => {
       dispatch(isFetching(false));
       })
       .catch((error) => {
-        dispatch(isErrored(error.response.data));
+        error.response ? dispatch(isErrored(error.response.data)):
+        showNetworkError();
         dispatch(isFetching(false));
       });
 };

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -111,6 +111,24 @@ describe('Test suite for dictionary actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
+
+  it('should handle fetch dictionaries network error', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        status: 599,
+      });
+    });
+    const expectedActions = [
+      { payload: true, type: IS_FETCHING },
+      { payload: false, type: IS_FETCHING },
+    ];
+    const store = mockStore({ payload: {} });
+    return store.dispatch(fetchDictionaries('', 1000, 1, 'sortAsc=name', 'verbose=true')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
   it('should return an error message from the db', () => {
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();
@@ -171,6 +189,23 @@ describe('Test suite for dictionary actions', () => {
     return store.dispatch(
       fetchDictionaryConcepts('/users/chriskala/collections/over/'),
     ).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should handle fetch dictionary concepts network error', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        status: 599,
+      });
+    });
+    const expectedActions = [
+      { payload: true, type: IS_FETCHING },
+      { payload: false, type: IS_FETCHING },
+    ];
+    const store = mockStore({ payload: {} });
+    return store.dispatch(fetchDictionaryConcepts('/users/chriskala/collections/over/')).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });


### PR DESCRIPTION
# JIRA TICKET NAME: 
[Create a custom error message when fetching dictionaries when offline](https://issues.openmrs.org/browse/OCLOMRS-318)

# Summary:
Previously, when accessing all dictionaries or a single dictionary without internet in production mode, the loader could display infinitely. A typeError used to be displayed in development mode.
This is fixed by this PR.