### PR TITLE
OCLOMRS-351: Make the Source column and on sidebar show Custom instead of UUID

### DIFF
--- a/src/components/dictionaryConcepts/components/SideNavItem.jsx
+++ b/src/components/dictionaryConcepts/components/SideNavItem.jsx
@@ -12,7 +12,7 @@ const SideNavItem = ({ item, handleChange, filterType }) => (
       onChange={handleChange}
     />
     <label className="custom-control-label" htmlFor={item}>
-      {item}
+      {filterType === 'source' && item !== 'CIEL' ? 'Custom' : item}
     </label>
   </div>
 );

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -155,6 +155,23 @@ export class DictionaryConcepts extends Component {
     return matchSorter(rows, filter.value, { keys: [id] });
   };
 
+  handleConcepts = (concepts) => {
+    const newConcepts = [];
+    concepts.forEach((concept) => {
+      if (concept.source !== 'CIEL') {
+        const newConcept = {
+          ...concept,
+          source: 'Custom',
+        };
+        newConcepts.push(newConcept);
+      }
+      if (concept.source === 'CIEL') {
+        newConcepts.push(concept);
+      }
+    });
+    return newConcepts;
+  }
+
   render() {
     const {
       match: {
@@ -169,6 +186,8 @@ export class DictionaryConcepts extends Component {
       loading,
       userIsMember,
     } = this.props;
+
+    const myConcepts = this.handleConcepts(concepts);
     const hasPermission = typeName === getUsername() || userIsMember;
     const org = {
       name: (type === 'orgs') ? typeName : '',
@@ -204,7 +223,7 @@ export class DictionaryConcepts extends Component {
           />
           <div className="col-12 col-md-10 custom-full-width">
             <ConceptTable
-              concepts={concepts}
+              concepts={myConcepts}
               loading={loading}
               conceptLimit={conceptLimit}
               org={org}

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -66,6 +66,11 @@ export const concept2 = {
   url: '/orgs/CIEL/sources/CIEL/concepts/146869/',
 };
 
+export const concept3 = {
+  ...concept2,
+  source: '12345678',
+};
+
 const concept = {
   id: '146869',
   external_id: '146869AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',

--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -8,7 +8,7 @@ import {
   DictionaryConcepts,
   mapStateToProps,
 } from '../../../components/dictionaryConcepts/containers/DictionaryConcepts';
-import concepts from '../../__mocks__/concepts';
+import concepts, { concept3 } from '../../__mocks__/concepts';
 
 const store = createMockStore({
   organizations: {
@@ -110,7 +110,7 @@ describe('Test suite for dictionary concepts components', () => {
       fetchDictionaryConcepts: jest.fn(),
       concepts: [concepts],
       filteredClass: ['Diagnosis'],
-      filteredSources: ['CIEL'],
+      filteredSources: ['1234567876'],
       loading: false,
       totalConceptCount: 11,
       filterBySource: jest.fn(),
@@ -145,7 +145,7 @@ describe('Test suite for dictionary concepts components', () => {
         pathname: '/random/path',
       },
       fetchDictionaryConcepts: jest.fn(),
-      concepts: [concepts],
+      concepts: [concept3],
       filteredClass: ['Diagnosis'],
       filteredSources: ['CIEL'],
       loading: false,


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make the Source column and on sidebar show CIEL instead of UUID](https://issues.openmrs.org/browse/OCLOMRS-351)

# Summary:
Source column is wrong. A source should be something like “CIEL”, but what is being displayed in that column looks like a UID. (Also it’s wrong in the sidebar.)