### PR TITLE
OCLOMRS-311: Implement delete/retire mapping functionality

### DIFF
--- a/src/components/dictionaryConcepts/components/ActionButtons.jsx
+++ b/src/components/dictionaryConcepts/components/ActionButtons.jsx
@@ -5,7 +5,7 @@ import AddMapping from './AddMapping';
 import ViewConceptMappings from './ViewConceptMappings';
 
 const ActionButtons = ({
-  actionButtons, id, concept_class, showDeleteModal, version_url, mappings, source, mappingLimit, display_name,
+  actionButtons, id, concept_class, showDeleteModal, version_url, mappings, source, mappingLimit, display_name, showDeleteMappingModal, handleDeleteMapping,
 }) => {
   const dictionaryPathName = localStorage.getItem('dictionaryPathName');
   let showExtra;
@@ -33,6 +33,8 @@ const ActionButtons = ({
             displayName={display_name}
             mappingLimit={mappingLimit}
             source={source}
+            showDeleteMappingModal={showDeleteMappingModal}
+            handleDeleteMapping={handleDeleteMapping}
           />
 
           )
@@ -57,6 +59,9 @@ ActionButtons.propTypes = {
   concept_class: PropTypes.string.isRequired,
   showDeleteModal: PropTypes.func.isRequired,
   version_url: PropTypes.string.isRequired,
+  handleDeleteMapping: PropTypes.func.isRequired,
+  showDeleteMappingModal: PropTypes.func.isRequired,
+  display_name: PropTypes.string.isRequired,
 };
 
 export default ActionButtons;

--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -22,6 +22,8 @@ const ConceptTable = ({
   closeDeleteModal,
   openDeleteModal,
   filterConcept,
+  showDeleteMappingModal,
+  handleDeleteMapping,
 }) => {
   const filter = { filterMethod: filterConcept, filterAll: true };
   if (concepts.length > 0) {
@@ -68,7 +70,9 @@ const ConceptTable = ({
                 const props = {
                   showDeleteModal,
                   handleDelete,
+                  handleDeleteMapping,
                   mappingLimit: conceptLimit,
+                  showDeleteMappingModal,
                 };
                 const renderButtons = username === concept.owner || (
                   concept.owner === org.name && org.userIsMember
@@ -104,6 +108,8 @@ ConceptTable.propTypes = {
   openDeleteModal: PropTypes.bool,
   closeDeleteModal: PropTypes.func.isRequired,
   filterConcept: PropTypes.func.isRequired,
+  handleDeleteMapping: PropTypes.func.isRequired,
+  showDeleteMappingModal: PropTypes.func.isRequired,
 };
 ConceptTable.defaultProps = {
   openDeleteModal: false,

--- a/src/components/dictionaryConcepts/components/RemoveMappings.jsx
+++ b/src/components/dictionaryConcepts/components/RemoveMappings.jsx
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import RemoveMappingsModal from './RemoveMappingsModal';
+
+class RemoveMappings extends Component {
+  state = {
+    modal: false,
+  };
+
+  handleToggle = () => {
+    const { modal } = this.state;
+    this.setState({
+      modal: !modal,
+    });
+  };
+
+  render() {
+    const { modal } = this.state;
+    const { url, retired, handleDeleteMapping, showDeleteMappingModal } = this.props;
+    return (
+      <React.Fragment>
+        { !retired ? (
+          <button
+            type="button"
+            className="btn btn-sm mb-1 actionButtons"
+            onClick={() => {
+              this.handleToggle();
+              showDeleteMappingModal(url);
+            }
+        }
+          >
+          Remove
+            <RemoveMappingsModal
+              modal={modal}
+              toggle={this.handleToggle}
+              handleDeleteMapping={handleDeleteMapping}
+              url={url}
+            />
+          </button>) : (
+            <button
+              type="button"
+              className="btn btn-sm mb-1 actionButtons disabled"
+            >
+              Retired
+            </button>
+        )
+      }
+      </React.Fragment>
+    );
+  }
+}
+
+RemoveMappings.propTypes = {
+  handleDeleteMapping: PropTypes.func.isRequired,
+  showDeleteMappingModal: PropTypes.func.isRequired,
+  url: PropTypes.string.isRequired,
+  retired: PropTypes.bool.isRequired,
+};
+
+export default RemoveMappings;

--- a/src/components/dictionaryConcepts/components/RemoveMappingsModal.jsx
+++ b/src/components/dictionaryConcepts/components/RemoveMappingsModal.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+  Button, Modal, ModalHeader, ModalFooter,
+} from 'reactstrap';
+import PropTypes from 'prop-types';
+
+const removeMapping = (props) => {
+  const {
+    handleDeleteMapping,
+    modal,
+    toggle,
+    url,
+  } = props;
+  return (
+    <div>
+      <Modal isOpen={modal} toggle={toggle}>
+        <ModalHeader toggle={toggle}>
+          Are you sure you want to Remove this Mapping?
+        </ModalHeader>
+        <ModalFooter>
+          <Button id="retireMapping" color="danger" onClick={() => { handleDeleteMapping(url); toggle(); }}>Remove Mapping</Button>
+          {' '}
+          <Button color="secondary" onClick={toggle}>Cancel</Button>
+        </ModalFooter>
+      </Modal>
+    </div>
+  );
+};
+
+removeMapping.propTypes = {
+  handleDeleteMapping: PropTypes.func.isRequired,
+  modal: PropTypes.bool.isRequired,
+  toggle: PropTypes.func.isRequired,
+  url: PropTypes.string.isRequired,
+};
+
+export default removeMapping;

--- a/src/components/dictionaryConcepts/components/ViewConceptMappings.jsx
+++ b/src/components/dictionaryConcepts/components/ViewConceptMappings.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ViewMappingsModal from './ViewMappingsModal';
 
 class ViewConceptMappings extends Component {
@@ -15,7 +16,9 @@ class ViewConceptMappings extends Component {
 
   render() {
     const { modal } = this.state;
-    const { mappings, displayName, source } = this.props;
+    const {
+      mappings, displayName, showDeleteMappingModal, handleDeleteMapping, source,
+    } = this.props;
     return (
       <React.Fragment>
         <button
@@ -24,11 +27,25 @@ class ViewConceptMappings extends Component {
           onClick={this.handleToggle}
         >
           View mappings
-          <ViewMappingsModal mappings={mappings} source={source} displayName={displayName} modal={modal} handleToggle={this.handleToggle} />
+          <ViewMappingsModal
+            mappings={mappings}
+            displayName={displayName}
+            source={source}
+            modal={modal}
+            handleDeleteMapping={handleDeleteMapping}
+            handleToggle={this.handleToggle}
+            showDeleteMappingModal={showDeleteMappingModal}
+          />
         </button>
       </React.Fragment>
     );
   }
 }
+
+ViewConceptMappings.propTypes = {
+  displayName: PropTypes.string.isRequired,
+  handleDeleteMapping: PropTypes.func.isRequired,
+  showDeleteMappingModal: PropTypes.func.isRequired,
+};
 
 export default ViewConceptMappings;

--- a/src/components/dictionaryConcepts/components/ViewMappingsModal.jsx
+++ b/src/components/dictionaryConcepts/components/ViewMappingsModal.jsx
@@ -8,6 +8,7 @@ import {
 import { conceptsProps } from '../proptypes';
 import AddMapping from './AddMapping';
 import { editMapping } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
+import RemoveMappings from './RemoveMappings';
 
 export const ViewMappingsModal = ({
   handleToggle,
@@ -18,6 +19,8 @@ export const ViewMappingsModal = ({
   source,
   editMapping,
   concepts,
+  handleDeleteMapping,
+  showDeleteMappingModal,
 }) => (
   <div className="col-9">
     <Modal isOpen={modal} className="modal-lg">
@@ -55,17 +58,24 @@ export const ViewMappingsModal = ({
                 id: 'row',
                 filterable: false,
                 sortable: false,
-                Cell: row => (
-                  <AddMapping
-                    buttonName="Edit mapping"
-                    to_concept_url={mappings[row.index].to_concept_url}
-                    url={mappings[row.index].url}
-                    map_type={mappings[row.index].map_type}
-                    to_concept_name={mappings[row.index].to_concept_name}
-                    source={source}
-                    editMapping={editMapping}
-                    concepts={concepts}
-                  />
+                Cell: ({ original: mapping }) => (
+                  <React.Fragment>
+                    <AddMapping
+                      buttonName="Edit"
+                      to_concept_url={mapping.to_concept_url}
+                      url={mapping.url}
+                      map_type={mapping.map_type}
+                      to_concept_name={mapping.to_concept_name}
+                      source={source}
+                      editMapping={editMapping}
+                      concepts={concepts}
+                    />
+                    <RemoveMappings
+                      showDeleteMappingModal={showDeleteMappingModal}
+                      handleDeleteMapping={handleDeleteMapping}
+                      {...mapping}
+                    />
+                  </React.Fragment>
                 ),
               },
             ]}
@@ -86,6 +96,8 @@ ViewMappingsModal.propTypes = {
   modal: PropTypes.bool.isRequired,
   handleToggle: PropTypes.func.isRequired,
   mappings: conceptsProps.mappings.isRequired,
+  showDeleteMappingModal: PropTypes.func.isRequired,
+  handleDeleteMapping: PropTypes.func.isRequired,
 };
 
 export const mapStateToProps = state => ({

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -15,7 +15,7 @@ import {
   filterByClass,
   paginateConcepts,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
-import { removeDictionaryConcept } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
+import { removeDictionaryConcept, removeConceptMapping } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import { fetchMemberStatus } from '../../../redux/actions/user/index';
 
 export class DictionaryConcepts extends Component {
@@ -41,6 +41,7 @@ export class DictionaryConcepts extends Component {
     fetchMemberStatus: PropTypes.func.isRequired,
     userIsMember: PropTypes.bool.isRequired,
     removeDictionaryConcept: PropTypes.func.isRequired,
+    removeConceptMappingAction: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -150,6 +151,18 @@ export class DictionaryConcepts extends Component {
     this.setState({ openDeleteModal: false });
   }
 
+  handleDeleteMapping = () => {
+    const { data } = this.state;
+    const { removeConceptMappingAction } = this.props;
+    removeConceptMappingAction(data);
+  }
+
+  handleShowDeleteMapping = (url) => {
+    this.setState({
+      data: { references: [url] },
+    });
+  };
+
   filterCaseInsensitive = (filter, rows) => {
     const id = filter.pivotId || filter.id;
     return matchSorter(rows, filter.value, { keys: [id] });
@@ -210,8 +223,10 @@ export class DictionaryConcepts extends Component {
               org={org}
               locationPath={this.props.match.params}
               showDeleteModal={this.handleShowDelete}
+              showDeleteMappingModal={this.handleShowDeleteMapping}
               url={this.state.versionUrl}
               handleDelete={this.handleDelete}
+              handleDeleteMapping={this.handleDeleteMapping}
               openDeleteModal={openDeleteModal}
               closeDeleteModal={this.closeDeleteModal}
               filterConcept={this.filterCaseInsensitive}
@@ -243,5 +258,6 @@ export default connect(
     paginateConcepts,
     fetchMemberStatus,
     removeDictionaryConcept,
+    removeConceptMappingAction: removeConceptMapping,
   },
 )(DictionaryConcepts);

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -7,6 +7,7 @@ import {
   dictionaryIsSuccess,
   isErrored,
   removeConcept,
+  removeMapping,
   fetchingVersions,
   dictionaryConceptsIsSuccess,
   realisingHeadSuccess,
@@ -118,6 +119,25 @@ export const removeDictionaryConcept = (data, type, owner, collectionId) => disp
       notify.show("Network Error. Please try again later!", 'error', 6000)
       });
     };
+
+export const removeConceptMapping = (data, source) => dispatch => {
+  return api.dictionaries
+    .removeConceptMapping(data)
+    .then(
+      () => {
+        dispatch(removeMapping(data.references[0]));
+        notify.show(
+          'Successfully removed mapping from concept',
+          'success', 1000
+          );
+        const ConceptsToFetch = `/users/${localStorage.getItem('username')}/sources/${localStorage.getItem('dictionaryId')}/concepts/?includeMappings=true&q=&limit=0&page=1&verbose=true`
+          dispatch(fetchDictionaryConcepts(ConceptsToFetch));
+      }
+    )
+    .catch((error) => {
+      notify.show("Network Error. Please try again later!",'error', 6000)
+    });
+};
 
 export const fetchVersions = data => (dispatch) => {
   return api.dictionaries

--- a/src/redux/actions/dictionaries/dictionaryActions.js
+++ b/src/redux/actions/dictionaries/dictionaryActions.js
@@ -11,6 +11,7 @@ import {
   FETCH_DICTIONARY_CONCEPT,
   EDIT_DICTIONARY_SUCCESS,
   REMOVE_CONCEPT,
+  REMOVE_MAPPING,
   CREATING_RELEASED_VERSION,
   CREATING_RELEASED_VERSION_FAILED,
   RELEASING_HEAD_VERSION,
@@ -68,6 +69,11 @@ export const clearDictionary = () => ({
 
 export const removeConcept = payload => ({
   type: REMOVE_CONCEPT,
+  payload,
+});
+
+export const removeMapping = payload => ({
+  type: REMOVE_MAPPING,
   payload,
 });
 

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -16,6 +16,7 @@ export const CLEAR_DICTIONARIES = '[dictionaries] clear dictionaries';
 export const FETCHING_DICTIONARY = '[dictionary] fetch dictionary';
 export const CLEAR_DICTIONARY = '[dictionary] clear dictionary';
 export const REMOVE_CONCEPT = '[concepts] remove concept';
+export const REMOVE_MAPPING = '[mappings] remove mapping';
 export const FETCHING_VERSIONS = '[dictionary] fetch versions of a dictionary';
 export const RELEASING_HEAD_VERSION = '[dictionary] releasing HEAD version of a dictionary';
 export const EDIT_DICTIONARY_SUCCESS = '[dictionary] edit dictionary success';

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -42,7 +42,12 @@ export default {
       instance
         .delete(`/${type}/${owner}/collections/${collectionId}/references/`, {data:data})
         .then(response => response.data),
-    
+
+    removeConceptMapping: (data) =>
+      instance
+        .delete(data.references[0], { data: data })
+        .then(response => response.data),
+
     fetchingVersions: (data) =>
       instance
       .get(`${data}`)

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -29,6 +29,7 @@ import {
   REMOVE_CONCEPT,
   REMOVE_ONE_ANSWER_MAPPING,
   ADD_NEW_ANSWER_MAPPING,
+  REMOVE_MAPPING,
 } from '../../../redux/actions/types';
 import {
   fetchDictionaryConcepts,
@@ -54,6 +55,7 @@ import {
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import {
   removeDictionaryConcept,
+  removeConceptMapping,
 } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import concepts, {
   mockConceptStore,
@@ -226,7 +228,7 @@ describe('Test suite for dictionary concept actions', () => {
       const request = moxios.requests.mostRecent();
       request.respondWith({
         status: 200,
-        response: newConcept.version_url,
+        response: '/users/admin/sources/858738987555379984/mappings/5bff9fb3bdfb8801a1702975/',
       });
     });
 
@@ -240,6 +242,60 @@ describe('Test suite for dictionary concept actions', () => {
     const owner = 'alexmochu';
     const collectionId = 'Tech';
     return store.dispatch(removeDictionaryConcept(data, type, owner, collectionId)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should handle REMOVE_MAPPINGS', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 201,
+        response: [],
+      });
+    });
+
+    const expectedActions = [
+      {
+        type: REMOVE_MAPPING,
+        payload: '/users/admin/sources/858738987555379984/mappings/5bff9fb3bdfb8801a1702975/',
+      },
+      {
+        payload: true,
+        type: '[ui] toggle spinner',
+      },
+    ];
+
+    const store = mockStore(mockConceptStore);
+    const data = { references: ['/users/admin/sources/858738987555379984/mappings/5bff9fb3bdfb8801a1702975/'] };
+    const type = 'users';
+    const owner = 'alexmochu';
+    return store.dispatch(removeConceptMapping(data, type, owner)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should handle REMOVE_MAPPING network error', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        status: 599,
+        response: {
+          data: { detail: 'Cannot remove mapping' },
+        },
+      });
+    });
+
+    const expectedActions = [
+      { type: REMOVE_MAPPING, payload: '/users/admin/sources/858738987555379984/mappings/5bff9fb3bdfb8801a1702975/' },
+    ];
+
+    const store = mockStore(mockConceptStore);
+    const data = { references: ['/users/admin/sources/858738987555379984/mappings/5bff9fb3bdfb8801a1702975/'] };
+    const type = 'users';
+    const owner = 'alexmochu';
+    const collectionId = 'Tech';
+    return store.dispatch(removeConceptMapping(data, type, owner, collectionId)).catch(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/src/tests/dictionaryConcepts/components/ActionButtons.test.jsx
+++ b/src/tests/dictionaryConcepts/components/ActionButtons.test.jsx
@@ -9,6 +9,9 @@ const props = {
   concept_class: 'drug',
   version_url: '/url',
   showDeleteModal: jest.fn(),
+  handleDeleteMapping: jest.fn(),
+  showDeleteMappingModal: jest.fn(),
+  display_name: '',
   mappings: [
     {
       "type": "Mapping",

--- a/src/tests/dictionaryConcepts/components/RemoveMappings.test.jsx
+++ b/src/tests/dictionaryConcepts/components/RemoveMappings.test.jsx
@@ -1,22 +1,23 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import ViewConceptMappings from '../../../components/dictionaryConcepts/components/ViewConceptMappings';
+import RemoveMappings from '../../../components/dictionaryConcepts/components/RemoveMappings';
 
 let wrapper;
 let props;
 
-describe('render ViewConceptMappings', () => {
+describe('render RemoveMappings', () => {
   beforeEach(() => {
     props = {
       modal: false,
       handleToggle: jest.fn(),
       showDeleteMappingModal: jest.fn(),
       handleDeleteMapping: jest.fn(),
-      mappings: [],
+      mappings: [{ url: 'jengkjeng' }],
       mappingLimit: 10,
-      displayName: '',
+      url: '',
+      retired: false,
     };
-    wrapper = shallow(<ViewConceptMappings {...props} />);
+    wrapper = shallow(<RemoveMappings {...props} />);
   });
   it('should render without breaking', () => {
     expect(wrapper.length).toEqual(1);

--- a/src/tests/dictionaryConcepts/components/RemoveMappingsModal.test.jsx
+++ b/src/tests/dictionaryConcepts/components/RemoveMappingsModal.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Modal } from 'reactstrap';
+import RemoveMappingsModal from '../../../components/dictionaryConcepts/components/RemoveMappingsModal';
+
+let wrapper;
+let props;
+
+describe('render RemoveMappingsModal', () => {
+  beforeEach(() => {
+    props = {
+      modal: false,
+      handleToggle: jest.fn(),
+      showDeleteMappingModal: jest.fn(),
+      handleDeleteMapping: jest.fn(),
+      toggle: jest.fn(),
+      mappings: [],
+      mappingLimit: 10,
+      displayName: 'Paracetamol',
+      url: '',
+      retired: false,
+    };
+    wrapper = shallow(<RemoveMappingsModal {...props} />);
+  });
+  it('should render without breaking', () => {
+    expect(wrapper.length).toEqual(1);
+  });
+  it('should contain a modal.', () => {
+    const modalWrapper = wrapper.find(Modal);
+    expect(modalWrapper.length).toEqual(1);
+  });
+  it('should call the showDeleteModal', () => {
+    wrapper.find('#retireMapping').simulate('click');
+    expect(props.handleDeleteMapping).toBeCalled();
+  });
+});

--- a/src/tests/dictionaryConcepts/components/ViewMappingsModal.test.js
+++ b/src/tests/dictionaryConcepts/components/ViewMappingsModal.test.js
@@ -7,6 +7,7 @@ import {
 import { Provider } from 'react-redux';
 import { createMockStore } from 'redux-test-utils';
 import ViewMappingsModal from '../../../components/dictionaryConcepts/components/ViewMappingsModal';
+import RemoveMappings from '../../../components/dictionaryConcepts/components/RemoveMappings';
 
 let wrapper;
 let props;
@@ -16,22 +17,44 @@ describe('render ViewMappingsModal', () => {
   beforeEach(() => {
     props = {
       modal: true,
-      concepts: [],
+      concepts: [{
+        id: '2b14dedd-662b-44f7-9fce-05d78de96fc5',
+        external_id: null,
+        concept_class: 'drug',
+        datatype: 'None',
+        retired: false,
+        source: '858738987555379984',
+        owner: 'admin',
+        owner_type: 'User',
+        owner_url: '/users/admin/',
+        display_name: 'Malaria',
+        display_locale: 'en',
+        version: '5bfea942bdfb8801a1702943',
+        mappings: null,
+        is_latest_version: true,
+        locale: null,
+        version_url: '/users/admin/sources/858738987555379984/concepts/2b14dedd-662b-44f7-9fce-05d78de96fc5/5bfea942bdfb8801a1702943/',
+        url: '/users/admin/sources/858738987555379984/concepts/2b14dedd-662b-44f7-9fce-05d78de96fc5/',
+      }],
       handleToggle: jest.fn(),
       editMapping: jest.fn(),
+      showDeleteMappingModal: jest.fn(),
+      handleDeleteMapping: jest.fn(),
       mappings: [{
         to_concept_url: '',
         url: '',
         map_type: '',
         to_concept_name: '',
+        retired: false,
       }],
       mappingLimit: 10,
       displayName: 'Paracetamol',
       source: '',
+      retired: false,
     };
     wrapper = mount(
       <Provider store={store}>
-        <ViewMappingsModal.WrappedComponent {...props} />
+        <ViewMappingsModal.WrappedComponent store={store} {...props} />
       </Provider>,
     );
   });
@@ -39,31 +62,18 @@ describe('render ViewMappingsModal', () => {
     expect(wrapper.length).toEqual(1);
   });
   it('should render without breaking', () => {
-    props = {
-      modal: false,
-      handleToggle: jest.fn(),
-      mappings: [{
-        to_concept_url: '',
-        url: '',
-        map_type: '',
-        to_concept_name: '',
-      }],
-      displayName: 'Paracetamol',
-      source: '',
-    };
-    wrapper = mount(
-      <Provider store={store}>
-        <ViewMappingsModal.WrappedComponent {...props} />
-      </Provider>,
-    );
     expect(wrapper.length).toEqual(1);
   });
   it('should contain a modal.', () => {
     const modalWrapper = wrapper.find(Modal);
-    expect(modalWrapper.length).toEqual(2);
+    expect(modalWrapper.length).toEqual(3);
   });
   it('should close modal when click cancel', () => {
     wrapper.find(Button).simulate('click');
     expect(props.handleToggle).toBeCalled();
+  });
+  it('render remove mappings if mappings', () => {
+    const removeWrapper = wrapper.find(RemoveMappings);
+    expect(removeWrapper.length).toEqual(1);
   });
 });

--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -46,6 +46,7 @@ describe('Test suite for dictionary concepts components', () => {
       totalConceptCount: 20,
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
     };
     const wrapper = mount(<Provider store={store}>
       <Router>
@@ -85,6 +86,7 @@ describe('Test suite for dictionary concepts components', () => {
       totalConceptCount: 20,
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
     };
     const wrapper = mount(<Provider store={store}>
       <Router>
@@ -119,6 +121,7 @@ describe('Test suite for dictionary concepts components', () => {
       fetchMemberStatus: jest.fn(),
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
     };
 
     const wrapper = mount(<Provider store={store}>
@@ -156,6 +159,7 @@ describe('Test suite for dictionary concepts components', () => {
       totalConceptCount: 20,
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
     };
     const wrapper = shallow(<DictionaryConcepts {...props} />);
     wrapper.setState({ versionUrl: 'url' });
@@ -165,6 +169,42 @@ describe('Test suite for dictionary concepts components', () => {
     expect(wrapper.state().openDeleteModal).toBe(true);
     instance.closeDeleteModal();
     expect(wrapper.state().openDeleteModal).toBe(false);
+  });
+
+  it('should change open delete mappings modal', () => {
+    const props = {
+      match: {
+        params: {
+          typeName: 'dev-col',
+          type: 'orgs',
+          collectionName: 'dev-col',
+          dictionaryName: 'dev-col',
+        },
+      },
+      location: {
+        pathname: '/random/path',
+      },
+      url: '/users/admin/sources/858738987555379984/mappings/5bff9fb3bdfb8801a1702975/',
+      fetchDictionaryConcepts: jest.fn(),
+      concepts: [concepts],
+      filteredClass: ['Diagnosis'],
+      filteredSources: ['CIEL'],
+      loading: false,
+      filterBySource: jest.fn(),
+      filterByClass: jest.fn(),
+      fetchMemberStatus: jest.fn(),
+      paginateConcepts: jest.fn(),
+      totalConceptCount: 20,
+      userIsMember: true,
+      removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
+    };
+    const wrapper = shallow(<DictionaryConcepts {...props} />);
+    wrapper.setState({ data: { references: [props.url] } });
+    wrapper.update();
+    const instance = wrapper.instance();
+    instance.handleShowDeleteMapping(props.url);
+    expect((wrapper.state().data) === { references: [props.url] });
   });
 
   it('it should call the handle delete function', () => {
@@ -192,10 +232,46 @@ describe('Test suite for dictionary concepts components', () => {
       totalConceptCount: 20,
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
     };
     const wrapper = shallow(<DictionaryConcepts {...props} />);
     const instance = wrapper.instance();
     expect(instance.handleDelete()).toEqual(undefined);
+  });
+
+  it('it should call the handle delete mapping function', () => {
+    const props = {
+      match: {
+        params: {
+          typeName: 'dev-col',
+          type: 'orgs',
+          collectionName: 'dev-col',
+          dictionaryName: 'dev-col',
+        },
+      },
+      location: {
+        pathname: '/random/path',
+      },
+      fetchDictionaryConcepts: jest.fn(),
+      concepts: [concepts],
+      filteredClass: ['Diagnosis'],
+      filteredSources: ['CIEL'],
+      loading: false,
+      filterBySource: jest.fn(),
+      filterByClass: jest.fn(),
+      fetchMemberStatus: jest.fn(),
+      paginateConcepts: jest.fn(),
+      totalConceptCount: 20,
+      userIsMember: true,
+      removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
+      handleToggle: jest.fn(),
+      showDeleteMappingModal: jest.fn(),
+      handleDeleteMapping: jest.fn(),
+    };
+    const wrapper = shallow(<DictionaryConcepts {...props} />);
+    const instance = wrapper.instance();
+    expect(instance.handleDeleteMapping()).toEqual(undefined);
   });
 
   it('should filter search result', () => {
@@ -223,6 +299,7 @@ describe('Test suite for dictionary concepts components', () => {
       totalConceptCount: 20,
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
     };
     const wrapper = mount(<Provider store={store}>
       <Router>
@@ -272,6 +349,7 @@ describe('Test suite for dictionary concepts components', () => {
       totalConceptCount: 20,
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
     };
     const wrapper = mount(<Provider store={store}>
       <Router>
@@ -315,6 +393,7 @@ describe('Test suite for dictionary concepts components', () => {
       totalConceptCount: 20,
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
     };
     const app = shallow(<DictionaryConcepts {...props} />);
     const newProps = {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Implement Delete/Retire mapping functionality](https://issues.openmrs.org/browse/OCLOMRS-311)

# Summary:
This PR adds the Delete/Retire mappings feature to Concept mappings although the backend raises a CORS error when the action is performed.