### PR TITLE
OCLOMRS-360: Add more content about the concept in the preview modal

### DIFF
--- a/src/components/bulkConcepts/component/CardBody.jsx
+++ b/src/components/bulkConcepts/component/CardBody.jsx
@@ -10,7 +10,7 @@ const CardBody = ({ title, body }) => (
 
 CardBody.propTypes = {
   title: PropTypes.string.isRequired,
-  body: PropTypes.any.isRequired,
+  body: PropTypes.string.isRequired,
 };
 
 export default CardBody;

--- a/src/components/bulkConcepts/component/MappingPreview.jsx
+++ b/src/components/bulkConcepts/component/MappingPreview.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import ReactTable from 'react-table';
+import PropTypes from 'prop-types';
+
+const MappingPreview = ({ title, body }) => {
+  if (body === 'none') {
+    return (
+      <React.Fragment>
+        <p className="synonyms">{title}</p>
+        <div className="pop-up-description rounded">{body}</div>
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      <p className="synonyms">{title}</p>
+      <ReactTable
+        data={body}
+        noDataText="No mappings found!"
+        minRows={2}
+        columns={[
+          {
+            Header: 'Relationship',
+            accessor: 'map_type',
+          },
+          {
+            Header: 'Name',
+            accessor: 'to_concept_name',
+          },
+          {
+            Header: 'Source',
+            accessor: 'source',
+          },
+          {
+            Header: 'Code',
+            accessor: 'to_concept_code',
+          },
+        ]}
+        className="-striped -highlight mapping-preview"
+        showPagination={false}
+      />
+    </React.Fragment>
+  );
+};
+
+MappingPreview.propTypes = {
+  title: PropTypes.string.isRequired,
+  body: PropTypes.any.isRequired,
+};
+
+export default MappingPreview;

--- a/src/components/bulkConcepts/component/PreviewCard.jsx
+++ b/src/components/bulkConcepts/component/PreviewCard.jsx
@@ -4,31 +4,69 @@ import {
   Button, Modal, ModalBody, ModalFooter,
 } from 'reactstrap';
 import CardBody from './CardBody';
+import MappingPreview from './MappingPreview';
 
 const PreviewCard = ({
   open, concept, closeModal, addConcept,
 }) => {
   const {
-    display_name, descriptions, mappings, display_locale, id, url,
+    display_name,
+    descriptions,
+    mappings,
+    display_locale,
+    id,
+    url,
+    version,
+    created_on,
+    concept_class,
+    datatype,
   } = concept;
 
+  const DATE_OPTIONS = {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  };
+
   const mapping = mappings ? mappings.length : 'none';
+  const description = descriptions ? descriptions[0].description : 'none';
   return (
     <div className="col-9">
-      <Modal isOpen={open} className="modal-sm">
-        <ModalBody>
-          <h6>{`Id ${id}`}</h6>
+      <Modal isOpen={open} className="modal-lg">
+        <ModalBody className="preview-modal">
+          <h6>
+            {id}
+            <div className="card-version">
+              <small>
+                <em>
+                  Version:&nbsp;
+                  {version}
+                </em>
+                <em>
+                  Created on:&nbsp;
+                  {new Date(created_on).toLocaleDateString('en-US', DATE_OPTIONS)}
+                </em>
+              </small>
+            </div>
+          </h6>
           <div className="header-divider" />
           <p className="synonyms">
-         Name
-            &nbsp;
+            Name
+            {''}
             <small>
               <em className="float-right">{display_locale}</em>
             </small>
           </p>
           <div className="pop-up-description rounded">{display_name}</div>
-          <CardBody title="Description" body={descriptions ? descriptions[0].description : ''} />
-          <CardBody title="Mappings" body={mapping} />
+          <CardBody title="Description" body={description} />
+          <div className="row preview-row">
+            <div><CardBody title="Class" body={concept_class} /></div>
+            <div><CardBody title="Data Type" body={datatype} /></div>
+          </div>
+          <MappingPreview title="Mappings" body={mapping} />
         </ModalBody>
         <ModalFooter>
           <Button
@@ -43,7 +81,7 @@ const PreviewCard = ({
           </Button>
           &nbsp;
           <Button color="secondary" id="previewModalCloseBtn" onClick={() => closeModal()}>
-              Close
+            Close
           </Button>
         </ModalFooter>
       </Modal>
@@ -60,6 +98,8 @@ PreviewCard.propTypes = {
     descriptions: PropTypes.array,
     mappings: PropTypes.any,
     display_locale: PropTypes.string,
+    concept_class: PropTypes.string,
+    datatype: PropTypes.string,
   }).isRequired,
 };
 

--- a/src/styles/bulk_concepts.scss
+++ b/src/styles/bulk_concepts.scss
@@ -138,7 +138,9 @@
   font-size: .8rem;
   transition: background-color 400ms ease-in-out;
 }
-
+.popup-content {
+  width: 30rem !important;
+}
 .pop-up-wrapper {
   padding: 1rem;
   height: auto;
@@ -154,7 +156,8 @@
 .pop-up-description {
   background: #e8e9eb;
   color: #2c2e35;
-  padding: .7rem;
+  padding: .4rem;
+  font-size: .9rem;
   white-space: normal;
 }
 
@@ -180,9 +183,19 @@
 }
 
 .synonyms {
-  margin: 0;
-  margin-top: 1rem;
-  font-size: .8rem;
+  margin: .5rem 0 0 0;
+  font-size: .9rem !important;
+}
+
+.card-version{
+  display: block;
+  float: right;
+  max-width: 18rem;
+}
+
+.card-version small em {
+  float: left;
+  font-weight: 300;
 }
 
 .form-check{
@@ -195,4 +208,31 @@
   width: 70%;
   list-style: none;
   z-index: 999;
+}
+
+.preview-row{
+  padding: 0 1rem;
+  div{
+    width: 50%
+  }
+}
+
+.mapping-preview{
+  font-size: .9rem;
+  font-weight: 200;
+  border: #e8e9eb solid 2px;
+  .rt-table{
+    text-align: justify;
+    .rt-thead{
+      font-weight: 600;
+    }
+    .rt-td, .rt-th{
+      border-right: 1px solid #bbb;
+    }
+  }
+}
+
+.preview-modal {
+  max-height: 40rem;
+  overflow: auto;
 }

--- a/src/tests/bulkConcepts/components/PreviewCard.test.js
+++ b/src/tests/bulkConcepts/components/PreviewCard.test.js
@@ -8,12 +8,14 @@ describe('Test suite for ActionButton in BulkConceptsPage component', () => {
   const props = {
     closeModal: jest.fn(),
     addConcept: jest.fn(),
-    open: jest.fn(),
+    open: true,
     concept: {
       display_name: 'lob dev',
       descriptions: [{ description: '' }],
       mappings: null,
       display_locale: 'en',
+      concept_class: 'diagnosis',
+      datatype: 'coded',
     },
   };
 
@@ -28,7 +30,7 @@ describe('Test suite for ActionButton in BulkConceptsPage component', () => {
     const newProps = {
       ...props,
       concept: {
-        mappings: ['erer', 'fvvv'],
+        mappings: {},
         descriptions: [{ description: '' }],
       },
     };


### PR DESCRIPTION
# JIRA TICKET NAME:
[Add more content about the concept in the preview modal](https://issues.openmrs.org/browse/OCLOMRS-360)

# Summary:
On this ticket, it’s generally important that the “Preview Concept” screen shows more information. Right now it actually shows less than is shown in the table, because it doesn’t show the Class and Datatype).