### PR TITLE
OCLOMRS-337: Load CIEL concepts on search only

### DIFF
--- a/src/components/bulkConcepts/component/ConceptTable.jsx
+++ b/src/components/bulkConcepts/component/ConceptTable.jsx
@@ -16,7 +16,7 @@ const ConceptTable = ({
     );
   }
   const filter = { filterMethod: filterConcept, filterAll: true };
-    return (
+  return (
       <div className="row col-12 custom-concept-list">
         <ReactTable
           data={concepts}
@@ -70,7 +70,7 @@ const ConceptTable = ({
           className="-striped -highlight"
         />
       </div>
-    );
+  );
 };
 
 ConceptTable.propTypes = {

--- a/src/components/bulkConcepts/component/SearchBar.jsx
+++ b/src/components/bulkConcepts/component/SearchBar.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Button } from 'reactstrap';
 
-const SearchBar = ({ handleChange, searchInput, handleSearch }) => (
+const SearchBar = ({
+  fetchAll, handleChange, searchInput, handleSearch,
+}) => (
   <div className="row search-container">
-    <div className="concept-search-wrapper col-12 col-md-5 col-sm-8">
+    <div className="concept-search-wrapper col-9 col-md-5 col-sm-8">
       <i className="fa fa-search search-icons" aria-hidden="true" />
       <form onSubmit={handleSearch} id="submit-search-form">
         <input
@@ -13,9 +16,13 @@ const SearchBar = ({ handleChange, searchInput, handleSearch }) => (
           id="search-concept"
           value={searchInput}
           onChange={handleChange}
-          placeholder="search"
+          placeholder="search concept"
+          required
         />
       </form>
+    </div>
+    <div className="col-3">
+      <Button color="secondary" onClick={fetchAll}>Show all</Button>
     </div>
   </div>
 );
@@ -24,6 +31,7 @@ SearchBar.propTypes = {
   handleSearch: PropTypes.func.isRequired,
   searchInput: PropTypes.string.isRequired,
   handleChange: PropTypes.func.isRequired,
+  fetchAll: PropTypes.func.isRequired,
 };
 
 export default SearchBar;

--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -54,17 +54,13 @@ export class BulkConceptsPage extends Component {
     };
   }
 
-  componentDidMount() {
-    this.props.fetchBulkConcepts();
-  }
-
   handleFilter = (event) => {
     const {
       target: { name },
     } = event;
     const targetName = name.split(',');
     const query = `q=${this.state.searchInput}`;
-    if (targetName[1] === 'datatype') {
+    if ((targetName[1]).trim() === 'datatype') {
       this.props.addToFilterList(targetName[0], 'datatype', query);
     } else {
       this.props.addToFilterList(targetName[0], 'classes', query);
@@ -76,18 +72,17 @@ export class BulkConceptsPage extends Component {
       target: { value },
     } = event;
     this.setState(() => ({ searchInput: value }));
-    if (!value) {
-      this.props.fetchFilteredConcepts('CIEL');
-    }
   };
+
+  fetchAll = () => {
+    this.props.fetchBulkConcepts();
+  }
 
   handleSearch = (event) => {
     event.preventDefault();
     const { searchInput } = this.state;
-    if (searchInput.trim() !== searchInput) {
-      const query = `q=${this.state.searchInput}`;
-      this.props.fetchFilteredConcepts('CIEL', query);
-    }
+    const query = `q=${searchInput.trim()}`;
+    this.props.fetchFilteredConcepts('CIEL', query);
   };
 
   filterCaseInsensitive = (filter, rows) => {
@@ -126,6 +121,7 @@ export class BulkConceptsPage extends Component {
           />
           <div className="col-10 col-md-9 bulk-concept-wrapper custom-full-width">
             <SearchBar
+              fetchAll={this.fetchAll}
               handleSearch={this.handleSearch}
               handleChange={this.handleChange}
               searchInput={searchInput}

--- a/src/redux/reducers/bulkConceptReducer.js
+++ b/src/redux/reducers/bulkConceptReducer.js
@@ -27,6 +27,8 @@ const bulkConcepts = (state = userInitialState, action) => {
       return {
         ...state,
         bulkConcepts: action.payload,
+        datatypes: getDatatypes(action.payload),
+        classes: filterClass(action.payload),
       };
     case PREVIEW_CONCEPT:
       return {

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -168,8 +168,11 @@ describe('Test suite for BulkConceptsPage component', () => {
     const wrapper = mount(<Router>
       <BulkConceptsPage {...props} />
     </Router>);
-    const event = { target: { name: 'Diagnosis, datatype', checked: true } };
+    let event = { target: { name: 'Diagnosis, datatype', checked: true } };
     wrapper.find('#Diagnosis').simulate('change', event);
+    event = { target: { name: 'Diagnosis, classes', checked: true } };
+    wrapper.find('#Diagnosis').simulate('change', event);
+    expect(wrapper.find('BulkConceptsPage').props().addToFilterList).toHaveBeenCalledTimes(2);
   });
 
   it('should filter concepts in the table', () => {
@@ -258,5 +261,40 @@ describe('Test suite for BulkConceptsPage component', () => {
     expect(mapStateToProps(initialState).classes).toEqual([]);
     expect(mapStateToProps(initialState).preview).toEqual([]);
     expect(mapStateToProps(initialState).loading).toEqual(false);
+  });
+  it('should show all concepts', () => {
+    const props = {
+      fetchBulkConcepts: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      handleSearch: jest.fn(),
+      handleChange: jest.fn(),
+      inputValue: '',
+      concepts: [concepts],
+      loading: false,
+      datatypes: ['text'],
+      classes: ['Diagnosis'],
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+    };
+    const wrapper = mount(<Router>
+      <BulkConceptsPage {...props} />
+    </Router>);
+    const instance = wrapper.find('BulkConceptsPage').instance();
+    const spy = jest.spyOn(instance, 'fetchAll');
+    instance.forceUpdate();
+    const showAllBtn = wrapper.find('Button');
+    showAllBtn.simulate('click');
+    expect(spy).toHaveBeenCalled();
   });
 });

--- a/src/tests/bulkConcepts/reducer/index.test.js
+++ b/src/tests/bulkConcepts/reducer/index.test.js
@@ -84,6 +84,8 @@ describe('Test suite for bulkConcepts reducer', () => {
     expect(reducer(state, action)).toEqual({
       ...state,
       bulkConcepts: action.payload,
+      classes: [undefined],
+      datatypes: [undefined],
     });
   });
   it('should handle PREVIEW_CONCEPT', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Load CIEL concepts on search only](https://issues.openmrs.org/browse/OCLOMRS-337)

# Summary:
Initially importing CIEL concepts to a dictionary loads for too long even with only 1217 concepts. Make it easier to load only when a search is entered.
