### PR TITLE
OCLOMRS-382: Add a search button to a search field on the add CIEL concepts and All Dictionaries interfaces.

### DIFF
--- a/src/components/bulkConcepts/component/SearchBar.jsx
+++ b/src/components/bulkConcepts/component/SearchBar.jsx
@@ -18,6 +18,7 @@ const SearchBar = ({
           placeholder="search concept"
           required
         />
+        <button type="submit" className="search-button"><i className="fas fa-arrow-right" /></button>
       </form>
     </div>
   </div>

--- a/src/components/dashboard/components/dictionary/DictionariesSearch.jsx
+++ b/src/components/dashboard/components/dictionary/DictionariesSearch.jsx
@@ -15,6 +15,7 @@ export const DictionariesSearch = ({ onSearch, onSubmit, searchValue }) => (
           className="concept-search"
           placeholder="Search for Public dictionaries"
         />
+        <button type="submit" className="search-button"><i className="fas fa-arrow-right" /></button>
       </form>
     </div>
   </div>

--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -150,9 +150,24 @@ body {
   background: inherit;
   line-height: 2rem;
   height: 2rem;
-  width: 90%;
+  width: 80%;
   outline: none;
   box-shadow: none;
+}
+
+.search-button {
+border: none;
+background: inherit;
+&:hover {
+background: lightgray;
+border-radius: .5rem;
+}
+}
+
+@media only screen and (max-width : 500px) {
+  .concept-search {
+    width: 75%;
+  }
 }
 
 .custom-concept-list {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Add a search button to a search field on the add CIEL concepts and All Dictionaries interfaces.](https://issues.openmrs.org/browse/OCLOMRS-382)

# Summary:
Currently, to get concepts and to search for dictionaries, you type a keyword on the search field and press Enter. This is not apparent to all users. Adding a search button will make this clear to all the users.
