### PR TITLE
OCLOMRS-345: Remove "(Other preferred sources here)" from Bulk add co…

### DIFF
--- a/src/components/bulkConcepts/addBulkConcepts.jsx
+++ b/src/components/bulkConcepts/addBulkConcepts.jsx
@@ -105,19 +105,6 @@ export class AddBulkConcepts extends Component {
               </label>
             </div>
             <br />
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="exampleRadios"
-                id="exampleRadios2"
-                value="option2"
-              />
-              <label className="form-check-label" htmlFor="exampleRadios2">
-                (Other preferred sources here)
-              </label>
-            </div>{' '}
-            <br />
             <div id="other-search">
               <div className="form-check">
                 <input


### PR DESCRIPTION
# JIRA TICKET NAME:
[Remove "(Other preferred sources here)" from Bulk add concepts page](https://issues.openmrs.org/browse/OCLOMRS-345)

# Summary:
The Option called “(Other preferred sources here)” was a placeholder in the mockup, and is not supposed to be in the real UI