### PR TITLE
OCLOMRS-353: Fix excessive padding in ReactTable on concepts page

### DIFF
--- a/src/components/bulkConcepts/bulkConceptList.jsx
+++ b/src/components/bulkConcepts/bulkConceptList.jsx
@@ -19,7 +19,7 @@ const BulkConceptList = ({
         defaultPageSize={cielConcepts.length <= conceptLimit ? cielConcepts.length : conceptLimit}
         filterable
         noDataText="No concept!"
-        minRows={0}
+        minRows={2}
         columns={[
           {
             Header: 'Select',
@@ -59,7 +59,7 @@ const BulkConceptList = ({
             ...filter,
           },
         ]}
-        className="-striped -highlight custom-table-min-height"
+        className="-striped -highlight"
       />
     );
   }

--- a/src/components/bulkConcepts/component/ConceptTable.jsx
+++ b/src/components/bulkConcepts/component/ConceptTable.jsx
@@ -24,7 +24,7 @@ const ConceptTable = ({
           defaultPageSize={concepts.length <= conceptLimit ? concepts.length : conceptLimit}
           filterable
           noDataText="No concepts found!"
-          minRows={0}
+          minRows={2}
           columns={[
             {
               Header: 'Name',
@@ -67,7 +67,7 @@ const ConceptTable = ({
               ),
             },
           ]}
-          className="-striped -highlight custom-table-min-height"
+          className="-striped -highlight"
         />
       </div>
     );

--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -45,7 +45,7 @@ const ConceptTable = ({
           defaultPageSize={concepts.length <= conceptLimit ? concepts.length : conceptLimit}
           filterable
           noDataText="No concept!"
-          minRows={0}
+          minRows={2}
           columns={[
             {
               Header: 'Name',
@@ -82,7 +82,7 @@ const ConceptTable = ({
               },
             },
           ]}
-          className="-striped -highlight custom-table-width custom-table-min-height"
+          className="-striped -highlight custom-table-width"
         />
       </div>
     );

--- a/src/components/dictionaryConcepts/components/ViewMappingsModal.jsx
+++ b/src/components/dictionaryConcepts/components/ViewMappingsModal.jsx
@@ -34,7 +34,7 @@ export const ViewMappingsModal = ({
             defaultPageSize={mappings.length <= mappingLimit ? mappings.length : mappingLimit}
             filterable
             noDataText="No mappings!"
-            minRows={0}
+            minRows={2}
             columns={[
               {
                 Header: 'From Concept Name',
@@ -79,7 +79,7 @@ export const ViewMappingsModal = ({
                 ),
               },
             ]}
-            className="-striped -highlight custom-table-width custom-table-min-height"
+            className="-striped -highlight custom-table-width"
           />
         </div>
       </ModalBody>

--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -339,10 +339,6 @@ input:-webkit-autofill:active {
   width: 100% !important;
 }
 
-.custom-table-min-height {
-  min-height: 50vh;
-}
-
 @media only screen and (max-width : 992px) {
 
   .bulk-concepts {


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-353: Fix excessive padding in ReactTable on concepts page](https://issues.openmrs.org/browse/OCLOMRS-353)

# Summary:
Previously, on the live website on the dictionary concepts page, when concepts are few (2) there was a lot of padding between concepts in ReactTable. This is fixed by this PR.