### PR TITLE
OCLOMRS-354:  Replaced table with textarea on bulk add concepts page

### DIFF
--- a/src/components/bulkConcepts/addBulkConcepts.jsx
+++ b/src/components/bulkConcepts/addBulkConcepts.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import matchSorter from 'match-sorter';
 import fetchCielConcepts, { addExistingBulkConcepts } from '../../redux/actions/bulkConcepts';
 import BulkConceptList from './bulkConceptList';
 import Header from './container/Header';
@@ -33,37 +32,8 @@ export class AddBulkConcepts extends Component {
     };
   }
 
-  handleAddAll = () => {
-    const {
-      match: {
-        params: { type, typeName, collectionName },
-      },
-    } = this.props;
-    const url = `${type}/${typeName}/collections/${collectionName}/references/`;
-    const { cielConcepts } = this.state;
-    this.props.addExistingBulkConcepts({ url, data: { data: { expressions: cielConcepts } } });
-    window.history.back();
-  };
   handleCielClick = () => {
     this.props.fetchCielConcepts();
-  };
-  handleSelect = (e) => {
-    const { value, checked } = e.target;
-    if (checked) {
-      this.setState({
-        cielConcepts: [value, ...this.state.cielConcepts],
-      });
-    } else {
-      const index = this.state.cielConcepts.indexOf(value);
-      this.setState({
-        cielConcepts: this.state.cielConcepts.filter((_, i) => i !== index),
-      });
-    }
-  };
-
-  filterCaseInsensitive = (filter, rows) => {
-    const id = filter.pivotId || filter.id;
-    return matchSorter(rows, filter.value, { keys: [id] });
   };
 
   render() {
@@ -84,8 +54,8 @@ export class AddBulkConcepts extends Component {
         <h3>
           <strong>{dictionaryName} Dictionary</strong>: Bulk Add Concepts
         </h3>
-        <fieldset className="scheduler-border">
-          <legend className="scheduler-border">Select a source</legend>
+        <div className="scheduler-border">
+          <h3>Select a source</h3>
           <div className="select-box">
             <div className="form-check">
               <input
@@ -126,31 +96,30 @@ export class AddBulkConcepts extends Component {
               </div>
             </div>
           </div>
-        </fieldset>
-        <h4>Concept IDs to add</h4>
-        <div className="preferred-concepts">
-          <BulkConceptList
-            cielConcepts={cielConcepts}
-            fetching={this.props.isFetching}
-            handleSelect={this.handleSelect}
-            filterConcept={this.filterCaseInsensitive}
-            conceptLimit={conceptLimit}
-          />
-        </div>
-        <br />
-        <div className="add-all-btn">
-          <Link
-            to={`/concepts/${type}/${typeName}/${collectionName}/${dictionaryName}/${language}/`}
-            className="btn btn-secondary"
-          >
-          Go back
-          </Link>
-          {' '}
-          {this.state.cielConcepts.length === 0 ? (
+          <h3>Concept IDs to add</h3>
+          <div className="preferred-concepts">
+            <BulkConceptList
+              cielConcepts={cielConcepts}
+              fetching={this.props.isFetching}
+              handleSelect={this.handleSelect}
+              filterConcept={this.filterCaseInsensitive}
+              conceptLimit={conceptLimit}
+            />
+          </div>
+          <br />
+          <div className="add-all-btn">
+            <Link
+              to={`/concepts/${type}/${typeName}/${collectionName}/${dictionaryName}/${language}/`}
+              className="btn btn-secondary"
+            >
+              Cancel
+            </Link>
+            {' '}
+            {this.state.cielConcepts.length === 0 ? (
             <button type="button" className="btn btn-primary" id="btn-add-all" disabled={disableButton}>
-              <i className="fa fa-plus" /> Add All Selected
+              <i className="fa fa-plus" /> Add
             </button>
-          ) : (
+            ) : (
             <button
               type="button"
               className="btn btn-primary btn-add-all"
@@ -158,9 +127,10 @@ export class AddBulkConcepts extends Component {
               onClick={this.handleAddAll}
               disabled={disableButton}
             >
-              <i className="fa fa-plus" /> Add All Selected
+              <i className="fa fa-plus" /> Add
             </button>
-          )}
+            )}
+          </div>
         </div>
       </div>
     );

--- a/src/components/bulkConcepts/bulkConceptList.jsx
+++ b/src/components/bulkConcepts/bulkConceptList.jsx
@@ -1,66 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactTable from 'react-table';
+import {
+  Form,
+  FormGroup,
+  Input,
+} from 'reactstrap';
 import Loader from '../Loader';
 
 const BulkConceptList = ({
   cielConcepts,
   fetching,
-  handleSelect,
-  conceptLimit,
-  filterConcept,
 }) => {
-  const filter = { filterMethod: filterConcept, filterAll: true };
   if (cielConcepts.length >= 1) {
     return (
-      <ReactTable
-        data={cielConcepts}
-        loading={fetching}
-        defaultPageSize={cielConcepts.length <= conceptLimit ? cielConcepts.length : conceptLimit}
-        filterable
-        noDataText="No concept!"
-        minRows={2}
-        columns={[
-          {
-            Header: 'Select',
-            accessor: 'select',
-            filterable: false,
-            minWidth: 300,
-            Cell: ({ original: concept }) => (
-              <div className="custom-control custom-checkbox">
-                <input
-                  type="checkbox"
-                  className="table-check"
-                  value={concept.url}
-                  onChange={handleSelect}
-                />
-              </div>
-            ),
-          },
-          {
-            Header: 'Name',
-            accessor: 'display_name',
-            minWidth: 300,
-            ...filter,
-          },
-          {
-            Header: 'Datatype',
-            accessor: 'datatype',
-            ...filter,
-          },
-          {
-            Header: 'Source',
-            accessor: 'source',
-            ...filter,
-          },
-          {
-            Header: 'ID',
-            accessor: 'id',
-            ...filter,
-          },
-        ]}
-        className="-striped -highlight"
-      />
+      <Form className="bulkForm">
+        <FormGroup>
+          <Input type="textarea" name="text" id="exampleText" rows="10" />
+        </FormGroup>
+      </Form>
     );
   }
   if (fetching) {
@@ -81,8 +38,5 @@ BulkConceptList.propTypes = {
   cielConcepts: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string,
   })).isRequired,
-  handleSelect: PropTypes.func.isRequired,
-  conceptLimit: PropTypes.number.isRequired,
-  filterConcept: PropTypes.func.isRequired,
 };
 export default BulkConceptList;

--- a/src/styles/bulk_concepts.scss
+++ b/src/styles/bulk_concepts.scss
@@ -1,18 +1,16 @@
 @import url('https://fonts.googleapis.com/css?family=Slabo+27px');
-fieldset.scheduler-border {
-  border: 1px groove #ddd !important;
-  padding: 0 1.6em 1.6em 1.6em !important;
+.scheduler-border {
+  border: 0px groove #ddd !important;
+  padding: 0 1.6em 1.6em 1.9em !important;
   margin-bottom: 10px;
+  margin-top: 10px;
   -webkit-box-shadow: 0px 0px 0px 0px #000;
   box-shadow: 0px 0px 0px 0px #000;
 }
 
-legend.scheduler-border {
-  width: inherit;
-  padding: 0 20px;
-  border-bottom: none;
+.scheduler-border h3 {
+  font-weight: 500;
 }
-
 .preferred-concepts {
   border-style: groove;
   display: block;
@@ -26,6 +24,10 @@ legend.scheduler-border {
   margin-top: -3%;
   padding-right: 5%;
   padding-left: 5%;
+}
+
+.bulkForm {
+  margin-bottom: -15px;
 }
 
 #search {

--- a/src/tests/Dashboard/container/DictionaryDisplay.test.jsx
+++ b/src/tests/Dashboard/container/DictionaryDisplay.test.jsx
@@ -171,4 +171,22 @@ describe('DictionaryCard', () => {
     const wrapper = shallow(<DictionaryCard {...props} />);
     expect(wrapper).toMatchSnapshot();
   });
+  it('should render with owner type user', () => {
+    const props = {
+      dictionary: [dictionaries],
+    };
+    const wrapper = shallow(<DictionaryCard {...props} />);
+    const ownerWrapper = wrapper.find('small');
+    expect(ownerWrapper.text()).toBe('(user)');
+  });
+  it('should render with owner type org', () => {
+    const props = {
+      dictionary: {
+        owner_type: 'Organization',
+      },
+    };
+    const wrapper = shallow(<DictionaryCard {...props} />);
+    const ownerWrapper = wrapper.find('small');
+    expect(ownerWrapper.text()).toBe('(org)');
+  });
 });

--- a/src/tests/bulkConcepts/addBulkConcepts.test.jsx
+++ b/src/tests/bulkConcepts/addBulkConcepts.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { createMockStore } from 'redux-test-utils';
@@ -69,95 +69,22 @@ describe('Add Bulk Concepts', () => {
     </MemoryRouter>);
     wrapper.find('#btn-add-all').at(0).simulate('click');
   });
-
-
-  it('hanldleSelect is called and add concept', () => {
+  it('enables the Add all button when a concept is selected', () => {
     const props = {
       fetchCielConcepts: jest.fn(),
       addExistingBulkConcepts: jest.fn(),
-      cielConcepts: mockConcepts,
+      cielConcepts: [],
       isFetching: false,
       match,
       language: 'en',
     };
-    const wrapper = mount(<MemoryRouter>
-      <Provider store={store}>
-        <AddBulkConcepts {...props} />
-      </Provider>
-    </MemoryRouter>);
-    const event = {
-      preventDefault: jest.fn(),
-      target: {
-        value: ['/users/michy/collections/test/concepts/'],
-        checked: true,
-      },
-    };
-    const spy = jest.spyOn(wrapper.find('AddBulkConcepts').instance(), 'handleSelect');
-    wrapper.instance().forceUpdate();
-    wrapper.find('#ciel').at(0).simulate('click');
-    wrapper.find('.table-check').at(0).simulate('change', event);
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-  it('hanldleSelect is called and remove a concept', () => {
-    const props = {
-      fetchCielConcepts: jest.fn(),
-      addExistingBulkConcepts: jest.fn(),
-      cielConcepts: mockConcepts,
-      isFetching: false,
-      match,
-      language: 'en',
-    };
-    const wrapper = mount(<MemoryRouter>
-      <Provider store={store}>
-        <AddBulkConcepts {...props} />
-      </Provider>
-    </MemoryRouter>);
-    const event = {
-      preventDefault: jest.fn(),
-      target: {
-        value: ['/users/michy/collections/test/concepts/'],
-        checked: false,
-      },
-    };
-    const spy = jest.spyOn(wrapper.find('AddBulkConcepts').instance(), 'handleSelect');
-    wrapper.instance().forceUpdate();
-    wrapper.find('#ciel').at(0).simulate('click');
-    wrapper.find('.table-check').at(0).simulate('change', {
-      preventDefault: jest.fn(),
-      target: {
-        value: ['/users/michy/collections/test/concepts/'],
-        checked: true,
-      },
+    const wrapper = shallow(<AddBulkConcepts {...props} />);
+    wrapper.setState({
+      cielConcepts: [{
+        'concept-url': 'random',
+      }],
     });
-    wrapper.find('.table-check').at(0).simulate('change', event);
-    expect(spy).toHaveBeenCalled();
-  });
-  it('it should call hanldleAddAll and add a concept', () => {
-    const props = {
-      fetchCielConcepts: jest.fn(),
-      addExistingBulkConcepts: jest.fn(),
-      cielConcepts: mockConcepts,
-      isFetching: false,
-      match,
-      language: 'en',
-    };
-    const wrapper = mount(<MemoryRouter>
-      <Provider store={store}>
-        <AddBulkConcepts {...props} />
-      </Provider>
-    </MemoryRouter>);
-    const event = {
-      target: {
-        value: ['/users/michy/collections/test/concepts/'],
-        checked: true,
-      },
-    };
-    const spy = jest.spyOn(wrapper.find('AddBulkConcepts').instance(), 'handleAddAll');
-    wrapper.instance().forceUpdate();
-    wrapper.find('#ciel').at(0).simulate('click');
-    wrapper.find('.table-check').at(0).simulate('change', event);
-    wrapper.find('#btn-add-all').simulate('click');
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(wrapper.find('.btn-add-all').length).toBe(1);
   });
 
   it('should test mapStateToProps', () => {
@@ -168,32 +95,4 @@ describe('Add Bulk Concepts', () => {
     };
     expect(mapStateToProps(initialState).cielConcepts).toEqual(['1']);
   });
-});
-
-it('should filter concepts in the table', () => {
-  const props = {
-    fetchCielConcepts: jest.fn(),
-    addExistingBulkConcepts: jest.fn(),
-    cielConcepts: mockConcepts,
-    isFetching: false,
-    match,
-    datatypes: ['text'],
-    classes: ['Diagnosis'],
-    language: 'en',
-  };
-  const wrapper = mount(<MemoryRouter>
-    <Provider store={store}>
-      <AddBulkConcepts {...props} />
-    </Provider>
-  </MemoryRouter>);
-  const event = {
-    target: {
-      value: 'malaria',
-    },
-  };
-  const addBulkConceptsWrapper = wrapper.find('AddBulkConcepts').instance();
-  const spy = jest.spyOn(addBulkConceptsWrapper, 'filterCaseInsensitive');
-  addBulkConceptsWrapper.forceUpdate();
-  wrapper.find('ReactTable').find('input').at(0).simulate('change', event);
-  expect(spy).toHaveBeenCalled();
 });

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -143,6 +143,35 @@ describe('Test suite for BulkConceptsPage component', () => {
     wrapper.find('#Diagnosis').simulate('change', event);
   });
 
+  it('should filter search result with datatype', () => {
+    const props = {
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      concepts: [concepts],
+      loading: false,
+      datatypes: ['text'],
+      classes: ['Diagnosis'],
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+    };
+    const wrapper = mount(<Router>
+      <BulkConceptsPage {...props} />
+    </Router>);
+    const event = { target: { name: 'Diagnosis, datatype', checked: true } };
+    wrapper.find('#Diagnosis').simulate('change', event);
+  });
+
   it('should filter concepts in the table', () => {
     const props = {
       fetchBulkConcepts: jest.fn(),


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-354: Implement adding bulk concepts using IDs populated in the text area on bulk add concepts page](https://issues.openmrs.org/browse/OCLOMRS-354)

# Summary:
- Removed react table displaying concepts with a text are which will populate concepts IDs to be added to dictionary concepts.