### PR TITLE
OCLOMRS-329: Fix placeholder spelling error on add mappings modal

### DIFF
--- a/src/components/dictionaryConcepts/components/ExternalMapping.jsx
+++ b/src/components/dictionaryConcepts/components/ExternalMapping.jsx
@@ -68,7 +68,7 @@ class ExternalMapping extends Component {
               <Input
                 type="text"
                 className="form-control answer"
-                placeholder="eg. Malariae"
+                placeholder="eg. Malaria"
                 name="term"
                 value={term}
                 onChange={this.handleChange}


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix placeholder spelling error on the Add mappings modal](https://issues.openmrs.org/browse/OCLOMRS-329)

# Summary:
Correcting the *Term field* placeholder on the add mappings modal from "Malariae" to "Malaria" for consistency as the platform is written in English.