### PR TITLE
OCLOMRS-320: Make reactstrap drop-downs work.

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -3,9 +3,25 @@ import Notification, { notify } from 'react-notify-toast';
 import { withRouter, Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import {
+  Collapse,
+  Navbar as Navigation,
+  NavbarToggler,
+  NavbarBrand,
+  Nav,
+  NavItem,
+  UncontrolledDropdown,
+  DropdownToggle,
+  DropdownMenu,
+  DropdownItem,
+} from 'reactstrap';
 import { logoutAction } from '../redux/actions/auth/authActions';
 
 export class Navbar extends Component {
+    state = {
+      isOpen: false,
+    };
+
   logoutUser = (event) => {
     event.preventDefault();
     this.props.logoutAction();
@@ -13,81 +29,55 @@ export class Navbar extends Component {
     notify.show('You Loggedout successfully', 'success', 3000);
   };
 
+  toggle = () => {
+    this.setState(prevState => ({
+      isOpen: !prevState.isOpen,
+    }));
+  }
+
   render() {
+    const { isOpen } = this.state;
+    const { loggedIn } = this.props;
     return (
       <div className="custom-bg-dark">
         <Notification options={{ zIndex: 10000, top: '200px' }} />
-        <nav className="navbar navbar-expand-lg navbar-light bg-dark custom-max-width">
-          <a className="nav-link navbar-brand" href="/">
-              OCL for OpenMRS
-          </a>
-          <button
-            className="navbar-toggler"
-            type="button"
-            data-toggle="collapse"
-            data-target="#navbarA"
-            aria-controls="navbarNavDropdown"
-            aria-expanded="false"
-            aria-label="Toggle navigation"
-          >
-            <span className="navbar-toggler-icon" />
-          </button>
-          <div className="collapse navbar-collapse " id="navbarA">
-            {this.props.loggedIn && (
-              <ul className="navbar-nav ml-auto" id="navList">
-                <li className="nav-item nav-link">
-                  <Link
-                    className="nav-link text-white"
-                    to="/home"
-                  >
-                      Home
-                  </Link>
-                </li>
-                <li className="nav-item nav-link">
-                  <Link
-                    className="nav-link text-white"
-                    to="/dashboard/dictionaries"
-                  >
-                      All Dictionaries
-                  </Link>
-                </li>
-                <li className="nav-item nav-link dropdown">
-                  <a
-                    className="nav-link dropdown-toggle text-white"
-                    href="!#"
-                    id="navbarDropdown"
-                    role="button"
-                    data-toggle="dropdown"
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                  >
+        <Navigation color="light" light expand="md" className="custom-max-width">
+          <NavbarBrand href="/">OCL for OpenMRS</NavbarBrand>
+          <NavbarToggler onClick={this.toggle} />
+          {loggedIn && (
+            <Collapse isOpen={isOpen} navbar>
+              <Nav className="ml-auto" navbar>
+                <NavItem>
+                  <Link className="nav-link text-white" to="/home">Home</Link>
+                </NavItem>
+                <NavItem>
+                  <Link className="nav-link text-white" to="/dashboard/dictionaries">All Dictionaries</Link>
+                </NavItem>
+                <UncontrolledDropdown nav inNavbar>
+                  <DropdownToggle nav caret className="text-white">
                     <span className="fa fa-user" />
-                    {' '}
+                  &nbsp;
                     {localStorage.getItem('username') || this.props.user.username}
-                    {' '}
-                  </a>
-                  <div
-                    className="dropdown-menu"
-                    aria-labelledby="navbarDropdown"
-                    id="navbarDropdown"
-                  >
-                    <button
-                      type="submit"
-                      className="dropdown-item nav-link"
-                      onClick={this.logoutUser}
-                    >
-                      <strong>
+                  </DropdownToggle>
+                  <DropdownMenu right>
+                    <DropdownItem>
+                      <a
+                        type="submit"
+                        className="dropdown-item nav-link"
+                        onClick={this.logoutUser}
+                      >
+                        <strong>
                         Logout
-                        {' '}
-                        <i className="fa fa-sign-out" />
-                      </strong>
-                    </button>
-                  </div>
-                </li>
-              </ul>
-            )}
-          </div>
-        </nav>
+                          {' '}
+                          <i className="fa fa-sign-out" />
+                        </strong>
+                      </a>
+                    </DropdownItem>
+                  </DropdownMenu>
+                </UncontrolledDropdown>
+              </Nav>
+            </Collapse>)}
+        </Navigation>
       </div>
     );
   }

--- a/src/components/dictionaryConcepts/components/ConceptDropdown.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptDropdown.jsx
@@ -1,65 +1,80 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import {
+  UncontrolledDropdown, DropdownToggle, DropdownMenu, DropdownItem,
+} from 'reactstrap';
 
 const ConceptDropdown = props => (
   <div className="col-12 col-md-10 concept-dropdown">
     <div className="btn-group concept-btn">
-      <button
-        className="btn btn-outline-dark dropdown-toggle rounded-edge"
-        type="button"
-        data-toggle="dropdown"
-        aria-haspopup="true"
-        aria-expanded="false"
-      >
-        Add existing concepts
-      </button>
-      <div className="dropdown-menu" aria-labelledby="dropdownMenuButton">
-        <Link className="dropdown-item" to={`/import${props.pathName}`}>
+      <UncontrolledDropdown>
+        <DropdownToggle className="rounded-edge" caret>
+      Add existing concepts
+        </DropdownToggle>
+        <DropdownMenu>
+          <DropdownItem>
+            <Link className="dropdown-item" to={`/import${props.pathName}`}>
           Add CIEL concepts
-        </Link>
-        <Link to={`/bulk${props.pathName}`} className="dropdown-item">
+            </Link>
+          </DropdownItem>
+          <DropdownItem>
+            <Link to={`/bulk${props.pathName}`} className="dropdown-item">
           Bulk add concepts
-        </Link>
-      </div>
+            </Link>
+          </DropdownItem>
+        </DropdownMenu>
+      </UncontrolledDropdown>
     </div>
 
     <div className="btn-group concept-btn">
-      <button
-        className="btn btn-outline-dark dropdown-toggle rounded-edge"
-        type="button"
-        data-toggle="dropdown"
-        aria-haspopup="true"
-        aria-expanded="false"
-      >
+      <UncontrolledDropdown>
+        <DropdownToggle className="rounded-edge" caret>
         Create new concept
-      </button>
-      <div className="dropdown-menu" aria-labelledby="dropdownMenuButton">
-        <Link className="dropdown-item" to={`/new/diagnosis${props.pathName}`}>
+        </DropdownToggle>
+        <DropdownMenu>
+          <DropdownItem>
+            <Link className="dropdown-item" to={`/new/diagnosis${props.pathName}`}>
           Create a Diagnosis concept
-        </Link>
-        <Link className="dropdown-item" to={`/new/symptom-finding${props.pathName}`}>
+            </Link>
+          </DropdownItem>
+          <DropdownItem>
+            <Link className="dropdown-item" to={`/new/symptom-finding${props.pathName}`}>
           Create a Symptom/Finding concept
-        </Link>
-        <Link className="dropdown-item" to={`/new/procedure${props.pathName}`}>
+            </Link>
+          </DropdownItem>
+          <DropdownItem>
+            <Link className="dropdown-item" to={`/new/procedure${props.pathName}`}>
           Create a Procedure concept
-        </Link>
-        <Link className="dropdown-item" to={`/new/question${props.pathName}`}>
+            </Link>
+          </DropdownItem>
+          <DropdownItem>
+            <Link className="dropdown-item" to={`/new/question${props.pathName}`}>
           Create a Q-and-A concept
-        </Link>
-        <Link className="dropdown-item" to={`/new/drug${props.pathName}`}>
+            </Link>
+          </DropdownItem>
+          <DropdownItem>
+            <Link className="dropdown-item" to={`/new/drug${props.pathName}`}>
           Create a Drug concept
-        </Link>
-        <Link className="dropdown-item" to={`/new/test${props.pathName}`}>
+            </Link>
+          </DropdownItem>
+          <DropdownItem>
+            <Link className="dropdown-item" to={`/new/test${props.pathName}`}>
           Create a Test concept
-        </Link>
-        <Link className="dropdown-item" to={`/new/set${props.pathName}`}>
+            </Link>
+          </DropdownItem>
+          <DropdownItem>
+            <Link className="dropdown-item" to={`/new/set${props.pathName}`}>
           Create a Set of concept
-        </Link>
-        <Link className="dropdown-item" to={`/new${props.pathName}`}>
+            </Link>
+          </DropdownItem>
+          <DropdownItem>
+            <Link className="dropdown-item" to={`/new${props.pathName}`}>
           Create another kind of concept
-        </Link>
-      </div>
+            </Link>
+          </DropdownItem>
+        </DropdownMenu>
+      </UncontrolledDropdown>
     </div>
   </div>
 );

--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -6,19 +6,16 @@
   width: auto;
 }
 
-.form-style {
-  margin-top: 12px;
-}
-
-.action-btn-style {
-  margin-left: 12px;
-}
-
 .bulk-concepts {
   text-align: left;
   margin-top: -3%;
   padding-right: 4%;
   padding-left: 5%;
+}
+
+.all-dictionaries {
+  margin-right: -8%;
+  margin-left: -8%;
 }
 
 body {
@@ -31,6 +28,8 @@ body {
   -moz-border-radius: 2rem;
   -ms-border-radius: 2rem;
   -o-border-radius: 2rem;
+  background-color: white;
+  color: black;
 }
 
 .concept-header {
@@ -242,10 +241,6 @@ input:-webkit-autofill:active {
 .concept-form-table .form-control:not(textarea) {
   height: 2.4rem !important;
   background: #fafafa;
-}
-
-#concept-description {
-  padding-top: 0px !important;
 }
 
 .concept-form-table-link {

--- a/src/tests/Navbar.test.js
+++ b/src/tests/Navbar.test.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { StaticRouter } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
+import { NavbarToggler } from 'reactstrap';
 import Navbar from '../components/Navbar';
 import GeneralSearch from '../components/GeneralSearch/NavbarGeneralSearch';
 
@@ -31,7 +32,35 @@ describe('Navbar Component', () => {
     expect(wrapper.find('LogoutAction')).toBeTruthy();
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should toggle state isOpen value on button click', () => {
+    const props = {
+      loggedIn: true,
+      history: { push: jest.fn() },
+      logoutAction: jest.fn(),
+    };
+    wrapper = shallow(<Navbar.WrappedComponent store={store} {...props} />);
+    const toggleBtn = wrapper.find(NavbarToggler);
+    toggleBtn.simulate('click');
+    expect(wrapper.state().isOpen).toBe(true);
+  });
 });
+
+describe('Toggle function', () => {
+  it('should toggle the dropdown', () => {
+    const props = {
+      loggedIn: true,
+      history: { push: jest.fn() },
+      logoutAction: jest.fn(),
+    };
+    wrapper = shallow(<Navbar.WrappedComponent store={store} {...props} />);
+    const instance = wrapper.instance();
+    expect(wrapper.state().isOpen).toBe(false);
+    instance.toggle();
+    expect(wrapper.state().isOpen).toBe(true);
+  });
+});
+
 describe('GeneralSearch', () => {
   const props = {
     onSearch: jest.fn(),


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make reactstrap drop-downs work.](https://issues.openmrs.org/browse/OCLOMRS-320)

# Summary:
Since the team decided to migrate to react strap, there was a removal of unnecessary links to the bootstrap CDNs in the index.html. Different dropdowns depended on the bootstrap files from these CDNs and after they were removed, the dropdowns don't work anymore.
