### PR TITLE
OCLOMRS-371: Show only one preview modal at a time

### DIFF
--- a/src/components/bulkConcepts/component/ActionButtons.jsx
+++ b/src/components/bulkConcepts/component/ActionButtons.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { notify } from 'react-notify-toast';
 import PropTypes from 'prop-types';
-import Popup from 'reactjs-popup';
 import PreviewCard from './PreviewCard';
 
 export class ActionButtons extends Component {
@@ -82,24 +81,15 @@ export class ActionButtons extends Component {
           onClick={() => this.fetchPreview(this.props.id)}
           role="presentation"
         >
-          <Popup
-            open={this.state.open}
-            trigger={(
-              <button type="submit" className="btn btn-sm mb-1 actionaButtons">
+          <button type="button" className="btn btn-sm mb-1 actionaButtons">
             Preview concept
-              </button>
-            )}
-            position="left center"
-            on="click"
-            onClose={this.closeModal}
-            contentStyle={{ width: '20rem', borderRadius: '.4rem' }}
-          >
             <PreviewCard
+              open={this.state.open}
               concept={this.props.preview}
               addConcept={this.addConcept}
               closeModal={this.closeModal}
             />
-          </Popup>
+          </button>
         </div>
       </React.Fragment>
     );

--- a/src/components/bulkConcepts/component/PreviewCard.jsx
+++ b/src/components/bulkConcepts/component/PreviewCard.jsx
@@ -1,43 +1,52 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {
+  Button, Modal, ModalBody, ModalFooter,
+} from 'reactstrap';
 import CardBody from './CardBody';
 
-const PreviewCard = ({ concept, closeModal, addConcept }) => {
+const PreviewCard = ({
+  open, concept, closeModal, addConcept,
+}) => {
   const {
     display_name, descriptions, mappings, display_locale, id, url,
   } = concept;
 
   const mapping = mappings ? mappings.length : 'none';
   return (
-    <div className="pop-up-wrapper">
-      <h6>{id}</h6>
-      <div className="header-divider" />
-      <p className="synonyms">
-        Name
-        {' '}
-        <small>
-          <em className="float-right">{display_locale}</em>
-        </small>
-      </p>
-      <div className="pop-up-description rounded">{display_name}</div>
-      <CardBody title="Description" body={descriptions[0].description} />
-      <CardBody title="Mappings" body={mapping} />
-      <div className="buttons text-right mt-3">
-        <button
-          type="submit"
-          className="btn btn-sm btn-success no-shadow mr-2"
-          id="add-concept"
-          onClick={() => {
-            addConcept(url, display_name);
-            closeModal();
-          }}
-        >
-          Add
-        </button>
-        <button type="submit" className="btn btn-sm btn-danger no-shadow" onClick={closeModal}>
-          Close
-        </button>
-      </div>
+    <div className="col-9">
+      <Modal isOpen={open} className="modal-sm">
+        <ModalBody>
+          <h6>{`Id ${id}`}</h6>
+          <div className="header-divider" />
+          <p className="synonyms">
+         Name
+            &nbsp;
+            <small>
+              <em className="float-right">{display_locale}</em>
+            </small>
+          </p>
+          <div className="pop-up-description rounded">{display_name}</div>
+          <CardBody title="Description" body={descriptions ? descriptions[0].description : ''} />
+          <CardBody title="Mappings" body={mapping} />
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            color="primary"
+            id="addConcept"
+            onClick={() => {
+              addConcept(url, display_name);
+              closeModal();
+            }}
+          >
+            Add
+          </Button>
+          &nbsp;
+          <Button color="secondary" id="previewModalCloseBtn" onClick={() => closeModal()}>
+              Close
+          </Button>
+        </ModalFooter>
+      </Modal>
     </div>
   );
 };
@@ -45,6 +54,7 @@ const PreviewCard = ({ concept, closeModal, addConcept }) => {
 PreviewCard.propTypes = {
   closeModal: PropTypes.func.isRequired,
   addConcept: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
   concept: PropTypes.shape({
     display_name: PropTypes.string,
     descriptions: PropTypes.array,

--- a/src/tests/bulkConcepts/components/PreviewCard.test.js
+++ b/src/tests/bulkConcepts/components/PreviewCard.test.js
@@ -8,6 +8,7 @@ describe('Test suite for ActionButton in BulkConceptsPage component', () => {
   const props = {
     closeModal: jest.fn(),
     addConcept: jest.fn(),
+    open: jest.fn(),
     concept: {
       display_name: 'lob dev',
       descriptions: [{ description: '' }],
@@ -41,8 +42,15 @@ describe('Test suite for ActionButton in BulkConceptsPage component', () => {
     const wrapper = mount(<Router>
       <PreviewCard {...props} />
     </Router>);
-
-    wrapper.find('button.mr-2').simulate('click');
+    wrapper.find('Button#addConcept').simulate('click');
     expect(props.addConcept).toBeCalled();
+  });
+
+  it('should call closeModal function when the close button is clicked', () => {
+    const wrapper = mount(<Router>
+      <PreviewCard {...props} />
+    </Router>);
+    wrapper.find('Button#previewModalCloseBtn').simulate('click');
+    expect(props.closeModal).toBeCalled();
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Show only one preview modal at a time](https://issues.openmrs.org/browse/OCLOMRS-371)

# Summary:
On the Add CIEL concepts page, when a user first clicks on the preview button for the first CIEL concept and then closes it followed by clicking on preview concept buttons of the next CIEL concepts (2....n), several preview modals belonging to the same CIEL concepts are opened.
