### PR TITLE
OCLOMRS-312: make the edit concept action link to be a button

### DIFF
--- a/src/components/dictionaryConcepts/components/ActionButtons.jsx
+++ b/src/components/dictionaryConcepts/components/ActionButtons.jsx
@@ -18,7 +18,7 @@ const ActionButtons = ({
       {showExtra && (
         <React.Fragment>
           <Link
-            className="btn btn-sm mb-1 actionButtons"
+            className="edit-button-link btn btn-sm mb-1 actionButtons"
             to={`/edit/${concept_class}/${id}${dictionaryPathName}`}
           >
           Edit

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -134,3 +134,9 @@
 .custom-bg-dark {
   background-color: rgb(5, 5, 5) !important;
 }
+
+.edit-button-link {
+  color: #000000 !important;
+  background-color: #ffffff;
+  margin-right: 5px;
+}


### PR DESCRIPTION
# JIRA TICKET NAME:
[make the edit concept action link to look like other action buttons for consistency](https://issues.openmrs.org/browse/OCLOMRS-312)

# Summary:
The edit concept action link in the view dictionary concepts table is placed under action buttons and should look similar to the action buttons for consistency.