### PR TITLE
OCLOMRS-379: Remove the `No dictionaries found` message when there exists a network error

### DIFF
--- a/src/components/userDasboard/components/CardWrapper.jsx
+++ b/src/components/userDasboard/components/CardWrapper.jsx
@@ -4,7 +4,12 @@ import DictionaryCard from '../../dashboard/components/dictionary/DictionaryCard
 import Loader from '../../Loader';
 
 const CardWrapper = (props) => {
-  const { dictionaries, fetching, org } = props;
+  const {
+    dictionaries,
+    fetching,
+    org,
+    networkError,
+  } = props;
   if (dictionaries.length >= 1) {
     return (
       <div className="row justify-content-center">
@@ -23,13 +28,22 @@ const CardWrapper = (props) => {
   }
   return (
     <div className="text-center mt-3 p-10">
-      {!org && <h6 className="p-20">No dictionaries found</h6>}
+      {!org && networkError
+        ? (
+          <h6 className="network-cardwrapper-error">
+            {
+          `${networkError}`
+            }
+          </h6>
+        )
+        : <h6 className="p-20">No dictionaries found</h6>}
     </div>
   );
 };
 
 CardWrapper.propTypes = {
   fetching: PropTypes.bool.isRequired,
+  networkError: PropTypes.string.isRequired,
   org: PropTypes.bool,
   dictionaries: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string,

--- a/src/components/userDasboard/container/UserDashboard.jsx
+++ b/src/components/userDasboard/container/UserDashboard.jsx
@@ -13,6 +13,7 @@ export class UserDashboard extends Component {
     fetchUserData: PropTypes.func.isRequired,
     clearDictionaryData: PropTypes.func.isRequired,
     loading: PropTypes.bool.isRequired,
+    networkError: PropTypes.string.isRequired,
     userDictionary: PropTypes.array.isRequired,
     userOrganization: PropTypes.array.isRequired,
     user: PropTypes.shape({
@@ -55,6 +56,7 @@ export class UserDashboard extends Component {
       userOrganization,
       userDictionary,
       loading,
+      networkError,
     } = this.props;
     const dictionary = public_collections === 1 ? 'dictionary' : 'dictionaries';
     return (
@@ -111,6 +113,7 @@ New Dictionary
                   dictionaries={userDictionary}
                   fetching={loading}
                   gotoDictionary={this.gotoDictionary}
+                  networkError={networkError}
                 />
               </div>
             </div>
@@ -126,6 +129,7 @@ export const mapStateToProps = state => ({
   userDictionary: state.user.userDictionary,
   userOrganization: state.user.userOrganization,
   loading: state.user.loading,
+  networkError: state.user.networkError,
 });
 
 export default connect(

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -63,3 +63,4 @@ export const EDIT_CONCEPT_ADD_DESCRIPTION = '[concept] edit_concept_add_descript
 export const EDIT_CONCEPT_REMOVE_ONE_DESCRIPTION = '[concept] edit_concept_remove_one_description';
 export const EDIT_CONCEPT_CREATE_NEW_NAMES = '[concept] edit_concept_create_new_names';
 export const EDIT_CONCEPT_REMOVE_ONE_NAME = '[concept] edit_concept_remove_one_name';
+export const NETWORK_ERROR = '[error] error_message';

--- a/src/redux/actions/user/index.js
+++ b/src/redux/actions/user/index.js
@@ -7,6 +7,7 @@ import {
   CLEAR_DICTIONARY,
   USER_IS_MEMBER,
   USER_IS_NOT_MEMBER,
+  NETWORK_ERROR,
 } from '../types';
 import instance from '../../../config/axiosConfig';
 import { filterUserPayload } from '../../reducers/util';
@@ -17,7 +18,9 @@ export const fetchUser = username => async (dispatch) => {
     const response = await instance.get(url);
     dispatch(isSuccess(response.data, GET_USER));
   } catch (error) {
-    notify.show('An error occurred with your internet connection, please fix it and try reloading the page.', 'error', 3000);
+    const message = 'An error occurred with your internet connection, please fix it and try reloading the page.';
+    notify.show(message, 'error', 3000);
+    dispatch(isErrored(message, NETWORK_ERROR));
   }
 };
 

--- a/src/redux/reducers/user/index.js
+++ b/src/redux/reducers/user/index.js
@@ -7,6 +7,7 @@ import {
   ADDING_DICTIONARY,
   USER_IS_MEMBER,
   USER_IS_NOT_MEMBER,
+  NETWORK_ERROR,
 } from '../../actions/types';
 
 const userInitialState = {
@@ -19,6 +20,7 @@ const userInitialState = {
     public_collections: 0,
   },
   userIsMember: false,
+  networkError: '',
 };
 const userReducer = (state = userInitialState, action) => {
   switch (action.type) {
@@ -61,6 +63,11 @@ const userReducer = (state = userInitialState, action) => {
       return {
         ...state,
         userIsMember: action.payload,
+      };
+    case NETWORK_ERROR:
+      return {
+        ...state,
+        networkError: action.payload,
       };
     default:
       return state;

--- a/src/tests/userDashboard/actions/index.test.js
+++ b/src/tests/userDashboard/actions/index.test.js
@@ -11,6 +11,7 @@ import {
   CLEAR_DICTIONARY,
   USER_IS_MEMBER,
   USER_IS_NOT_MEMBER,
+  NETWORK_ERROR,
 } from '../../../redux/actions/types';
 import {
   fetchUserData,
@@ -151,7 +152,12 @@ describe('Test suite for user dashboard actions', () => {
       });
     });
 
-    const expectedActions = [];
+    const expectedActions = [
+      {
+        type: NETWORK_ERROR,
+        payload: 'An error occurred with your internet connection, please fix it and try reloading the page.',
+      },
+    ];
 
     const store = mockStore({});
     return store.dispatch(fetchUser('emasys')).then(() => {

--- a/src/tests/userDashboard/container/UserDashboard.test.jsx
+++ b/src/tests/userDashboard/container/UserDashboard.test.jsx
@@ -198,6 +198,36 @@ describe('Test suite for dictionary concepts components', () => {
     expect(wrapper.find('#dictionaryHeader h6').text()).toEqual('ChrisMain4567');
     wrapper.unmount();
   });
+  it('should show network error', () => {
+    const propsWithDictionary = createMockStore({
+      ...storeObject,
+      ...Authenticated,
+      fetchUserData: jest.fn(),
+      loading: false,
+      userDictionary: [],
+      orgDictionary: [],
+      clearDictionaryData: jest.fn(),
+      user: {
+        userDictionary: [],
+        user: {
+          name: '',
+          orgs: 0,
+          public_collections: 0,
+        },
+        userOrganization: [],
+        userIsMember: false,
+        loading: false,
+        networkError: 'An error occurred with your internet connection, please fix it and try reloading the page.',
+      },
+    });
+    const wrapper = mount(<Provider store={propsWithDictionary}>
+      <MemoryRouter>
+        <UserDashboard {...props} />
+      </MemoryRouter>
+    </Provider>);
+    expect(wrapper.find('.network-cardwrapper-error').text()).toEqual('An error occurred with your internet connection, please fix it and try reloading the page.');
+    wrapper.unmount();
+  });
 
   it('should test mapStateToProps', () => {
     const initialState = {

--- a/src/tests/userDashboard/reducers/index.test.js
+++ b/src/tests/userDashboard/reducers/index.test.js
@@ -9,6 +9,7 @@ import {
   CLEAR_DICTIONARY,
   USER_IS_MEMBER,
   USER_IS_NOT_MEMBER,
+  NETWORK_ERROR,
 } from '../../../redux/actions/types';
 
 let state;
@@ -26,6 +27,7 @@ beforeEach(() => {
       public_collections: 0,
     },
     userIsMember: false,
+    networkError: '',
   };
   action = {};
 });
@@ -128,6 +130,19 @@ describe('Test suite for user dashboard reducer', () => {
     expect(reducer(state, action)).toEqual({
       ...state,
       userIsMember: false,
+    });
+  });
+  it('should handle NETWORK_ERROR', () => {
+    action = {
+      type: NETWORK_ERROR,
+      payload: 'An error occurred with your internet connection, please fix it and try reloading the page.',
+    };
+
+    deepFreeze(state);
+    deepFreeze(action);
+    expect(reducer(state, action)).toEqual({
+      ...state,
+      networkError: action.payload,
     });
   });
 });


### PR DESCRIPTION

# JIRA TICKET NAME:
[Remove the `No dictionaries found` message when there exists a network error](https://issues.openmrs.org/browse/OCLOMRS-379)

# Summary:
Whenever there is no internet, and dictionaries are failed to be fetched, a message is returned saying there are no dictionaries, this should be fixed as it can mislead a user that has dictionaries into thinking there are no dictionaries.
