### PR TITLE
OCLOMRS-357: Run coveralls in verbose mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ script:
   - npm test -- -u --coverage
 
 after_success:
-  - coveralls < coverage/lcov.info
+  - coveralls -v < coverage/lcov.info


### PR DESCRIPTION
# JIRA TICKET NAME:
[Run coveralls in verbose mode](https://issues.openmrs.org/browse/OCLOMRS-357)

# Summary:
This ticket is about running coveralls in verbose mode in order to figure why Travis CI is not sending coverage reports