### PR TITLE
OCLOMRS-386 : Make the mappings search field wider

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -125,5 +125,5 @@
 }
 
 .react-async {
-  width: 26%;
+  width: 40%;
 }


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make the mappings search field wider](https://issues.openmrs.org/browse/OCLOMRS-386)

# Summary:
The mappings search field is too small and cannot accommodate the mappings. The search field should be wider