### PR TITLE
OCLOMRS-384: Fix warnings on browser and terminal console logs

### DIFF
--- a/src/components/bulkConcepts/addBulkConcepts.jsx
+++ b/src/components/bulkConcepts/addBulkConcepts.jsx
@@ -26,10 +26,10 @@ export class AddBulkConcepts extends Component {
         type: PropTypes.string,
         typeName: PropTypes.string,
         collectionName: PropTypes.string,
+        language: PropTypes.string,
       }).isRequired,
     }).isRequired,
     isFetching: PropTypes.bool.isRequired,
-    language: PropTypes.string.isRequired,
   };
 
   constructor(props) {
@@ -117,15 +117,14 @@ export class AddBulkConcepts extends Component {
     const { conceptIds, openResultModal, otherSelected } = this.state;
     const {
       match: {
-        params: { type, typeName, collectionName },
+        params: {
+          type, typeName, collectionName, language,
+        },
       },
       sourceConcepts,
       conceptSources,
-      language,
     } = this.props;
-
     const disableButton = (conceptIds.length < 1);
-
     return (
       <div className="container-fluid add-bulk-concepts custom-max-width">
         <ResultModal

--- a/src/components/bulkConcepts/component/CardBody.jsx
+++ b/src/components/bulkConcepts/component/CardBody.jsx
@@ -10,7 +10,11 @@ const CardBody = ({ title, body }) => (
 
 CardBody.propTypes = {
   title: PropTypes.string.isRequired,
-  body: PropTypes.string.isRequired,
+  body: PropTypes.string,
+};
+
+CardBody.defaultProps = {
+  body: null,
 };
 
 export default CardBody;

--- a/src/components/bulkConcepts/component/PreviewCard.jsx
+++ b/src/components/bulkConcepts/component/PreviewCard.jsx
@@ -31,7 +31,7 @@ const PreviewCard = ({
     minute: 'numeric',
   };
 
-  const mapping = mappings ? mappings.length : 'none';
+  const mapping = mappings || 'none';
   const description = descriptions ? descriptions[0].description : 'none';
   return (
     <div className="col-9">

--- a/src/components/bulkConcepts/component/addBulkConceptResultModal.jsx
+++ b/src/components/bulkConcepts/component/addBulkConceptResultModal.jsx
@@ -10,7 +10,7 @@ const addBulkConceptResultModal = ({ openModal, closeModal, ids }) => (
       <ModalHeader toggle={closeModal}>
       Invalid Concept IDs
       </ModalHeader>
-      <Input type="textarea" name="text" id="idsText" value={ids.join(', ')} rows="10" />
+      <Input type="textarea" name="text" id="idsText" defaultValue={ids.join(', ')} rows="10" />
       <ModalFooter>
         <Button color="secondary" id="closeModal" onClick={closeModal}>Close</Button>
       </ModalFooter>

--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -242,10 +242,10 @@ CreateConceptForm.propTypes = {
   queryAnswers: PropTypes.func,
   selectedAnswers: PropTypes.array,
   mappings: PropTypes.array,
-  addMappingRow: PropTypes.func.isRequired,
-  updateEventListener: PropTypes.func.isRequired,
-  removeMappingRow: PropTypes.func.isRequired,
-  updateAsyncSelectValue: PropTypes.func.isRequired,
+  addMappingRow: PropTypes.func,
+  updateEventListener: PropTypes.func,
+  removeMappingRow: PropTypes.func,
+  updateAsyncSelectValue: PropTypes.func,
 };
 
 CreateConceptForm.defaultProps = {
@@ -257,6 +257,10 @@ CreateConceptForm.defaultProps = {
   queryAnswers: () => {},
   selectedAnswers: [],
   mappings: [],
+  addMappingRow: null,
+  updateEventListener: null,
+  removeMappingRow: null,
+  updateAsyncSelectValue: null,
 };
 
 export default CreateConceptForm;

--- a/src/tests/bulkConcepts/addBulkConcepts.test.jsx
+++ b/src/tests/bulkConcepts/addBulkConcepts.test.jsx
@@ -159,8 +159,8 @@ describe('Add Bulk Concepts', () => {
 
     moxios.wait(() => {
       expect(spy).toHaveBeenCalled();
+      wrapper.unmount();
     });
-    wrapper.unmount();
   });
 
   it('handleaAdAll close resultModal on close', () => {

--- a/src/tests/bulkConcepts/components/PreviewCard.test.js
+++ b/src/tests/bulkConcepts/components/PreviewCard.test.js
@@ -30,7 +30,14 @@ describe('Test suite for ActionButton in BulkConceptsPage component', () => {
     const newProps = {
       ...props,
       concept: {
-        mappings: {},
+        mappings: [
+          {
+            map_type: '',
+            to_concept_name: '',
+            source: '',
+            to_concept_code: '',
+          },
+        ],
         descriptions: [{ description: '' }],
       },
     };

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -24,7 +24,6 @@ describe('Test suite for dictionary concepts components', () => {
     history: {
       push: jest.fn(),
     },
-    path: '/',
     existingConcept: [],
     createNewName: jest.fn(),
     answer: [12343],
@@ -59,6 +58,7 @@ describe('Test suite for dictionary concepts components', () => {
   let wrapper;
 
   beforeEach(() => {
+    localStorage.setItem('dictionaryPathName', '/dictionary/url');
     wrapper = mount(<Router>
       <CreateConcept {...props} />
     </Router>);
@@ -94,7 +94,6 @@ describe('Test suite for dictionary concepts components', () => {
   });
 
   it('should render without breaking', () => {
-    localStorage.setItem('dictionaryPathName', '/dictionary/url');
     expect(wrapper.find('h3').text()).toEqual(': Create a question Concept ');
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/tests/userDashboard/container/UserDashboard.test.jsx
+++ b/src/tests/userDashboard/container/UserDashboard.test.jsx
@@ -26,6 +26,7 @@ const storeObject = {
     },
     userOrganization: [],
     loading: false,
+    networkError: '',
   },
   dictionaries: {
     dictionaries: mockDictionaries,
@@ -111,6 +112,7 @@ describe('Test suite for dictionary concepts components', () => {
         ],
         userDictionary: [dictionary],
         loading: false,
+        networkError: '',
       },
       history: { push: jest.fn() },
       dictionaries: [],
@@ -149,6 +151,7 @@ describe('Test suite for dictionary concepts components', () => {
         },
         userOrganization: [],
         loading: true,
+        networkError: '',
       },
     });
     const wrapper = mount(<Provider store={propsWithDictionary}>
@@ -188,6 +191,7 @@ describe('Test suite for dictionary concepts components', () => {
           },
         ],
         loading: false,
+        networkError: '',
       },
     });
     const wrapper = mount(<Provider store={propsWithDictionary}>
@@ -281,6 +285,7 @@ describe('Test suite for dictionary concepts components', () => {
           },
         ],
         loading: false,
+        networkError: '',
       },
     });
     const wrapper = mount(<Provider store={propsWithDictionary}>


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix warnings on the browser and terminal console logs](https://issues.openmrs.org/browse/OCLOMRS-384)

# Summary:
There are errors on the terminal console log when running tests and also a few that appear in the browsers console logs. These can cause issues during production if not caught early.