### PR TITLE
OCLOMRS-321: Implement view all mappings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Login from './components/login/container';
 import Authenticate from './components/Auth';
 import DictionaryDisplay from './components/dashboard/container/DictionariesDisplay';
 import DictionaryConcepts from './components/dictionaryConcepts/containers/DictionaryConcepts';
+import DictionaryMappings from './components/dictionaryConcepts/containers/DictionaryMappings';
 import CreateConcept from './components/dictionaryConcepts/containers/CreateConcept';
 import EditConcept from './components/dictionaryConcepts/containers/EditConcept';
 import NotFound from './components/NotFound';
@@ -52,6 +53,11 @@ const App = () => (
               exact
               path="/concepts/:type/:typeName/:collectionName/:dictionaryName/:language"
               component={Authenticate(DictionaryConcepts)}
+            />
+            <Route
+              exact
+              path="/mappings/:type"
+              component={Authenticate(DictionaryMappings)}
             />
             <Route
               exact

--- a/src/components/dictionaryConcepts/components/ConceptDropdown.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptDropdown.jsx
@@ -76,6 +76,15 @@ const ConceptDropdown = props => (
         </DropdownMenu>
       </UncontrolledDropdown>
     </div>
+
+    <div className="btn-group concept-btn">
+      <Link className="dropdown-item" to={`/mappings/${props.collectionName}`}>
+                <button className="btn btn-sm btn-secondary rounded-edge custom-dictionary-mappings" type="submit">
+                  View Mappings
+                </button>
+      </Link>
+    </div>
+
   </div>
 );
 ConceptDropdown.propTypes = {

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -13,7 +13,7 @@ import {
   fetchDictionaryConcepts,
   filterBySource,
   filterByClass,
-  paginateConcepts,
+paginateConcepts,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import { removeDictionaryConcept } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import { fetchMemberStatus } from '../../../redux/actions/user/index';
@@ -72,6 +72,7 @@ export class DictionaryConcepts extends Component {
     localStorage.setItem('type', this.props.match.params.type);
     localStorage.setItem('typeName', this.props.match.params.typeName);
     localStorage.setItem('dictionaryName', this.props.match.params.dictionaryName);
+    localStorage.setItem('params', this.props.match.params);
     this.setState({
       collectionName,
       type,

--- a/src/components/dictionaryConcepts/containers/DictionaryMappings.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryMappings.jsx
@@ -1,0 +1,155 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import autoBind from 'react-autobind';
+import matchSorter from 'match-sorter';
+import { Link } from 'react-router-dom';
+import ReactTable from 'react-table';
+import { connect } from 'react-redux';
+import SideNav from '../components/Sidenav';
+import Loader from '../../Loader';
+import {
+  filterBySource,
+  filterByClass,
+} from '../../../redux/actions/concepts/dictionaryConcepts';
+import {
+  fetchDictionaryMappings,
+} from '../../../redux/actions/dictionaries/dictionaryActionCreators';
+import { fetchMemberStatus } from '../../../redux/actions/user/index';
+
+export class DictionaryMappings extends Component {
+  static propTypes = {
+    match: PropTypes.shape({
+      params: PropTypes.shape({
+        typeName: PropTypes.string,
+        collectionName: PropTypes.string,
+        type: PropTypes.string,
+        dictionaryName: PropTypes.string,
+      }),
+    }).isRequired,
+    location: PropTypes.shape({
+      pathname: PropTypes.string,
+    }).isRequired,
+    mappings: PropTypes.arrayOf(PropTypes.shape({
+      from_concept_name: PropTypes.string,
+      to_concept_name: PropTypes.string,
+      map_type: PropTypes.string,
+      source: PropTypes.string,
+    })).isRequired,
+    loading: PropTypes.bool.isRequired,
+    fetchDictionaryMappings: PropTypes.func.isRequired,
+  };
+
+  state = {
+    mappingLimit: 10,
+  };
+
+  componentDidMount() {
+    const {
+      match: {
+        params: {
+          type,
+        },
+      },
+    } = this.props;
+    this.props.fetchDictionaryMappings(type);
+  }
+
+  filterCaseInsensitive = (filter, rows) => {
+    const id = filter.pivotId || filter.id;
+    return matchSorter(rows, filter.value, { keys: [id] });
+  };
+
+  render() {
+    const {
+      mappings,
+      loading,
+    } = this.props;
+    const { mappingLimit } = this.state;
+    const path = localStorage.getItem('dictionaryPathName');
+    const dictionaryName = localStorage.getItem('dictionaryName');
+    const filter = { filterMethod: this.filterCaseInsensitive, filterAll: true };
+    return (
+      <div className="container-fluid custom-dictionary-mappings custom-max-width">
+          <section className="row mt-2">
+            <div className="col-12 col-md-4 pt-1">
+              <h4>{`${dictionaryName} Mappings`}</h4>
+              <div className="submit-button text-left">
+                <Link to={path} className="collection-name small-text">
+                  <button className="btn btn-sm btn-secondary rounded-edge" type="submit">
+                    Go Back
+                  </button>
+                </Link>
+              </div>
+            </div>
+          </section>
+          <section className="row mt-3">
+            <div className="col-12 col-md-10 custom-full-width">
+              {
+              loading
+               && (
+               <div className="mt-200 text-center">
+                 <Loader />
+               </div>)
+            }
+
+              {mappings.length > 0 ? (
+                <ReactTable
+                  data={mappings}
+                  loading={loading}
+                  defaultPageSize={mappings.length <= mappingLimit ? mappings.length : mappingLimit}
+                  filterable
+                  noDataText="No mappings!"
+                  minRows={0}
+                  columns={[
+                    {
+                      Header: 'From Concept Name',
+                      accessor: 'from_concept_name',
+                      minWidth: 100,
+                      ...filter,
+                    },
+                    {
+                      Header: 'To Concept Name',
+                      accessor: 'to_concept_name',
+                      ...filter,
+                    },
+                    {
+                      Header: 'Map Type',
+                      accessor: 'map_type',
+                      ...filter,
+                    },
+                    {
+                      Header: 'Dictionary',
+                      accessor: 'source',
+                      ...filter,
+                    },
+                  ]}
+                  className="-striped -highlight custom-table-width"
+                />
+
+              ) : (
+                <div className="col-12 col-md-10 custom-full-width">
+                  <h3>No mappings found! </h3>
+                </div>
+              )
+              }
+            </div>
+          </section>
+        </div>
+    );
+  }
+}
+export const mapStateToProps = state => ({
+  mappings: state.organizations.mappings,
+  concepts: state.concepts,
+  loading: state.concepts.loading,
+});
+
+export default connect(
+  mapStateToProps,
+  {
+    fetchDictionaryMappings,
+    fetchMemberStatus,
+    filterBySource,
+    filterByClass,
+  },
+)(DictionaryMappings);

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -9,6 +9,7 @@ import {
   removeConcept,
   fetchingVersions,
   dictionaryConceptsIsSuccess,
+  dictionaryMappingsIsSuccess,
   realisingHeadSuccess,
   editDictionarySuccess,
   creatingVersionsSuccess,
@@ -146,6 +147,23 @@ export const fetchDictionaryConcepts = data => (dispatch) => {
         dispatch(isFetching(false));
       });
 };
+
+export const fetchDictionaryMappings  = data => (dispatch) => {
+  dispatch(isFetching(true));
+  return api.dictionaries
+    .fetchDictionaryMappings(data)
+    .then(
+      (payload) => {
+      dispatch(dictionaryMappingsIsSuccess(payload));
+      dispatch(isFetching(false));
+      })
+      .catch((error) => {
+        error.response ? dispatch(isErrored(error.response.data)):
+        showNetworkError();
+        dispatch(isFetching(false));
+      });
+};
+
 
 export const releaseHead = (url, data) => (dispatch) => {
   return api.dictionaries

--- a/src/redux/actions/dictionaries/dictionaryActions.js
+++ b/src/redux/actions/dictionaries/dictionaryActions.js
@@ -9,6 +9,7 @@ import {
   CLEAR_DICTIONARY,
   FETCHING_VERSIONS,
   FETCH_DICTIONARY_CONCEPT,
+  FETCH_DICTIONARY_MAPPINGS,
   EDIT_DICTIONARY_SUCCESS,
   REMOVE_CONCEPT,
   CREATING_RELEASED_VERSION,
@@ -58,6 +59,11 @@ export const dictionaryIsSuccess = payload => ({
 
 export const dictionaryConceptsIsSuccess = payload => ({
   type: FETCH_DICTIONARY_CONCEPT,
+  payload,
+});
+
+export const dictionaryMappingsIsSuccess = payload => ({
+  type: FETCH_DICTIONARY_MAPPINGS,
   payload,
 });
 

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -12,6 +12,7 @@ export const FETCHING_ORGANIZATIONS = '[orgs] fetch user organizations';
 export const ADDING_DICTIONARY_FAILURE = '[dictionary] adding dictionaries failure';
 export const FETCHING_DICTIONARIES = '[dictionaries] fetch dictionaries';
 export const FETCH_DICTIONARY_CONCEPT = '[concepts] fetch concepts of one dictionary';
+export const FETCH_DICTIONARY_MAPPINGS = '[mappings] fetch mappings of one dictionary';
 export const CLEAR_DICTIONARIES = '[dictionaries] clear dictionaries';
 export const FETCHING_DICTIONARY = '[dictionary] fetch dictionary';
 export const CLEAR_DICTIONARY = '[dictionary] clear dictionary';

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -53,6 +53,12 @@ export default {
         .get(`${data}`)
         .then(response => response.data),
 
+    fetchDictionaryMappings: (data) =>
+      instance
+        .get(`/user/sources/${data}/mappings/`)
+        .then(response => response.data),
+
+
     creatingVersion: (url,data) => 
       instance
          .post(`${url}`, data)

--- a/src/redux/reducers/dictionaryReducer.js
+++ b/src/redux/reducers/dictionaryReducer.js
@@ -1,11 +1,21 @@
-import { FETCHING_ORGANIZATIONS } from '../actions/types';
+import { FETCHING_ORGANIZATIONS, FETCH_DICTIONARY_MAPPINGS } from '../actions/types';
 
-export default (state = {}, action) => {
+const initialState = {
+  loading: false,
+  mappings: [],
+};
+
+export default (state = initialState, action) => {
   switch (action.type) {
     case FETCHING_ORGANIZATIONS:
       return {
         ...state,
         organizations: action.payload,
+      };
+    case FETCH_DICTIONARY_MAPPINGS:
+      return {
+        ...state,
+        mappings: action.payload,
       };
     default:
       return state;

--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -6,6 +6,13 @@
   width: auto;
 }
 
+.custom-dictionary-mappings {
+  text-align: left;
+  padding: 5px 10px;
+  font-size: 1rem;
+  width: auto;
+}
+
 .bulk-concepts {
   text-align: left;
   margin-top: -3%;
@@ -48,12 +55,17 @@ body {
   box-shadow: none;
 }
 
+.dropdown-item {
+  padding: 0 !important;
+}
+
 .sidenav-container {
   background: white;
   padding: .5rem .7rem;
   box-shadow: 0 4px 15px 1px #00000012;
   font-size: 70%;
   margin-bottom: 2rem;
+  text-align: left;
 }
 
 .sidenav-container .sidenav-header {

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -12,6 +12,7 @@ import {
   EDIT_DICTIONARY_SUCCESS,
   FETCHING_VERSIONS,
   FETCH_DICTIONARY_CONCEPT,
+  FETCH_DICTIONARY_MAPPINGS,
   FETCHING_ORGANIZATIONS,
   RELEASING_HEAD_VERSION,
   REMOVE_CONCEPT,
@@ -33,6 +34,7 @@ import {
   fetchDictionary,
   fetchVersions,
   fetchDictionaryConcepts,
+  fetchDictionaryMappings,
   releaseHead,
   editDictionary,
   createVersion,
@@ -257,6 +259,55 @@ describe('Test suite for dictionary actions', () => {
     return store.dispatch(
       editMapping('/users/chriskala/sources/858738987555379984/mappings/5bfeac11bdfb8801a1702953/', MappingToEdit, '858738987555379984'),
     ).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should return mappings in a dictionary', () => {
+    const mappings = {
+      to_concept_name: 'random_name',
+      from_concept_name: 'random_name',
+      map_type: 'Map As Type',
+      source: 'random source',
+    };
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [{
+          to_concept_name: 'random_name',
+          from_concept_name: 'random_name',
+          map_type: 'Map As Type',
+          source: 'random source',
+        }],
+      });
+    });
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_DICTIONARY_MAPPINGS, payload: [mappings] },
+      { type: IS_FETCHING, payload: false },
+    ];
+    const store = mockStore({ payload: {} });
+    return store.dispatch(
+      fetchDictionaryMappings('/users/sources/CM/mappings/'),
+    ).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should handle fetch dictionary mappings network error', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        status: 599,
+      });
+    });
+    const expectedActions = [
+      { payload: true, type: IS_FETCHING },
+      { payload: false, type: IS_FETCHING },
+    ];
+    const store = mockStore({ payload: {} });
+    return store.dispatch(fetchDictionaryMappings('/users/sources/CM/mappings/')).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/src/tests/Dashboard/reducer/dictionaryReducers.test.js
+++ b/src/tests/Dashboard/reducer/dictionaryReducers.test.js
@@ -6,6 +6,7 @@ import {
   FETCHING_DICTIONARIES,
   IS_FETCHING, ADDING_DICTIONARY,
   FETCHING_DICTIONARY,
+  FETCH_DICTIONARY_MAPPINGS,
   FETCHING_VERSIONS,
   CLEAR_DICTIONARY,
   EDIT_DICTIONARY_SUCCESS,
@@ -16,7 +17,10 @@ import {
 import dictionaries from '../../__mocks__/dictionaries';
 import versions from '../../__mocks__/versions';
 
-const initialState = {};
+const initialState = {
+  loading: false,
+  mappings: [],
+};
 describe('Test suite for vote reducer', () => {
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual(initialState);
@@ -31,6 +35,18 @@ describe('Test suite for vote reducer', () => {
       },
     )).toEqual({
       organizations: {},
+    });
+  });
+
+  it('should handle FETCH_DICTIONARY_MAPPINGS', () => {
+    expect(reducer(
+      {},
+      {
+        type: FETCH_DICTIONARY_MAPPINGS,
+        payload: {},
+      },
+    )).toEqual({
+      mappings: {},
     });
   });
 });

--- a/src/tests/dictionaryConcepts/container/DictionaryMappings.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryMappings.test.jsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import { createMockStore } from 'redux-test-utils';
+import { Provider } from 'react-redux';
+import Router from 'react-mock-router';
+
+import {
+  DictionaryMappings,
+  mapStateToProps,
+} from '../../../components/dictionaryConcepts/containers/DictionaryMappings';
+
+const store = createMockStore({
+  organizations: {
+    organizations: [],
+  },
+});
+let wrapper;
+let props;
+
+describe('Test suite for dictionary mappings components', () => {
+  beforeEach(() => {
+    props = {
+      match: {
+        params: {
+          typeName: 'dev-col',
+          type: 'orgs',
+          collectionName: 'dev-col',
+          dictionaryName: 'dev-col',
+        },
+      },
+      location: {
+        pathname: '/random/path',
+      },
+      fetchDictionaryMappings: jest.fn(),
+      mappings: [{
+        to_concept_name: 'random_name',
+        from_concept_name: 'random_name',
+        map_type: 'Map As Type',
+        source: 'random source',
+      }],
+      filteredClass: ['Diagnosis'],
+      filteredSources: ['CIEL'],
+      loading: false,
+      to: 'random',
+    };
+    localStorage.setItem('dictionaryPathName', '/concepts/users/admin/858738987555379984/Malaria/en');
+    wrapper = mount(<Provider store={store}>
+      <Router>
+        <DictionaryMappings {...props} />
+      </Router>
+    </Provider>);
+  });
+
+  it('should render component without breaking', () => {
+    localStorage.setItem('dictionaryName', 'Malaria');
+    expect(wrapper.find('section').length).toEqual(2);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should paginate components with more than 10 mappings', () => {
+    props = {
+      match: {
+        params: {
+          typeName: 'dev-col',
+          type: 'orgs',
+          collectionName: 'dev-col',
+          dictionaryName: 'dev-col',
+        },
+      },
+      location: {
+        pathname: '/random/path',
+      },
+      fetchDictionaryMappings: jest.fn(),
+      mappings: [
+        {
+        to_concept_name: 'random_name',
+        from_concept_name: 'random_name',
+        map_type: 'Map As Type',
+        source: 'random source',
+      },
+        {
+        to_concept_name: 'random_name',
+        from_concept_name: 'random_name',
+        map_type: 'Map As Type',
+        source: 'random source',
+      },
+        {
+        to_concept_name: 'random_name',
+        from_concept_name: 'random_name',
+        map_type: 'Map As Type',
+        source: 'random source',
+      },
+        {
+        to_concept_name: 'random_name',
+        from_concept_name: 'random_name',
+        map_type: 'Map As Type',
+        source: 'random source',
+      },
+        {
+        to_concept_name: 'random_name',
+        from_concept_name: 'random_name',
+        map_type: 'Map As Type',
+        source: 'random source',
+      },
+        {
+        to_concept_name: 'random_name',
+        from_concept_name: 'random_name',
+        map_type: 'Map As Type',
+        source: 'random source',
+      },
+        {
+        to_concept_name: 'random_name',
+        from_concept_name: 'random_name',
+        map_type: 'Map As Type',
+        source: 'random source',
+      },
+        {
+        to_concept_name: 'random_name',
+        from_concept_name: 'random_name',
+        map_type: 'Map As Type',
+        source: 'random source',
+      },
+        {
+        to_concept_name: 'random_name',
+        from_concept_name: 'random_name',
+        map_type: 'Map As Type',
+        source: 'random source',
+      },
+        {
+        to_concept_name: 'random_name',
+        from_concept_name: 'random_name',
+        map_type: 'Map As Type',
+        source: 'random source',
+      },
+        {
+        to_concept_name: 'random_name',
+        from_concept_name: 'random_name',
+        map_type: 'Map As Type',
+        source: 'random source',
+      },
+      ],
+      filteredClass: ['Diagnosis'],
+      filteredSources: ['CIEL'],
+      loading: false,
+      to: 'random',
+    };
+    localStorage.setItem('dictionaryPathName', '/concepts/users/admin/858738987555379984/Malaria/en');
+    wrapper = mount(<Provider store={store}>
+      <Router>
+        <DictionaryMappings {...props} />
+      </Router>
+    </Provider>);
+    expect(wrapper.find('.-totalPages').text()).toBe('2');
+  });
+
+  it('should test loader', () => {
+    const app = shallow(<DictionaryMappings {...props} />);
+    app.setProps({
+      mapppings: [],
+      loading: true,
+    });
+    expect(app.find('Loader').length).toEqual(1);
+  });
+
+  it('should show no mappings', () => {
+    const propsHere = {
+      match: {
+        params: {
+          typeName: 'dev-col',
+          type: 'orgs',
+          collectionName: 'dev-col',
+          dictionaryName: 'dev-col',
+        },
+      },
+      location: {
+        pathname: '/random/path',
+      },
+      fetchDictionaryMappings: jest.fn(),
+      filteredClass: ['Diagnosis'],
+      filteredSources: ['CIEL'],
+      to: 'random',
+      mappings: [],
+      loading: false,
+    };
+    const app = shallow(<DictionaryMappings {...propsHere} />);
+    expect(app.find('h3').text()).toBe('No mappings found! ');
+  });
+
+  it('should have initial state', () => {
+    const app = shallow(<DictionaryMappings {...props} />);
+    expect(app.state().mappingLimit).toBe(10);
+  });
+
+  it('should filter mappings in the table', () => {
+    const event = {
+      target: {
+        value: 'random',
+      },
+    };
+    const dictionaryMappingsWrapper = wrapper.find('DictionaryMappings').instance();
+    const spy = jest.spyOn(dictionaryMappingsWrapper, 'filterCaseInsensitive');
+    dictionaryMappingsWrapper.forceUpdate();
+    wrapper.find('ReactTable').find('input').at(0).simulate('change', event);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should test mapStateToProps', () => {
+    const initialState = {
+      match: {
+        params: {
+          typeName: 'dev-col',
+          type: 'orgs',
+          collectionName: 'dev-col',
+          dictionaryName: 'dev-col',
+        },
+      },
+      concepts: {
+        loading: false,
+      },
+      organizations: {
+        mappings: [],
+      },
+    };
+    expect(mapStateToProps(initialState).loading).toEqual(false);
+  });
+});


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-321: Implement view all mappings ](https://issues.openmrs.org/browse/OCLOMRS-321)

# Summary:
- In this ticket, I worked on functionality to display given dictionary mappings. A user can filter mappings by all mapping's attributes e.g `map-type`, `from-concept-name`