### PR TITLE
OCLOMRS-331: Add custom error messages when fetching the API while offline

### DIFF
--- a/src/redux/actions/auth/authActions.js
+++ b/src/redux/actions/auth/authActions.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import {
   login, loginFailed, loginStarted, logout,
 } from './authActionCreators';
+import { showNetworkError } from '../dictionaries/dictionaryActionCreators';
 
 const BASE_URL = 'https://api.qa.openconceptlab.org/';
 
@@ -19,17 +20,17 @@ const loginAction = ({ username, password }) => (dispatch) => {
     localStorage.setItem('username', `${username}`);
     return dispatch(login(response));
   }).catch((error) => {
-    if (error.response) {
-      let errorMessage = error.response.data.detail;
-      if (errorMessage === 'Not found.') {
-        errorMessage = 'No such user was found.';
-      }
-      if (errorMessage === 'Passwords did not match.') {
-        errorMessage = 'Either the username or password you provided is incorrect.';
-      }
-      return dispatch(loginFailed(errorMessage));
+    if (error.response === undefined) {
+      return showNetworkError();
     }
-    return dispatch(loginFailed('Please check your internet connection.'));
+    let errorMessage = error.response.data.detail;
+    if (errorMessage === 'Not found.') {
+      errorMessage = 'No such user was found.';
+    }
+    if (errorMessage === 'Passwords did not match.') {
+      errorMessage = 'Either the username or password you provided is incorrect.';
+    }
+    return dispatch(loginFailed(errorMessage));
   });
 };
 

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -1,5 +1,6 @@
 import uuid from 'uuid/v4';
 import { notify } from 'react-notify-toast';
+import { showNetworkError } from '../dictionaries/dictionaryActionCreators';
 
 import {
   POPULATE_SIDEBAR,
@@ -141,9 +142,10 @@ export const fetchDictionaryConcepts = (
       dispatch(populateSidenav());
     }
   } catch (error) {
-    if (error.response) {
+    if (error.response !== undefined) {
       dispatch(isErrored(error.response.data, FETCH_DICTIONARY_CONCEPT));
     }
+    showNetworkError();
   }
   dispatch(isFetching(false));
 };

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -19,7 +19,7 @@ import { filterPayload } from '../../reducers/util';
 import { addDictionaryReference } from '../bulkConcepts';
 import api from '../../api';
 
-const showNetworkError = () => (
+export const showNetworkError = () => (
   notify.show('Network Error. Please try again later!', 'error', 6000));
 
 /* eslint-disable */
@@ -35,10 +35,12 @@ export const createDictionary = data => async dispatch =>
         notify.show(
           'Successfully added dictionary to your organization',
           'success', 6000,
-        ),
+        ), 
       )})
-    .catch(error =>
-      notify.show(`${error.response.data.__all__[0]}`, 'error', 6000));
+    .catch(error => {
+      error.response ? notify.show(`${error.response.data.__all__[0]}`, 'error', 6000):
+      showNetworkError();
+    });
 
 export const createDictionaryUser = data => dispatch =>
   api.dictionaries
@@ -54,8 +56,10 @@ export const createDictionaryUser = data => dispatch =>
           'success', 6000,
         ),
       )})
-    .catch(error =>
-      notify.show(`${error.response.data.__all__[0]}`, 'error', 6000));
+    .catch(error => {
+      error.response ? notify.show(`${error.response.data.__all__[0]}`, 'error', 6000) : 
+      showNetworkError();
+    });
 
 export const fetchingOrganizations = () => dispatch =>
   api.organizations
@@ -196,7 +200,8 @@ export const releaseHead = (url, data) => (dispatch) => {
         return dispatch(editDictionarySuccess(payload));
       })
       .catch(error => {
-        notify.show(`${error.response.data.__all__[0]}`, 'error', 6000);
+        error.response ? notify.show(`${error.response.data.__all__[0]}`, 'error', 6000) :
+        showNetworkError();
       })
 };
 

--- a/src/tests/Dashboard/action/api.test.js
+++ b/src/tests/Dashboard/action/api.test.js
@@ -81,6 +81,57 @@ describe('Test suite for dictionary actions', () => {
       });
   });
 
+  it('should display an error for organization when trying to dispatch ADD_DICTIONARY when offline', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        status: 599,
+      });
+    });
+
+    const expectedActions = [];
+
+    const store = mockStore({});
+
+    const data = {
+     conceptUrl: '/concept-url',
+    }
+
+    return store
+      .dispatch(createDictionary(data))
+      .then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+      });
+  });
+
+  it('should dispatch ADD_DICTIONARY error for organization', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 400,
+        response: {
+          __all__: [
+            'could not create dictionary'
+          ],
+        }
+      });
+    });
+
+    const expectedActions = [];
+
+    const store = mockStore({});
+
+    const data = {
+     conceptUrl: '/concept-url',
+    }
+
+    return store
+      .dispatch(createDictionary(data))
+      .then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+      });
+  });
+
   it('should dispatch ADD_DICTIONARY for user', () => {
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();
@@ -95,6 +146,57 @@ describe('Test suite for dictionary actions', () => {
     const expectedActions = [
       { type: ADDING_DICTIONARY, payload: {data: {}} },
     ];
+
+    const store = mockStore({});
+
+    const data = {
+     conceptUrl: '/concept-url',
+    }
+
+    return store
+      .dispatch(createDictionaryUser(data))
+      .then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+      });
+  });
+
+  it('should display an error for user when trying to dispatch ADD_DICTIONARY when offline', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        status: 599,
+      });
+    });
+
+    const expectedActions = [];
+
+    const store = mockStore({});
+
+    const data = {
+     conceptUrl: '/concept-url',
+    }
+
+    return store
+      .dispatch(createDictionaryUser(data))
+      .then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+      });
+  });
+
+  it('should dispatch ADD_DICTIONARY error for user', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 400,
+        response: {
+          __all__: [
+            'could not create dictionary'
+          ],
+        }
+      });
+    });
+
+    const expectedActions = [];
 
     const store = mockStore({});
 

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -342,6 +342,21 @@ describe('Test suite for dictionary actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
+
+  it('should display error message when offline', () => {
+    const dictionary = dictionaries;
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        status: 599,
+      });
+    });
+    const expectedActions = [];
+    const store = mockStore({ payload: {} });
+    return store.dispatch(editDictionary('/dictionary-url', dictionary)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
 });
 
 describe('Test for successful dictionaries fetch, failure and refresh', () => {

--- a/src/tests/Login/actions/login.test.js
+++ b/src/tests/Login/actions/login.test.js
@@ -113,11 +113,11 @@ describe('Test suite for login action', () => {
       });
   });
 
-  it('should handle no internet connection', async () => {
+  it('should handle login attempt when offline', async () => {
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();
-      request.respondWith({
-        response: undefined,
+      request.reject({
+        status: 599,
       });
     });
 
@@ -125,11 +125,6 @@ describe('Test suite for login action', () => {
       {
         type: AUTHENTICATION_IN_PROGRESS,
         loading: true,
-      },
-      {
-        type: AUTHENTICATION_FAILED,
-        payload: { errorMessage: 'Please check your internet connection.' },
-        loading: false,
       }];
 
     const store = mockStore();


### PR DESCRIPTION
# JIRA TICKET NAME:
[Add custom error messages when fetching the API while offline](https://issues.openmrs.org/browse/OCLOMRS-331)

# Summary:
Currently, there are no error messages when trying to access the API when offline hence providing a descriptive information makes the user aware that they are offline at that time.