### PR TITLE
OCLOMRS-378: Re-enable the buttons on the create dictionary modal once an error occurs

### DIFF
--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -152,7 +152,10 @@ export class DictionaryModal extends React.Component {
   };
 
   addDictionary = (e) => {
-    this.setState({ disableButton: true });
+    const errors = this.validate(this.state.data);
+    if (Object.keys(errors).length === 0) {
+      this.setState({ disableButton: true });
+    }
     this.onSubmit(e);
   }
 
@@ -172,6 +175,7 @@ export class DictionaryModal extends React.Component {
       },
       errors: {},
       supportedLocalesOptions: [],
+      disableButton: false,
     });
     this.props.modalhide();
   }

--- a/src/tests/Dictionary/DictionaryModal.test.jsx
+++ b/src/tests/Dictionary/DictionaryModal.test.jsx
@@ -206,4 +206,24 @@ describe('Test suite for dictionary modal', () => {
     };
     wrapper.find('#copy_dictionary').simulate('change', item);
   });
+
+  it('it should disable button if there is no error', () => {
+    wrapper.setState({
+      data: {
+        ...wrapper.state().data,
+        id: '1',
+        preferred_source: 'CIEL',
+        public_access: 'None',
+        name: 'OpenMRSDictionary',
+        owner: 'OpenMRS',
+        description: 'OpenMRSDictionary',
+        default_locale: 'en',
+        supported_locales: 'us',
+        repository_type: 'OpenMRSDictionary',
+      },
+    });
+    const submitButtonWrapper = wrapper.find('#addDictionary');
+    submitButtonWrapper.simulate('click', preventDefault);
+    expect(wrapper.state().disableButton).toBeTruthy();
+  });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Re-enable the buttons on the create dictionary modal once error occurs](https://issues.openmrs.org/browse/OCLOMRS-378)

# Summary:
The create dictionary modal's buttons do not get re-enabled once there occurs an error in the form.