### PR TITLE
OCLOMRS-374: Remove filter text inputs at the top of tables on add CIEL concepts and dictionary concepts interfaces

### DIFF
--- a/src/components/bulkConcepts/component/ConceptTable.jsx
+++ b/src/components/bulkConcepts/component/ConceptTable.jsx
@@ -6,7 +6,7 @@ import ActionButtons from './ActionButtons';
 import { conceptsProps } from '../../dictionaryConcepts/proptypes';
 
 const ConceptTable = ({
-  concepts, loading, location, preview, previewConcept, addConcept, conceptLimit, filterConcept,
+  concepts, loading, location, preview, previewConcept, addConcept, conceptLimit,
 }) => {
   if (loading) {
     return (
@@ -15,14 +15,12 @@ const ConceptTable = ({
       </div>
     );
   }
-  const filter = { filterMethod: filterConcept, filterAll: true };
   return (
       <div className="row col-12 custom-concept-list">
         <ReactTable
           data={concepts}
           loading={loading}
           defaultPageSize={concepts.length <= conceptLimit ? concepts.length : conceptLimit}
-          filterable
           noDataText="No concepts found!"
           minRows={2}
           columns={[
@@ -30,31 +28,25 @@ const ConceptTable = ({
               Header: 'Name',
               accessor: 'display_name',
               minWidth: 300,
-              ...filter,
             },
             {
               Header: 'Class',
               accessor: 'concept_class',
-              ...filter,
             },
             {
               Header: 'Datatype',
               accessor: 'datatype',
-              ...filter,
             },
             {
               Header: 'Source',
               accessor: 'source',
-              ...filter,
             },
             {
               Header: 'ID',
               accessor: 'id',
-              ...filter,
             },
             {
               Header: 'Action',
-              filterable: false,
               width: 250,
               Cell: ({ original: concept }) => (
                 <ActionButtons
@@ -86,7 +78,6 @@ ConceptTable.propTypes = {
     display_name: PropTypes.string,
   }).isRequired,
   addConcept: PropTypes.func.isRequired,
-  filterConcept: PropTypes.func.isRequired,
   previewConcept: PropTypes.func.isRequired,
   conceptLimit: PropTypes.number.isRequired,
 };

--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -85,12 +85,6 @@ export class BulkConceptsPage extends Component {
     this.props.fetchFilteredConcepts('CIEL', query);
   };
 
-  filterCaseInsensitive = (filter, rows) => {
-    const id = filter.pivotId || filter.id;
-    return matchSorter(rows, filter.value, { keys: [id] });
-  };
-
-
   render() {
     const {
       concepts,
@@ -133,7 +127,6 @@ export class BulkConceptsPage extends Component {
               preview={preview}
               previewConcept={this.props.previewConcept}
               addConcept={this.props.addConcept}
-              filterConcept={this.filterCaseInsensitive}
               conceptLimit={conceptLimit}
             />
           </div>

--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -21,11 +21,9 @@ const ConceptTable = ({
   conceptLimit,
   closeDeleteModal,
   openDeleteModal,
-  filterConcept,
   showDeleteMappingModal,
   handleDeleteMapping,
 }) => {
-  const filter = { filterMethod: filterConcept, filterAll: true };
   if (concepts.length > 0) {
     return (
       <div className="row col-12 custom-concept-list">
@@ -43,7 +41,6 @@ const ConceptTable = ({
           data={concepts}
           loading={loading}
           defaultPageSize={concepts.length <= conceptLimit ? concepts.length : conceptLimit}
-          filterable
           noDataText="No concept!"
           minRows={2}
           columns={[
@@ -51,21 +48,17 @@ const ConceptTable = ({
               Header: 'Name',
               accessor: 'display_name',
               minWidth: 100,
-              ...filter,
             },
             {
               Header: 'Class',
               accessor: 'concept_class',
-              ...filter,
             },
             {
               Header: 'Source',
               accessor: 'source',
-              ...filter,
             },
             {
               Header: 'Action',
-              filterable: false,
               width: 350,
               Cell: ({ original: concept }) => {
                 const props = {
@@ -108,7 +101,6 @@ ConceptTable.propTypes = {
   conceptLimit: PropTypes.number.isRequired,
   openDeleteModal: PropTypes.bool,
   closeDeleteModal: PropTypes.func.isRequired,
-  filterConcept: PropTypes.func.isRequired,
   handleDeleteMapping: PropTypes.func.isRequired,
   showDeleteMappingModal: PropTypes.func.isRequired,
 };

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -164,11 +164,6 @@ export class DictionaryConcepts extends Component {
     });
   };
 
-  filterCaseInsensitive = (filter, rows) => {
-    const id = filter.pivotId || filter.id;
-    return matchSorter(rows, filter.value, { keys: [id] });
-  };
-
   handleConcepts = (concepts) => {
     const newConcepts = [];
     concepts.forEach((concept) => {
@@ -249,7 +244,6 @@ export class DictionaryConcepts extends Component {
               handleDeleteMapping={this.handleDeleteMapping}
               openDeleteModal={openDeleteModal}
               closeDeleteModal={this.closeDeleteModal}
-              filterConcept={this.filterCaseInsensitive}
             />
           </div>
         </section>

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -175,43 +175,6 @@ describe('Test suite for BulkConceptsPage component', () => {
     expect(wrapper.find('BulkConceptsPage').props().addToFilterList).toHaveBeenCalledTimes(2);
   });
 
-  it('should filter concepts in the table', () => {
-    const props = {
-      fetchBulkConcepts: jest.fn(),
-      filterConcept: jest.fn(),
-      concepts: [concepts],
-      loading: false,
-      datatypes: ['text'],
-      classes: ['Diagnosis'],
-      match: {
-        params: {
-          type: 'users',
-          typeName: 'emasys',
-          collectionName: 'dev-org',
-          language: 'en',
-          dictionaryName: 'CIEL',
-        },
-      },
-      addToFilterList: jest.fn(),
-      addConcept: jest.fn(),
-      previewConcept: jest.fn(),
-      fetchFilteredConcepts: jest.fn(),
-    };
-    const wrapper = mount(<Router>
-      <BulkConceptsPage {...props} />
-    </Router>);
-    const event = {
-      target: {
-        value: 'malaria',
-      },
-    };
-    const bulkConceptsWrapper = wrapper.find('BulkConceptsPage').instance();
-    const spy = jest.spyOn(bulkConceptsWrapper, 'filterCaseInsensitive');
-    bulkConceptsWrapper.forceUpdate();
-    wrapper.find('ReactTable').find('input').at(0).simulate('change', event);
-    expect(spy).toHaveBeenCalled();
-  });
-
   it('should simulate clicks on action buttons', () => {
     const props = {
       fetchBulkConcepts: jest.fn(),

--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -59,6 +59,46 @@ describe('Test suite for dictionary concepts components', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should render component without breaking when the type is not specified', () => {
+    const props = {
+      match: {
+        params: {
+          typeName: 'dev-col',
+          type: '',
+          collectionName: 'dev-col',
+          dictionaryName: 'dev-col',
+        },
+      },
+      location: {
+        pathname: '/random/path',
+      },
+      fetchDictionaryConcepts: jest.fn(),
+      concepts: [],
+      filteredClass: ['Diagnosis'],
+      filteredSources: ['CIEL'],
+      loading: false,
+      conceptsCount: 1,
+      totalConceptsCount: 1,
+      filterBySource: jest.fn(),
+      filterByClass: jest.fn(),
+      fetchMemberStatus: jest.fn(),
+      paginateConcepts: jest.fn(),
+      totalConceptCount: 20,
+      userIsMember: true,
+      removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
+    };
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <DictionaryConcepts {...props} />
+      </Router>
+    </Provider>);
+    expect(wrapper.find('h2.text-capitalize').text()).toEqual('dev-col Dictionary');
+    jest.runAllTimers();
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('should render a loader', () => {
     const props = {
       match: {
@@ -322,50 +362,6 @@ describe('Test suite for dictionary concepts components', () => {
     wrapper.find('#CIEL').simulate('change', sourceEvent);
     wrapper.find('#Diagnosis').simulate('change', classesEvent);
     expect(spy).toHaveBeenCalledTimes(2);
-  });
-
-  it('should filter concepts in the table', () => {
-    const props = {
-      match: {
-        params: {
-          typeName: 'dev-col',
-          type: 'orgs',
-          collectionName: 'dev-col',
-          dictionaryName: 'dev-col',
-        },
-      },
-      location: {
-        pathname: '/random/path',
-      },
-      fetchDictionaryConcepts: jest.fn(),
-      concepts: [concepts],
-      filteredClass: ['Diagnosis'],
-      filteredSources: ['CIEL'],
-      loading: false,
-      filterBySource: jest.fn(),
-      filterByClass: jest.fn(),
-      fetchMemberStatus: jest.fn(),
-      paginateConcepts: jest.fn(),
-      totalConceptCount: 20,
-      userIsMember: true,
-      removeDictionaryConcept: jest.fn(),
-      removeConceptMappingAction: jest.fn(),
-    };
-    const wrapper = mount(<Provider store={store}>
-      <Router>
-        <DictionaryConcepts {...props} />
-      </Router>
-    </Provider>);
-    const event = {
-      target: {
-        value: 'malaria',
-      },
-    };
-    const dictionaryConceptsWrapper = wrapper.find('DictionaryConcepts').instance();
-    const spy = jest.spyOn(dictionaryConceptsWrapper, 'filterCaseInsensitive');
-    dictionaryConceptsWrapper.forceUpdate();
-    wrapper.find('ReactTable').find('input').at(0).simulate('change', event);
-    expect(spy).toHaveBeenCalled();
   });
 
   it('should test componentWillReceiveProps', () => {


### PR DESCRIPTION

# JIRA TICKET NAME:
[Remove filter text inputs at the top of tables on add CIEL concepts and dictionary concepts interfaces](https://issues.openmrs.org/browse/OCLOMRS-374)

# Summary:
There exist two ways of filtering CIEL concepts on the add CIEL concepts interface and the interface that shows concepts in a dictionary (The text inputs and the checkboxes on the left of the interface). The text inputs should be removed so as to enable a user only filter using the checkboxes.
