### PR TITLE
OCLOMRS-319:Remove ID and DataType column from concepts table

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -56,18 +56,8 @@ const ConceptTable = ({
               ...filter,
             },
             {
-              Header: 'Datatype',
-              accessor: 'datatype',
-              ...filter,
-            },
-            {
               Header: 'Source',
               accessor: 'source',
-              ...filter,
-            },
-            {
-              Header: 'ID',
-              accessor: 'id',
               ...filter,
             },
             {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Remove ID and DataType column from concepts table](https://issues.openmrs.org/browse/OCLOMRS-319)

# Summary:
Remove the ID and DataType column in order to pave way for mapping buttons on the actions column