### PR TITLE
OCLOMRS-336: Display all concepts in the concepts table

### DIFF
--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -120,18 +120,18 @@ export const fetchDictionaryConcepts = (
   page = 1,
 ) => async (dispatch, getState) => {
   dispatch(isFetching(true));
-  let url = `${conceptType}/${conceptOwner}/sources/${conceptName}/concepts/?includeMappings=true&q=${query}&limit=${limit}&page=${page}&verbose=true`;
+  let url = `${conceptType}/${conceptOwner}/collections/${conceptName}/concepts/?includeMappings=true&q=${query}&limit=${limit}&page=${page}&verbose=true`;
   const filterBySource = getState().concepts.filteredBySource;
   const filterByClass = getState().concepts.filteredByClass;
 
   if (filterBySource.length > 0 && filterByClass.length > 0) {
-    url = `${conceptType}/${conceptOwner}/sources/${conceptName}/concepts/?q=${query}&limit=${limit}&page=${page}&verbose=true&source=${filterBySource.join(',')}&conceptClass=${filterByClass.join(',')}`;
+    url = `${conceptType}/${conceptOwner}/collections/${conceptName}/concepts/?q=${query}&limit=${limit}&page=${page}&verbose=true&source=${filterBySource.join(',')}&conceptClass=${filterByClass.join(',')}`;
   }
   if (filterBySource.length > 0 && filterByClass.length === 0) {
-    url = `${conceptType}/${conceptOwner}/sources/${conceptName}/concepts/?q=${query}&limit=${limit}&page=${page}&verbose=true&source=${filterBySource.join(',')}`;
+    url = `${conceptType}/${conceptOwner}/collections/${conceptName}/concepts/?q=${query}&limit=${limit}&page=${page}&verbose=true&source=${filterBySource.join(',')}`;
   }
   if (filterBySource.length === 0 && filterByClass.length > 0) {
-    url = `${conceptType}/${conceptOwner}/sources/${conceptName}/concepts/?q=${query}&limit=${limit}&page=${page}&verbose=true&conceptClass=${filterByClass.join(',')}`;
+    url = `${conceptType}/${conceptOwner}/collections/${conceptName}/concepts/?q=${query}&limit=${limit}&page=${page}&verbose=true&conceptClass=${filterByClass.join(',')}`;
   }
   try {
     const response = await instance.get(url);

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -100,6 +100,84 @@ describe('Test suite for dictionary concept actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
+
+  it('should handle FETCH_DICTIONARY_CONCEPT_WITH_SOURCE_FILTERS', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [concepts],
+      });
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_DICTIONARY_CONCEPT, payload: [concepts] },
+      { type: TOTAL_CONCEPT_COUNT, payload: 1 },
+      { type: FETCH_NEXT_CONCEPTS, payload: [concepts] },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    mockConceptStore.concepts.filteredBySource = ['CIEL'];
+    const store = mockStore(mockConceptStore);
+
+    return store.dispatch(fetchDictionaryConcepts('orgs', 'CIEL', 'CIEL')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should handle FETCH_DICTIONARY_CONCEPT_WITH_CLASS_FILTERS', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [concepts],
+      });
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_DICTIONARY_CONCEPT, payload: [concepts] },
+      { type: TOTAL_CONCEPT_COUNT, payload: 1 },
+      { type: FETCH_NEXT_CONCEPTS, payload: [concepts] },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    mockConceptStore.concepts.filteredBySource = [];
+    mockConceptStore.concepts.filteredByClass = ['procedure'];
+    const store = mockStore(mockConceptStore);
+
+    return store.dispatch(fetchDictionaryConcepts('orgs', 'CIEL', 'CIEL')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should handle FETCH_DICTIONARY_CONCEPT_WITH_CLASS_AND_SOURCE_FILTERS', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [concepts],
+      });
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_DICTIONARY_CONCEPT, payload: [concepts] },
+      { type: TOTAL_CONCEPT_COUNT, payload: 1 },
+      { type: FETCH_NEXT_CONCEPTS, payload: [concepts] },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    mockConceptStore.concepts.filteredBySource = ['CIEL'];
+    mockConceptStore.concepts.filteredByClass = ['procedure'];
+    const store = mockStore({ ...mockConceptStore, filteredByClass: ['procedure'] });
+
+    return store.dispatch(fetchDictionaryConcepts('orgs', 'CIEL', 'CIEL')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
   it('should handle error in FETCH_DICTIONARY_CONCEPT', () => {
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();


### PR DESCRIPTION
# JIRA TICKET NAME:
[Display all concepts in the concepts table](https://issues.openmrs.org/browse/OCLOMRS-336)

# Summary:
The concepts table shows custom concepts alone. This PR will fix that, such that all concepts both custom and from existing sources are shown.