### PR TITLE
OCLOMRS-362: Make the "NEXT" or "BACK" button darker on the pagination

### DIFF
--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -125,6 +125,16 @@ body {
   color: lightgray;
 }
 
+.-pagination .-btn:not([disabled]){
+  color: #303438;
+  background: rgba(108, 117, 125, 0.5);
+}
+
+.-pagination .-btn:not([disabled]):hover{
+  color: #fff;
+  background: #6c757d !important;
+}
+
 .search-container .concept-search-wrapper .fa-search {
   font-size: .8rem;
   padding-right: .7rem;


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make the "NEXT" or "BACK" button darker on the pagination](https://issues.openmrs.org/browse/OCLOMRS-362)

# Summary:
During pagination of concepts, when there are more items to scroll to, the "NEXT" button isn't significantly different from the when there are no "next" items to scroll to. The same applies to the "BACK" button.
This is fixed on this PR by adding custom styling to the buttons.