### PR TITLE
OCLOMRS-373: Add pagination to the add CIEL concepts.

### DIFF
--- a/src/components/bulkConcepts/component/ConceptPagination.jsx
+++ b/src/components/bulkConcepts/component/ConceptPagination.jsx
@@ -1,0 +1,58 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Paginations from './Pagination';
+import { conceptsProps } from '../../dictionaryConcepts/proptypes';
+
+class ConceptPagination extends Component {
+  static propTypes = {
+    data: PropTypes.arrayOf(PropTypes.shape(conceptsProps)).isRequired,
+    limitCount: PropTypes.number.isRequired,
+    currentPage: PropTypes.number.isRequired,
+  };
+
+  showPagination = () => {
+    const { data, currentPage, limitCount } = this.props;
+    if (currentPage === 1) {
+      if (data.length !== limitCount) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  getLastPage = () => {
+    const { data, currentPage } = this.props;
+    const lastPage = data.length === 10 ? (currentPage + 1) : currentPage;
+    return lastPage;
+  }
+
+  showTo = () => {
+    const { data, limitCount, currentPage } = this.props;
+    const buildPage = (limitCount * (currentPage - 1)) + data.length;
+    return buildPage;
+  }
+
+  showFrom = () => {
+    const { limitCount, currentPage } = this.props;
+    const buildPage = (limitCount * currentPage + 1) - limitCount;
+    return buildPage;
+  }
+
+  render() {
+    const {
+      data, currentPage,
+    } = this.props;
+    return (
+      <Paginations
+        dictionaries={this.showTo()}
+        firstDictionaryIndex={this.showFrom()}
+        totalDictionaries={data.length}
+        currentPage={currentPage}
+        lastPage={this.getLastPage()}
+        view={this.showPagination()}
+      />
+    );
+  }
+}
+
+export default ConceptPagination;

--- a/src/components/bulkConcepts/component/ConceptTable.jsx
+++ b/src/components/bulkConcepts/component/ConceptTable.jsx
@@ -4,9 +4,10 @@ import ReactTable from 'react-table';
 import Loader from '../../Loader';
 import ActionButtons from './ActionButtons';
 import { conceptsProps } from '../../dictionaryConcepts/proptypes';
+import ConceptPagination from './ConceptPagination';
 
 const ConceptTable = ({
-  concepts, loading, location, preview, previewConcept, addConcept, conceptLimit,
+  concepts, loading, location, preview, previewConcept, addConcept, conceptLimit, currentPage,
 }) => {
   if (loading) {
     return (
@@ -19,10 +20,13 @@ const ConceptTable = ({
     <div className="row col-12 custom-concept-list">
       <ReactTable
         data={concepts}
+        currentPage={currentPage}
         loading={loading}
+        PaginationComponent={ConceptPagination}
         defaultPageSize={concepts.length <= conceptLimit ? concepts.length : conceptLimit}
         noDataText="No concepts found!"
         minRows={2}
+        limitCount={10}
         columns={[
           {
             Header: 'Name',
@@ -81,6 +85,7 @@ ConceptTable.propTypes = {
   addConcept: PropTypes.func.isRequired,
   previewConcept: PropTypes.func.isRequired,
   conceptLimit: PropTypes.number.isRequired,
+  currentPage: PropTypes.number.isRequired,
 };
 ConceptTable.defaultProps = {
   original: {},

--- a/src/components/bulkConcepts/component/Pagination.jsx
+++ b/src/components/bulkConcepts/component/Pagination.jsx
@@ -1,0 +1,96 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import {
+  setNextPage,
+  setPreviousPage,
+} from '../../../redux/actions/concepts/addBulkConcepts';
+
+
+export class Paginations extends Component {
+  static propTypes = {
+    firstDictionaryIndex: PropTypes.number.isRequired,
+    dictionaries: PropTypes.number.isRequired,
+    currentPage: PropTypes.number,
+    lastPage: PropTypes.number,
+    setNextPage: PropTypes.func.isRequired,
+    setPreviousPage: PropTypes.func.isRequired,
+    view: PropTypes.bool.isRequired,
+  };
+
+  static defaultProps = {
+    currentPage: 1,
+    lastPage: 2,
+  }
+
+  render() {
+    const {
+      firstDictionaryIndex, dictionaries, lastPage, currentPage,
+      setNextPage: NextPage, setPreviousPage: PreviousPage, view,
+    } = this.props;
+    return (
+      <Fragment>
+        {view && (
+        <div className="container">
+          <div className="row">
+            <div className="col-md-6 text-left">
+              <i>
+                Showing
+                {' '}
+                {firstDictionaryIndex}
+                -
+                {dictionaries}
+                {' '}
+                of
+                {' '}
+                many
+                {' '}
+                concepts
+              </i>
+            </div>
+            <div className="col-6 text-right">
+              <span className="paginate-controllers">
+                {currentPage > 1 ? (
+                  <i
+                    className="fas fa-angle-double-left prev"
+                    role="presentation"
+                    id={currentPage - 1}
+                    onClick={PreviousPage}
+                  />
+                ) : (
+                  <i className="fas fa-angle-double-left disabled" role="presentation" />
+                )}
+                <span className="badge badge-light">
+                  <h6>{currentPage}</h6>
+                </span>
+                {currentPage < lastPage ? (
+                  <i
+                    className="fas fa-angle-double-right nxt"
+                    role="presentation"
+                    id={currentPage + 1}
+                    onClick={NextPage}
+                  />
+                ) : (
+                  <i className="fas fa-angle-double-right disabled" role="presentation" />
+                )}
+              </span>
+            </div>
+          </div>
+        </div>
+        )}
+      </Fragment>
+    );
+  }
+}
+
+export const mapStateToProps = ({ bulkConcepts }) => ({
+  ...bulkConcepts,
+});
+
+export default connect(
+  mapStateToProps,
+  {
+    setNextPage,
+    setPreviousPage,
+  },
+)(Paginations);

--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -8,10 +8,13 @@ import {
   FETCH_FILTERED_CONCEPTS,
   PREVIEW_CONCEPT,
   ADD_EXISTING_CONCEPTS,
+  SET_PERVIOUS_PAGE,
+  SET_NEXT_PAGE,
+  SET_CURRENT_PAGE,
 } from '../../types';
 
-export const fetchBulkConcepts = (source = 'CIEL') => async (dispatch) => {
-  const url = `orgs/${source}/sources/${source}/concepts/?limit=0&&verbose=true`;
+export const fetchBulkConcepts = (currentPage, source = 'CIEL') => async (dispatch) => {
+  const url = `orgs/${source}/sources/${source}/concepts/?limit=10&page=${currentPage}&&verbose=true`;
   dispatch(isFetching(true));
   try {
     const response = await instance.get(url);
@@ -23,7 +26,7 @@ export const fetchBulkConcepts = (source = 'CIEL') => async (dispatch) => {
   }
 };
 
-export const fetchFilteredConcepts = (source = 'CIEL', query = '') => async (
+export const fetchFilteredConcepts = (source = 'CIEL', query = '', currentPage) => async (
   dispatch,
   getState,
 ) => {
@@ -31,17 +34,16 @@ export const fetchFilteredConcepts = (source = 'CIEL', query = '') => async (
   const {
     bulkConcepts: { datatypeList, classList },
   } = getState();
-
-  let url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=0&verbose=true`;
+  let url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=10&page=${currentPage}&verbose=true`;
 
   if (datatypeList.length > 0 && classList.length > 0) {
-    url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=0&verbose=true&datatype=${datatypeList.join(',')}&conceptClass=${classList.join(',')}`;
+    url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=10&page=${currentPage}&verbose=true&datatype=${datatypeList.join(',')}&conceptClass=${classList.join(',')}`;
   }
   if (datatypeList.length > 0 && classList.length === 0) {
-    url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=0&verbose=true&datatype=${datatypeList.join(',')}`;
+    url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=10&page=${currentPage}&verbose=true&datatype=${datatypeList.join(',')}`;
   }
   if (datatypeList.length === 0 && classList.length > 0) {
-    url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=0&verbose=true&conceptClass=${classList.join(',')}`;
+    url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=10&page=${currentPage}&verbose=true&conceptClass=${classList.join(',')}`;
   }
 
   try {
@@ -80,4 +82,16 @@ export const addConcept = (params, data, conceptName) => async (dispatch) => {
     notify.show(`Just Added - ${conceptName}`, 'success', 3000);
   }
   notify.show(`${conceptName} already added`, 'error', 3000);
+};
+
+export const setCurrentPage = currentPage => async (dispatch) => {
+  dispatch(isSuccess(currentPage, SET_CURRENT_PAGE));
+};
+
+export const setNextPage = () => async (dispatch) => {
+  dispatch(isSuccess(null, SET_NEXT_PAGE));
+};
+
+export const setPreviousPage = () => async (dispatch) => {
+  dispatch(isSuccess(null, SET_PERVIOUS_PAGE));
 };

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -66,3 +66,6 @@ export const EDIT_CONCEPT_REMOVE_ONE_DESCRIPTION = '[concept] edit_concept_remov
 export const EDIT_CONCEPT_CREATE_NEW_NAMES = '[concept] edit_concept_create_new_names';
 export const EDIT_CONCEPT_REMOVE_ONE_NAME = '[concept] edit_concept_remove_one_name';
 export const NETWORK_ERROR = '[error] error_message';
+export const SET_PERVIOUS_PAGE = '[page] prev_page';
+export const SET_NEXT_PAGE = '[page] next_page';
+export const SET_CURRENT_PAGE = '[page] current_page';

--- a/src/redux/reducers/bulkConceptReducer.js
+++ b/src/redux/reducers/bulkConceptReducer.js
@@ -4,6 +4,9 @@ import {
   ADD_TO_CLASS_LIST,
   FETCH_FILTERED_CONCEPTS,
   PREVIEW_CONCEPT,
+  SET_PERVIOUS_PAGE,
+  SET_NEXT_PAGE,
+  SET_CURRENT_PAGE,
 } from '../actions/types';
 import { getDatatypes, filterClass, normalizeList } from './util';
 
@@ -13,6 +16,7 @@ const userInitialState = {
   classes: [],
   datatypeList: [],
   classList: [],
+  currentPage: 1,
 };
 const bulkConcepts = (state = userInitialState, action) => {
   switch (action.type) {
@@ -34,6 +38,21 @@ const bulkConcepts = (state = userInitialState, action) => {
       return {
         ...state,
         preview: action.payload,
+      };
+    case SET_CURRENT_PAGE:
+      return {
+        ...state,
+        currentPage: action.payload,
+      };
+    case SET_NEXT_PAGE:
+      return {
+        ...state,
+        currentPage: state.currentPage + 1,
+      };
+    case SET_PERVIOUS_PAGE:
+      return {
+        ...state,
+        currentPage: state.currentPage - 1,
       };
     case ADD_TO_DATATYPE_LIST:
       return {

--- a/src/tests/Dashboard/reducer/conceptReducer.test.js
+++ b/src/tests/Dashboard/reducer/conceptReducer.test.js
@@ -89,6 +89,36 @@ describe('Test suite for concepts reducer', () => {
 
   it(
     // eslint-disable-next-line max-len
+    'should handle setting redux state key concepts to list of concepts and hasMore to true on dispatching actiontype FETCH_CONCEPTS',
+    () => {
+      const newConcepts = [{ id: 1 }, { id: 2 },
+        { id: 3 }, { id: 4 },
+        { id: 5 }, { id: 6 },
+        { id: 7 }, { id: 8 },
+        { id: 9 }, { id: 10 },
+        { id: 11 }, { id: 12 },
+        { id: 13 }, { id: 14 },
+        { id: 15 }, { id: 16 },
+        { id: 17 }, { id: 18 },
+        { id: 19 }, { id: 20 },
+        { id: 21 }, { id: 22 },
+        { id: 23 }, { id: 24 },
+        { id: 25 }];
+      expect(reducer(
+        { concepts: [] },
+        {
+          type: FETCH_CONCEPTS,
+          payload: newConcepts,
+        },
+      )).toEqual({
+        concepts: newConcepts,
+        hasMore: true,
+      });
+    },
+  );
+
+  it(
+    // eslint-disable-next-line max-len
     'should handle setting redux state key loading to false on dispatching actiontype IS_FETCHING', () => {
       expect(reducer(
         {},

--- a/src/tests/bulkConcepts/actions/bulkConcept.test.js
+++ b/src/tests/bulkConcepts/actions/bulkConcept.test.js
@@ -11,6 +11,9 @@ import {
   FETCH_FILTERED_CONCEPTS,
   PREVIEW_CONCEPT,
   ADD_EXISTING_CONCEPTS,
+  SET_CURRENT_PAGE,
+  SET_NEXT_PAGE,
+  SET_PERVIOUS_PAGE,
 } from '../../../redux/actions/types';
 import {
   fetchBulkConcepts,
@@ -18,6 +21,9 @@ import {
   fetchFilteredConcepts,
   previewConcept,
   addConcept,
+  setCurrentPage,
+  setNextPage,
+  setPreviousPage,
 } from '../../../redux/actions/concepts/addBulkConcepts';
 import concepts, { mockConceptStore } from '../../__mocks__/concepts';
 
@@ -196,6 +202,52 @@ describe('Test suite for addBulkConcepts async actions', () => {
     return store.dispatch(fetchFilteredConcepts()).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
+  });
+  it('dispatches the current page', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+      });
+    });
+
+    const returnedAction = [
+      { type: SET_CURRENT_PAGE, payload: 1 },
+    ];
+    const store = mockStore({});
+    const currentPage = 1;
+    return store.dispatch(setCurrentPage(currentPage))
+      .then(() => expect(store.getActions()).toEqual(returnedAction));
+  });
+  it('dispatches the next page', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+      });
+    });
+
+    const returnedAction = [
+      { type: SET_NEXT_PAGE, payload: null },
+    ];
+    const store = mockStore({});
+    return store.dispatch(setNextPage())
+      .then(() => expect(store.getActions()).toEqual(returnedAction));
+  });
+  it('dispatches the previous page', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+      });
+    });
+
+    const returnedAction = [
+      { type: SET_PERVIOUS_PAGE, payload: null },
+    ];
+    const store = mockStore({});
+    return store.dispatch(setPreviousPage())
+      .then(() => expect(store.getActions()).toEqual(returnedAction));
   });
 });
 

--- a/src/tests/bulkConcepts/components/ConceptPagination.test.js
+++ b/src/tests/bulkConcepts/components/ConceptPagination.test.js
@@ -1,0 +1,181 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ConceptPagination from '../../../components/bulkConcepts/component/ConceptPagination';
+import concepts from '../../__mocks__/concepts';
+
+jest.useFakeTimers();
+
+jest.mock('react-notify-toast');
+
+describe('Test suite for ConceptPagination component', () => {
+  it('it should call the handle getLastPage function', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      data: [concepts],
+      loading: false,
+      datatypes: ['text'],
+      classes: ['Diagnosis'],
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      showFrom: jest.fn(),
+      showTo: jest.fn(),
+      getLastPage: jest.fn(),
+      limitCount: 10,
+    };
+    const wrapper = shallow(<ConceptPagination {...props} />);
+    const instance = wrapper.instance();
+    expect(instance.getLastPage()).toEqual(1);
+  });
+  it('it should return showPagination function as false', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      data: [concepts],
+      addToFilterList: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      showFrom: jest.fn(),
+      showTo: jest.fn(),
+      getLastPage: jest.fn(),
+      showPagination: jest.fn(),
+      limitCount: 10,
+    };
+    const wrapper = shallow(<ConceptPagination {...props} />);
+    const instance = wrapper.instance();
+    expect(instance.showPagination()).toEqual(false);
+  });
+  it('it should return showPagination function as true', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 2,
+      data: [concepts],
+      addToFilterList: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      showFrom: jest.fn(),
+      showTo: jest.fn(),
+      getLastPage: jest.fn(),
+      showPagination: jest.fn(),
+      limitCount: 10,
+    };
+    const wrapper = shallow(<ConceptPagination {...props} />);
+    const instance = wrapper.instance();
+    expect(instance.showPagination()).toEqual(true);
+  });
+  it('it should call the handle getLastPage when concepts is up to ten', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      data: [{ id: '1' }, { id: '2' },
+        { id: '3' }, { id: '4' },
+        { id: '5' }, { id: '6' },
+        { id: '7' }, { id: '8' },
+        { id: '9' }, { id: '10' }],
+      loading: false,
+      datatypes: ['text'],
+      classes: ['Diagnosis'],
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      showFrom: jest.fn(),
+      showTo: jest.fn(),
+      getLastPage: jest.fn(),
+      limitCount: 10,
+    };
+    const wrapper = shallow(<ConceptPagination {...props} />);
+    const instance = wrapper.instance();
+    expect(instance.getLastPage()).toEqual(2);
+  });
+  it('it should call the handle showTo function', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      data: [concepts],
+      loading: false,
+      datatypes: ['text'],
+      classes: ['Diagnosis'],
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      showFrom: jest.fn(),
+      showTo: jest.fn(),
+      getLastPage: jest.fn(),
+      limitCount: 10,
+    };
+    const wrapper = shallow(<ConceptPagination {...props} />).setState({ limit: 10 });
+    const instance = wrapper.instance();
+    expect(instance.showTo()).toEqual(1);
+  });
+  it('it should call the handle showFrom function', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      data: [concepts],
+      loading: false,
+      datatypes: ['text'],
+      classes: ['Diagnosis'],
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      showFrom: jest.fn(),
+      showTo: jest.fn(),
+      getLastPage: jest.fn(),
+      limitCount: 10,
+    };
+    const wrapper = shallow(<ConceptPagination {...props} />).setState({ limit: 10 });
+    const instance = wrapper.instance();
+    expect(instance.showFrom()).toEqual(1);
+  });
+});

