### PR TITLE
OCLOMRS-365: Make the modal disappear after deleting a concept and show concepts without the deleted concept.

### DIFF
--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -141,6 +141,7 @@ export class DictionaryConcepts extends Component {
     const { data, collectionName, type } = this.state;
     this.props
       .removeDictionaryConcept(data, type, this.props.match.params.typeName, collectionName);
+    this.closeDeleteModal();
   }
 
   handleShowDelete = (url) => {

--- a/src/redux/reducers/ConceptReducers.js
+++ b/src/redux/reducers/ConceptReducers.js
@@ -89,6 +89,8 @@ export default (state = initialState, action) => {
         ...state,
         paginatedConcepts: state.paginatedConcepts
           .filter(concept => concept.version_url !== action.payload),
+        dictionaryConcepts: state.dictionaryConcepts
+          .filter(concept => concept.version_url !== action.payload),
       };
     case TOTAL_CONCEPT_COUNT:
       return {

--- a/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
@@ -36,7 +36,7 @@ beforeEach(() => {
   state = {
     concepts: [],
     loading: false,
-    dictionaryConcepts: [],
+    dictionaryConcepts: [paginatedConcepts.concepts],
     paginatedConcepts: [paginatedConcepts.concepts],
     filteredSources: [],
     filteredClass: [],
@@ -273,6 +273,8 @@ describe('Test suite for single dictionary concepts', () => {
     expect(reducer(state, action)).toEqual({
       ...state,
       paginatedConcepts: state.paginatedConcepts
+        .filter(concept => concept.version_url !== action.payload),
+      dictionaryConcepts: state.dictionaryConcepts
         .filter(concept => concept.version_url !== action.payload),
     });
   });


### PR DESCRIPTION

# JIRA TICKET NAME:
[Make the modal disappear after deleting a concept and show concepts without the deleted concept.](https://issues.openmrs.org/browse/OCLOMRS-365)

# Summary:
Previously, after deleting a concept, the modal did not disappear automatically and after closing it, the table still showed the deleted concept untill the the page was refreshed. That behaviour is fixed in this PR.
