### PR TITLE
OCLOMRS-381: show network error message when one tries to search for dictionaries with no internet

### DIFF
--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -82,18 +82,19 @@ export const fetchDictionaries = () => (dispatch) => {
     });
 };
 
-export const searchDictionaries = searchItem => (dispatch) => {
+export const searchDictionaries = searchItem => async (dispatch) => {
   dispatch(isFetching(true));
-  return api.dictionaries
-    .searchDictionaries(searchItem)
-    .then((payload) => {
-      dispatch(isSuccess(payload));
-      dispatch(isFetching(false));
-    })
-    .catch(error => () => {
-      dispatch(isErrored(error.payload.data));
-      dispatch(isFetching(false));
-    });
+  try {
+    const payload = await api.dictionaries
+      .searchDictionaries(searchItem);
+    dispatch(isSuccess(payload));
+    dispatch(isFetching(false));
+  }
+  catch (error) {
+    dispatch(isFetching(false));
+    error.response ? dispatch(isErrored(error.response.data)):
+    showNetworkError();
+  }
 };
 
 export const fetchDictionary = data => (dispatch) => {

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -294,6 +294,8 @@ describe('Test suite for dictionary actions', () => {
     });
     const expectedActions = [
       { type: IS_FETCHING, payload: true },
+      { type: IS_FETCHING, payload: false },
+      { type: '[dictionaries] fetch dictionaries', payload: 'could not complete this request' },
     ];
     const store = mockStore({ payload: {} });
     return store.dispatch(
@@ -302,6 +304,28 @@ describe('Test suite for dictionary actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
+  it('should return a network error message if failed search', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        status: 599,
+      });
+    });
+    const expectedActions = [
+      { payload: true, type: IS_FETCHING },
+      { payload: false, type: IS_FETCHING },
+    ];
+    const store = mockStore({ payload: {} });
+    return store.dispatch(
+      searchDictionaries('', 1000, 1, 'sortAsc=name', 'verbose=true'),
+    ).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should return action type and payload', () => {
+    expect(clearDictionary()).toEqual(responseDict);
+  });
+
   it('should return action type and payload', () => {
     expect(clearDictionary()).toEqual(responseDict);
   });


### PR DESCRIPTION
# JIRA TICKET NAME:
[show network error message when one tries to search for dictionaries with no internet](https://issues.openmrs.org/browse/OCLOMRS-381)

# Summary:
Whenever one tries to search for dictionaries when there is a network issue, a loader is shown and no error message is shown in the all dictionaries interface.