### PR TITLE
OCLOMRS-339: Fix the "No concept/No mapping" info display position on all the react tables

### DIFF
--- a/src/components/bulkConcepts/bulkConceptList.jsx
+++ b/src/components/bulkConcepts/bulkConceptList.jsx
@@ -59,7 +59,7 @@ const BulkConceptList = ({
             ...filter,
           },
         ]}
-        className="-striped -highlight"
+        className="-striped -highlight custom-table-min-height"
       />
     );
   }

--- a/src/components/bulkConcepts/component/ConceptTable.jsx
+++ b/src/components/bulkConcepts/component/ConceptTable.jsx
@@ -69,7 +69,7 @@ const ConceptTable = ({
               ),
             },
           ]}
-          className="-striped -highlight"
+          className="-striped -highlight custom-table-min-height"
         />
       </div>
     );

--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -77,7 +77,7 @@ const ConceptTable = ({
               },
             },
           ]}
-          className="-striped -highlight custom-table-width"
+          className="-striped -highlight custom-table-width custom-table-min-height"
         />
       </div>
     );

--- a/src/components/dictionaryConcepts/components/ViewMappingsModal.jsx
+++ b/src/components/dictionaryConcepts/components/ViewMappingsModal.jsx
@@ -69,7 +69,7 @@ export const ViewMappingsModal = ({
                 ),
               },
             ]}
-            className="-striped -highlight custom-table-width"
+            className="-striped -highlight custom-table-width custom-table-min-height"
           />
         </div>
       </ModalBody>

--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -339,6 +339,10 @@ input:-webkit-autofill:active {
   width: 100% !important;
 }
 
+.custom-table-min-height {
+  min-height: 50vh;
+}
+
 @media only screen and (max-width : 992px) {
 
   .bulk-concepts {


### PR DESCRIPTION

# JIRA TICKET NAME:
[Fix the "No concept/No mapping" info display position on all the react tables](https://issues.openmrs.org/browse/OCLOMRS-339)

# Summary:
Previously, the "No concepts/No mappings" info was overlapping other table rows and columns. This is fixed by this PR.