### PR TITLE
OCLOMRS-335: Fix 'Take me back home' button alignment

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -96,7 +96,7 @@
 .btn-not-found {
   background-color: #495056;
   border-color: white;
-  margin-bottom: -287% !important;
+  margin-bottom: -310% !important;
 }
 .error-template {
   margin-top: 10px !important;


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-335: Put the "Take me back home" button lower on the Not Found page](https://issues.openmrs.org/browse/OCLOMRS-335)

# Summary:
Fix the `Take me back` home button CSS margin to move a bit lower.