### PR TITLE
OCLOMRS-366: Clean props validation warnings in console when running tests

### DIFF
--- a/src/components/dictionaryConcepts/components/RemoveMappings.jsx
+++ b/src/components/dictionaryConcepts/components/RemoveMappings.jsx
@@ -54,7 +54,11 @@ RemoveMappings.propTypes = {
   handleDeleteMapping: PropTypes.func.isRequired,
   showDeleteMappingModal: PropTypes.func.isRequired,
   url: PropTypes.string.isRequired,
-  retired: PropTypes.bool.isRequired,
+  retired: PropTypes.bool,
+};
+
+RemoveMappings.defaultProps = {
+  retired: false,
 };
 
 export default RemoveMappings;

--- a/src/tests/dictionaryConcepts/components/ViewMappingsModal.test.js
+++ b/src/tests/dictionaryConcepts/components/ViewMappingsModal.test.js
@@ -64,7 +64,13 @@ describe('render ViewMappingsModal', () => {
   it('should render with a set mapping limit', () => {
     const newProps = {
       ...props,
-      mappings: [{}, {}, {}],
+      mappings: [{
+        url: '',
+      }, {
+        url: '',
+      }, {
+        url: '',
+      }],
       mappingLimit: 2,
     };
     wrapper = mount(


### PR DESCRIPTION
# JIRA TICKET NAME:
[Clean props validation warnings in console when running tests](https://issues.openmrs.org/browse/OCLOMRS-366)

# Summary:
Currently, due to props validation, the RemoveMappings component throws warnings of missing URL prop when tests are run. This ticket fixes the code to take out the warnings.