### PR TITLE
OCLOMRS-330: Prevent the Footer and the Login form from overlapping 

### DIFF
--- a/src/styles/login.scss
+++ b/src/styles/login.scss
@@ -1,7 +1,7 @@
 .form-container {
   display: flex;
   flex-direction: column;
-  height: 30vh;
+  margin-bottom: 1em;
   justify-content: center;
   align-items: center;
 }


### PR DESCRIPTION


# JIRA TICKET NAME:
[Prevent the Footer and the Login form from overlapping](https://issues.openmrs.org/browse/OCLOMRS-330)

# Summary:
Previously, as seen on the login page, the login form overlaps with the footer content. This should not be the case. This is fixed by this PR. 