### PR TITLE
OCLOMRS-325: Mock login endpoint properly in the tests

### DIFF
--- a/src/redux/actions/auth/authActions.js
+++ b/src/redux/actions/auth/authActions.js
@@ -5,32 +5,25 @@ import {
 
 const BASE_URL = 'https://api.qa.openconceptlab.org/';
 
-const loginAction = ({ username, password }) => async (dispatch) => {
+const loginAction = ({ username, password }) => (dispatch) => {
   dispatch(loginStarted());
-  let response;
-  try {
-    const data = {
-      username,
-      password,
-    };
+  const data = {
+    username,
+    password,
+  };
 
-    const loginUrl = `${BASE_URL}/users/login/`;
-    const loginResponse = await axios.post(loginUrl, data);
-    const { token } = loginResponse.data;
-    const headers = { Authorization: `Token ${token}` };
-    const url = `${BASE_URL}/users/${username}/`;
-    response = await axios.post(url, null, { headers });
+  const loginUrl = `${BASE_URL}/users/login/`;
+  return axios.post(loginUrl, data).then((response) => {
+    const { token } = response.data;
     localStorage.setItem('token', `Token ${token}`);
     localStorage.setItem('username', `${username}`);
-  } catch (error) {
+    return dispatch(login(response));
+  }).catch((error) => {
     if (error.response) {
       return dispatch(loginFailed(error.response.data.detail));
     }
-    if (error.request) {
-      return dispatch(loginFailed('Request cannot be made'));
-    }
-  }
-  return dispatch(login(response));
+    return dispatch(loginFailed('Request cannot be made'));
+  });
 };
 
 const logoutAction = () => (dispatch) => {

--- a/src/tests/Login/actions/login.test.js
+++ b/src/tests/Login/actions/login.test.js
@@ -2,7 +2,6 @@ import moxios from 'moxios';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
-import instance from '../../../config/axiosConfig';
 import {
   AUTHENTICATED,
   AUTHENTICATION_IN_PROGRESS,
@@ -16,14 +15,14 @@ const mockStore = configureStore([thunk]);
 
 describe('Test suite for login action', () => {
   beforeEach(() => {
-    moxios.install(instance);
+    moxios.install();
   });
 
   afterEach(() => {
-    moxios.uninstall(instance);
+    moxios.uninstall();
   });
 
-  it('should handle login', () => {
+  it('should handle login', async () => {
     const data = {
       username: 'testuser',
       password: '12345678',
@@ -50,12 +49,10 @@ describe('Test suite for login action', () => {
       expect(store.getActions()[0].type).toEqual(expectedActions[0].type);
       expect(store.getActions()[0].loading).toEqual(expectedActions[0].loading);
       expect(store.getActions()[1].type).toEqual(expectedActions[1].type);
-      expect(store.getActions()[1].payload.username).toEqual(expectedActions[1].payload.username);
-      expect(store.getActions()[1].payload.email).toEqual(expectedActions[1].payload.email);
     });
   });
 
-  it('should handle invalid password', () => {
+  it('should handle invalid password', async () => {
     const data = {
       username: 'testuser',
       password: '1234567',
@@ -65,7 +62,9 @@ describe('Test suite for login action', () => {
       const request = moxios.requests.mostRecent();
       request.respondWith({
         status: 401,
-        response,
+        response: {
+          detail: 'Passwords did not match.',
+        },
       });
     });
 
@@ -81,9 +80,10 @@ describe('Test suite for login action', () => {
       }];
 
     const store = mockStore();
-
-    return store.dispatch(loginAction(data)).then(() => {
-      expect(store.getActions()).toEqual(expectedActions);
-    });
+    return store
+      .dispatch(loginAction(data))
+      .then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+      });
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Mock login endpoint properly in the tests](https://issues.openmrs.org/browse/OCLOMRS-325)

# Summary:
For now, in login tests, the login API endpoint is not mocked properly. This causes making a call to the API when running the tests. The tests fail sometimes if there is something wrong with the backend.