--- a/src/tests/bulkConcepts/components/Pagination.test.js
+++ b/src/tests/bulkConcepts/components/Pagination.test.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Router from 'react-mock-router';
+import { createMockStore } from 'redux-test-utils';
+import { Provider } from 'react-redux';
+import {
+  Paginations,
+  mapStateToProps,
+} from '../../../components/bulkConcepts/component/Pagination';
+import concepts from '../../__mocks__/concepts';
+
+const store = createMockStore({
+  bulkConcepts: {
+    bulkConcepts: [],
+    currentPage: 1,
+  },
+});
+jest.useFakeTimers();
+
+jest.mock('react-notify-toast');
+
+describe('Test suite for Paginations component', () => {
+  it('it should show current page', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      concepts: [concepts],
+      loading: false,
+      datatypes: ['text'],
+      classes: ['Diagnosis'],
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      showFrom: jest.fn(),
+      showTo: jest.fn(),
+      getLastPage: jest.fn(),
+      firstDictionaryIndex: 1,
+      dictionaries: 10,
+      lastPage: 2,
+      setNextPage: jest.fn(),
+      setPreviousPage: jest.fn(),
+      view: true,
+    };
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <Paginations {...props} />
+      </Router>
+    </Provider>);
+    expect(wrapper.find('h6').text()).toEqual('1');
+  });
+  it('should render without breaking', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      concepts: [concepts],
+      loading: false,
+      datatypes: ['text'],
+      classes: ['Diagnosis'],
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      showFrom: jest.fn(),
+      showTo: jest.fn(),
+      getLastPage: jest.fn(),
+      firstDictionaryIndex: 1,
+      dictionaries: 10,
+      lastPage: 2,
+      setNextPage: jest.fn(),
+      setPreviousPage: jest.fn(),
+      view: true,
+    };
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <Paginations {...props} />
+      </Router>
+    </Provider>);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('it should go to next page', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      firstDictionaryIndex: 1,
+      dictionaries: 10,
+      lastPage: 2,
+      setNextPage: jest.fn(),
+      setPreviousPage: jest.fn(),
+      view: true,
+    };
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <Paginations {...props} />
+      </Router>
+    </Provider>);
+    wrapper.find('.fa-angle-double-right').simulate('click');
+    expect(wrapper.find('Paginations').instance().props.currentPage + 1).toEqual(2);
+  });
+  it('should test mapStateToProps', () => {
+    const initialState = {
+      bulkConcepts: {
+        bulkConcepts: [],
+        currentPage: 1,
+      },
+    };
+    expect(mapStateToProps(initialState).currentPage).toEqual(1);
+  });
+});

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -1,13 +1,20 @@
 import React from 'react';
