### PR TITLE
OCLOMRS-343: Fix the description overlap in the concept preview form.

### DIFF
--- a/src/styles/bulk_concepts.scss
+++ b/src/styles/bulk_concepts.scss
@@ -153,6 +153,7 @@ legend.scheduler-border {
   background: #e8e9eb;
   color: #2c2e35;
   padding: .7rem;
+  overflow-x: scroll;
 }
 
 .fas.fas-arrow-left {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix the description overlap in the concept preview form.](https://issues.openmrs.org/browse/OCLOMRS-343)

# Summary:
Currently, when a user clicks on the "preview concept" button, the description overlaps the form.