### PR TITLE
OCLOMRS-372: Remove the show all button on add CEIL concepts page.

### DIFF
--- a/src/components/bulkConcepts/component/SearchBar.jsx
+++ b/src/components/bulkConcepts/component/SearchBar.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'reactstrap';
 
 const SearchBar = ({
-  fetchAll, handleChange, searchInput, handleSearch,
+  handleChange, searchInput, handleSearch,
 }) => (
   <div className="row search-container">
     <div className="concept-search-wrapper col-9 col-md-5 col-sm-8">
@@ -21,9 +20,6 @@ const SearchBar = ({
         />
       </form>
     </div>
-    <div className="col-3">
-      <Button color="secondary" onClick={fetchAll}>Show all</Button>
-    </div>
   </div>
 );
 
@@ -31,7 +27,6 @@ SearchBar.propTypes = {
   handleSearch: PropTypes.func.isRequired,
   searchInput: PropTypes.string.isRequired,
   handleChange: PropTypes.func.isRequired,
-  fetchAll: PropTypes.func.isRequired,
 };
 
 export default SearchBar;

--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -74,10 +74,6 @@ export class BulkConceptsPage extends Component {
     this.setState(() => ({ searchInput: value }));
   };
 
-  fetchAll = () => {
-    this.props.fetchBulkConcepts();
-  }
-
   handleSearch = (event) => {
     event.preventDefault();
     const { searchInput } = this.state;
@@ -115,7 +111,6 @@ export class BulkConceptsPage extends Component {
           />
           <div className="col-10 col-md-9 bulk-concept-wrapper custom-full-width">
             <SearchBar
-              fetchAll={this.fetchAll}
               handleSearch={this.handleSearch}
               handleChange={this.handleChange}
               searchInput={searchInput}

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -225,39 +225,4 @@ describe('Test suite for BulkConceptsPage component', () => {
     expect(mapStateToProps(initialState).preview).toEqual([]);
     expect(mapStateToProps(initialState).loading).toEqual(false);
   });
-  it('should show all concepts', () => {
-    const props = {
-      fetchBulkConcepts: jest.fn(),
-      fetchFilteredConcepts: jest.fn(),
-      filterConcept: jest.fn(),
-      handleSearch: jest.fn(),
-      handleChange: jest.fn(),
-      inputValue: '',
-      concepts: [concepts],
-      loading: false,
-      datatypes: ['text'],
-      classes: ['Diagnosis'],
-      match: {
-        params: {
-          type: 'users',
-          typeName: 'emasys',
-          collectionName: 'dev-org',
-          language: 'en',
-          dictionaryName: 'CIEL',
-        },
-      },
-      addToFilterList: jest.fn(),
-      addConcept: jest.fn(),
-      previewConcept: jest.fn(),
-    };
-    const wrapper = mount(<Router>
-      <BulkConceptsPage {...props} />
-    </Router>);
-    const instance = wrapper.find('BulkConceptsPage').instance();
-    const spy = jest.spyOn(instance, 'fetchAll');
-    instance.forceUpdate();
-    const showAllBtn = wrapper.find('Button');
-    showAllBtn.simulate('click');
-    expect(spy).toHaveBeenCalled();
-  });
 });


### PR DESCRIPTION

# JIRA TICKET NAME:
[OCLOMRS-372: Remove the show all button on the add CEIL concepts interface.](https://issues.openmrs.org/browse/OCLOMRS-372)

# Summary:
- Removed "**show all concepts**" button and implement `fetchConcepts` request on `componentDidMount`. 