-
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import Router from 'react-mock-router';
+import { createMockStore } from 'redux-test-utils';
+import { Provider } from 'react-redux';
 import {
   BulkConceptsPage,
   mapStateToProps,
 } from '../../../components/bulkConcepts/container/BulkConceptsPage';
 import concepts from '../../__mocks__/concepts';
 
+const store = createMockStore({
+  bulkConcepts: {
+    bulkConcepts: [],
+    currentPage: 1,
+  },
+});
 jest.useFakeTimers();
 
 jest.mock('react-notify-toast');
@@ -15,6 +22,8 @@ jest.mock('react-notify-toast');
 describe('Test suite for BulkConceptsPage component', () => {
   it('should render without breaking', () => {
     const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
       fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [],
@@ -45,6 +54,8 @@ describe('Test suite for BulkConceptsPage component', () => {
   });
   it('should render without concepts', () => {
     const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
       fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [],
@@ -66,14 +77,267 @@ describe('Test suite for BulkConceptsPage component', () => {
       previewConcept: jest.fn(),
 
     };
-    const wrapper = mount(<Router>
-      <BulkConceptsPage {...props} />
-    </Router>);
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <BulkConceptsPage {...props} />
+      </Router>
+    </Provider>);
     expect(wrapper.find('.rt-noData').text()).toEqual('No concepts found!');
+  });
+  it('should render a loader', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      concepts: [],
+      loading: true,
+      datatypes: [],
+      classes: [],
+      conceptLimit: 10,
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      handleNextPage: jest.fn(),
+    };
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <BulkConceptsPage {...props} />
+      </Router>
+    </Provider>);
+    expect(wrapper.find('Loader')).toHaveLength(1);
+  });
+
+  it('it should call the handle handleNextPage function', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      concepts: [],
+      loading: true,
+      datatypes: [],
+      classes: [],
+      conceptLimit: 10,
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      handleNextPage: jest.fn(),
+    };
+    const wrapper = shallow(<BulkConceptsPage {...props} />);
+    const event = {
+      preventDefault: jest.fn(),
+      target: {
+        id: 1,
+      },
+    };
+    const instance = wrapper.instance();
+    expect(instance.handleNextPage(event)).toEqual(undefined);
+  });
+  it('it should call the handle handleNextPage function while searching', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      concepts: [],
+      loading: true,
+      datatypes: [],
+      classes: [],
+      conceptLimit: 10,
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      handleNextPage: jest.fn(),
+    };
+    const wrapper = shallow(<BulkConceptsPage {...props} />).setState({ searchingOn: true });
+    const event = {
+      preventDefault: jest.fn(),
+      target: {
+        id: 1,
+      },
+    };
+    const instance = wrapper.instance();
+    expect(instance.handleNextPage(event)).toEqual(undefined);
+  });
+
+  it('it should call searchingOn state should be available', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      searchingOn: true,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      concepts: [],
+      loading: true,
+      datatypes: [],
+      classes: [],
+      conceptLimit: 10,
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      handleNextPage: jest.fn(),
+    };
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <BulkConceptsPage {...props} />
+      </Router>
+    </Provider>);
+    const event = {
+      preventDefault: jest.fn(),
+      target: {
+        id: 1,
+      },
+    };
+    wrapper.find('BulkConceptsPage').instance().setState({
+      searchingOn: true,
+    });
+
+    wrapper.find('BulkConceptsPage').instance().handleNextPage(event);
+    const showState = wrapper.find('BulkConceptsPage').instance().state.searchingOn;
+    expect(showState).toEqual(true);
+  });
+
+  it('it should call the handle componentDidUpdate function', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      concepts: [],
+      loading: true,
+      datatypes: [],
+      classes: [],
+      conceptLimit: 10,
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      handleNextPage: jest.fn(),
+      componentDidUpdate: jest.fn(),
+    };
+    const wrapper = shallow(<BulkConceptsPage {...props} />);
+    const instance = wrapper.instance();
+    expect(instance.componentDidUpdate(2)).toEqual(undefined);
+  });
+
+  it('it should call the handle componentDidMount function', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      concepts: [],
+      loading: true,
+      datatypes: [],
+      classes: [],
+      conceptLimit: 10,
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      handleNextPage: jest.fn(),
+      componentDidMount: jest.fn(),
+    };
+    const wrapper = shallow(<BulkConceptsPage {...props} />);
+    const instance = wrapper.instance();
+    expect(instance.componentDidMount()).toEqual(undefined);
+  });
+
+  it('it should call the handle componentDidUpdate function while searching', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      concepts: [],
+      loading: true,
+      datatypes: [],
+      classes: [],
+      conceptLimit: 10,
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      handleNextPage: jest.fn(),
+      componentDidUpdate: jest.fn(),
+    };
+    const wrapper = shallow(<BulkConceptsPage {...props} />).setState({ searchingOn: true });
+    const instance = wrapper.instance();
+    expect(instance.componentDidUpdate(2)).toEqual(undefined);
   });
 
   it('should search for concepts', () => {
     const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
       fetchBulkConcepts: jest.fn(),
       fetchFilteredConcepts: jest.fn(),
       filterConcept: jest.fn(),
@@ -97,9 +361,11 @@ describe('Test suite for BulkConceptsPage component', () => {
       addConcept: jest.fn(),
       previewConcept: jest.fn(),
     };
-    const wrapper = mount(<Router>
-      <BulkConceptsPage {...props} />
-    </Router>);
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <BulkConceptsPage {...props} />
+      </Router>
+    </Provider>);
     const event = { target: { name: 'searchInput', value: '   testing' } };
     wrapper.find('#search-concept').simulate('change', event);
     wrapper.find('#submit-search-form').simulate('submit');
@@ -114,6 +380,8 @@ describe('Test suite for BulkConceptsPage component', () => {
 
   it('should filter search result', () => {
     const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
       fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [concepts],
@@ -134,9 +402,11 @@ describe('Test suite for BulkConceptsPage component', () => {
       previewConcept: jest.fn(),
       fetchFilteredConcepts: jest.fn(),
     };
-    const wrapper = mount(<Router>
-      <BulkConceptsPage {...props} />
-    </Router>);
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <BulkConceptsPage {...props} />
+      </Router>
+    </Provider>);
     const event = { target: { name: 'Diagnosis, datatype', checked: true } };
     const event2 = { target: { name: 'Diagnosis, datatype', checked: true } };
     wrapper.find('#text').simulate('change', event2);
@@ -145,6 +415,8 @@ describe('Test suite for BulkConceptsPage component', () => {
 
   it('should filter search result with datatype', () => {
     const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
       fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [concepts],
@@ -165,9 +437,11 @@ describe('Test suite for BulkConceptsPage component', () => {
       previewConcept: jest.fn(),
       fetchFilteredConcepts: jest.fn(),
     };
-    const wrapper = mount(<Router>
-      <BulkConceptsPage {...props} />
-    </Router>);
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <BulkConceptsPage {...props} />
+      </Router>
+    </Provider>);
     let event = { target: { name: 'Diagnosis, datatype', checked: true } };
     wrapper.find('#Diagnosis').simulate('change', event);
     event = { target: { name: 'Diagnosis, classes', checked: true } };
@@ -177,6 +451,8 @@ describe('Test suite for BulkConceptsPage component', () => {
 
   it('should simulate clicks on action buttons', () => {
     const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
       fetchBulkConcepts: jest.fn(),
       concepts: [concepts],
       loading: false,
@@ -200,9 +476,11 @@ describe('Test suite for BulkConceptsPage component', () => {
       previewConcept: jest.fn(),
       fetchFilteredConcepts: jest.fn(),
     };
-    const wrapper = mount(<Router>
-      <BulkConceptsPage {...props} />
-    </Router>);
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <BulkConceptsPage {...props} />
+      </Router>
+    </Provider>);
     wrapper.find('#add-button').simulate('click');
     jest.runAllTimers();
   });

--- a/src/tests/bulkConcepts/reducer/index.test.js
+++ b/src/tests/bulkConcepts/reducer/index.test.js
@@ -6,6 +6,9 @@ import {
   ADD_TO_CLASS_LIST,
   FETCH_FILTERED_CONCEPTS,
   PREVIEW_CONCEPT,
+  SET_CURRENT_PAGE,
+  SET_NEXT_PAGE,
+  SET_PERVIOUS_PAGE,
 } from '../../../redux/actions/types';
 import concepts, { concept2, multipleConceptsMockStore } from '../../__mocks__/concepts';
 
@@ -19,6 +22,7 @@ beforeEach(() => {
     classes: [],
     datatypeList: [],
     classList: [],
+    currentPage: 1,
   };
   action = {};
 });
@@ -42,6 +46,48 @@ describe('Test suite for bulkConcepts reducer', () => {
       classes: ['Diagnosis'],
       datatypes: ['N/A'],
       bulkConcepts: action.payload,
+    });
+  });
+  it('should handle SET_NEXT_PAGE', () => {
+    action = {
+      type: SET_NEXT_PAGE,
+      payload: 1,
+    };
+
+    deepFreeze(state);
+    deepFreeze(action);
+
+    expect(reducer(state, action)).toEqual({
+      ...state,
+      currentPage: action.payload + 1,
+    });
+  });
+  it('should handle SET_PERVIOUS_PAGE', () => {
+    action = {
+      type: SET_PERVIOUS_PAGE,
+      payload: 1,
+    };
+
+    deepFreeze(state);
+    deepFreeze(action);
+
+    expect(reducer(state, action)).toEqual({
+      ...state,
+      currentPage: action.payload - 1,
+    });
+  });
+  it('should handle SET_CURRENT_PAGE', () => {
+    action = {
+      type: SET_CURRENT_PAGE,
+      payload: 1,
+    };
+
+    deepFreeze(state);
+    deepFreeze(action);
+
+    expect(reducer(state, action)).toEqual({
+      ...state,
+      currentPage: action.payload,
     });
   });
   it('should handle ADD_TO_DATATYPE_LIST', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Add pagination to the add CIEL concepts.](https://issues.openmrs.org/browse/OCLOMRS-373)

# Summary:
Enable a user to be able to view the first ten concepts in the add CIEL concepts interface when the component first loads. A user should then be able to click next to view the next ten. At this point, you should fetch the next ten in the table.

