### PR TITLE
OCLOMRS-346: Remove radio button on "Other" option on bulk add concepts page

### DIFF
--- a/src/components/bulkConcepts/addBulkConcepts.jsx
+++ b/src/components/bulkConcepts/addBulkConcepts.jsx
@@ -123,13 +123,6 @@ export class AddBulkConcepts extends Component {
             <br />
             <div id="other-search">
               <div className="form-check">
-                <input
-                  className="form-check-input"
-                  type="radio"
-                  name="exampleRadios"
-                  id="exampleRadios3"
-                  value="option3"
-                />
                 <label className="form-check-label" htmlFor="exampleRadios3">
                   Other:&nbsp;&nbsp;
                 </label>


### PR DESCRIPTION

# JIRA TICKET NAME:
[Remove radio button on "Other" option on bulk add concepts page](https://issues.openmrs.org/browse/OCLOMRS-346)

# Summary:
There’s a radio button followed by a search for Other; in practice, you don't need the radio button.
