### PR TITLE
OCLOMRS-361: Disable create button when creating a concept

### DIFF
--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -93,9 +93,9 @@ export class CreateConcept extends Component {
     const isAddedConcept = addedConcept.length;
     if (isNewConcept && isAddedConcept) {
       setTimeout(() => {
-        notify.show('concept successfully created', 'success', 3000);
         nextProps.history.push(`/concepts/${type}/${typeName}/${collectionName}/${dictionaryName}/${language}`);
-      }, 3000);
+        notify.show('concept successfully created', 'success', 3000);
+      }, 10);
     }
   }
 

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -193,10 +193,10 @@ export const createNewConcept = (data, dataUrl) => async (dispatch) => {
   dispatch(isFetching(true));
   const url = dataUrl;
   try {
+    notify.show('creating concept, please wait...', 'warning', 1000);
     const response = await instance.post(url, data);
     dispatch(isSuccess(response.data, CREATE_NEW_CONCEPT));
     dispatch(addConceptToDictionary(response.data.id, dataUrl));
-    notify.show('creating concept, please wait...', 'warning', 3000);
   } catch (error) {
     if (error.response) {
       const { response } = error;


### PR DESCRIPTION
… new concept

# JIRA TICKET NAME:
[OCLOMRS-361: Disable create button through the process of creating a new concept](https://issues.openmrs.org/browse/OCLOMRS-361)

# Summary:
- Reduced the setTime out as the store was being updated in a shorter time than the set timeout.