### PR TITLE
OCLOMRS-341: Fix preview CIEL concept card overflow

### DIFF
--- a/src/styles/bulk_concepts.scss
+++ b/src/styles/bulk_concepts.scss
@@ -153,6 +153,7 @@ legend.scheduler-border {
   background: #e8e9eb;
   color: #2c2e35;
   padding: .7rem;
+  white-space: normal;
 }
 
 .fas.fas-arrow-left {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix preview CIEL concept card overflow](https://issues.openmrs.org/browse/OCLOMRS-341)

# Summary:
The description fo the preview overflowed from the container.
Fixed it by wrapping the text to prevent overflow.