### PR TITLE
OCLOMRS-326: Remove untestable files

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "collectCoverageFrom": [
       "**/src/**/*.{js,jsx}",
       "!**/store.js",
-      "!*/setupTests.js"
+      "!*/setupTests.js",
+      "!src/index.js"
     ],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"


### PR DESCRIPTION
# JIRA TICKET NAME:
[Remove untestable files](https://issues.openmrs.org/browse/OCLOMRS-326)

# Summary:
Untestable files in the application lower the coverage hence removing them will increase the coverage