### PR TITLE
OCLOMRS-334: Make the link in NotFound.js file to use "Link" instead of "a" tag

### DIFF
--- a/src/components/NotFound.js
+++ b/src/components/NotFound.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const NotFound = () => (
   <div className="not-found">
@@ -6,11 +7,11 @@ const NotFound = () => (
       <h2 className="error-template">Oops!, Page Not Found</h2>
 
       <div className="error-actions">
-        <a href="/" className="btn btn-primary btn-lg btn-not-found">
+        <Link to="/" className="btn btn-primary btn-lg btn-not-found">
           <span className="fa fa-home" />
               Take me back home
           {' '}
-        </a>
+        </Link>
       </div>
 
     </div>

--- a/src/tests/Auth/notFound.test.js
+++ b/src/tests/Auth/notFound.test.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
 import NotFound from '../../components/NotFound';
 
 describe('Not found Component', () => {
-  const wrapper = mount(<NotFound />);
+  const wrapper = mount(<MemoryRouter><NotFound /></MemoryRouter>);
   it('should render without crashing', () => {
     expect(wrapper).toMatchSnapshot();
-    expect(mount.bind(null, <NotFound />)).not.toThrow();
+    expect(mount.bind(null, <MemoryRouter><NotFound /></MemoryRouter>)).not.toThrow();
   });
 });


### PR DESCRIPTION


# JIRA TICKET NAME:
[Make the link in NotFound.js file to use "Link" instead of "a" tag](https://issues.openmrs.org/browse/OCLOMRS-334)

# Summary:


The Link back to the home page in the NotFound.js file should take advantage of the react-router `Link` rather than HTML's `<a>`

