### PR TITLE
OCLOMRS-369: Hide retired mappings from the list of all dictionary mappings

### DIFF
--- a/src/components/dictionaryConcepts/components/RemoveMappings.jsx
+++ b/src/components/dictionaryConcepts/components/RemoveMappings.jsx
@@ -19,15 +19,14 @@ class RemoveMappings extends Component {
     const { url, retired, handleDeleteMapping, showDeleteMappingModal } = this.props;
     return (
       <React.Fragment>
-        { !retired ? (
+        { !retired && (
           <button
             type="button"
             className="btn btn-sm mb-1 actionButtons"
             onClick={() => {
               this.handleToggle();
               showDeleteMappingModal(url);
-            }
-        }
+            }}
           >
           Remove
             <RemoveMappingsModal
@@ -36,14 +35,7 @@ class RemoveMappings extends Component {
               handleDeleteMapping={handleDeleteMapping}
               url={url}
             />
-          </button>) : (
-            <button
-              type="button"
-              className="btn btn-sm mb-1 actionButtons disabled"
-            >
-              Retired
-            </button>
-        )
+          </button>)
       }
       </React.Fragment>
     );

--- a/src/components/dictionaryConcepts/components/ViewConceptMappings.jsx
+++ b/src/components/dictionaryConcepts/components/ViewConceptMappings.jsx
@@ -13,11 +13,22 @@ class ViewConceptMappings extends Component {
     });
   };
 
+  handleMappings = (mappings) => {
+    const newMappings = [];
+    mappings.forEach((mapping) => {
+      if (mapping.retired === false) {
+        newMappings.push(mapping);
+      }
+    });
+    return newMappings;
+  }
+
   render() {
     const { editModalIsOpen } = this.state;
     const {
       mappings, displayName, showDeleteMappingModal, handleDeleteMapping, source,
     } = this.props;
+    const activeMappings = this.handleMappings(mappings);
     return (
       <React.Fragment>
         <button
@@ -27,7 +38,7 @@ class ViewConceptMappings extends Component {
         >
           View mappings
           <ViewMappingsModal
-            mappings={mappings}
+            mappings={activeMappings}
             displayName={displayName}
             source={source}
             handleDeleteMapping={handleDeleteMapping}

--- a/src/tests/dictionaryConcepts/components/ViewConceptMappings.test.js
+++ b/src/tests/dictionaryConcepts/components/ViewConceptMappings.test.js
@@ -12,7 +12,12 @@ describe('render ViewConceptMappings', () => {
       handleToggle: jest.fn(),
       showDeleteMappingModal: jest.fn(),
       handleDeleteMapping: jest.fn(),
-      mappings: [],
+      mappings: [{
+        retired: false,
+      },
+      {
+        retired: true,
+      }],
       displayName: '',
       mappingLimit: 10,
     };


### PR DESCRIPTION
# JIRA TICKET NAME:
[Hide retired mappings from the list of all dictionary mappings](https://issues.openmrs.org/browse/OCLOMRS-369)

# Summary:
Currently, after a mapping belonging to a particular dictionary is retired, it's still visible to the user among the list of mappings.