### PR TITLE
OCLOMRS-391: Make all buttons consistent

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -127,7 +127,7 @@ Dictionary
             {owner === username && (
               <button
                 type="button"
-                className="btn btn-secondary"
+                className="btn btn-primary m-3"
                 id="editB"
                 onClick={showEditModal}
               >
@@ -178,7 +178,7 @@ Dictionary
               {otherConcepts}
             </p>
             <Link
-              className="btn btn-secondary"
+              className="btn btn-primary m-3"
               id="conceptB"
               to={`/concepts${owner_url}${short_code}/${name}/${default_locale}`}
             >

--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -433,7 +433,7 @@ export class DictionaryModal extends React.Component {
           </ModalBody>
           <ModalFooter>
             <Button
-              className="btn btn-outline-info"
+              className="btn btn-primary"
               id="addDictionary"
               onClick={this.addDictionary}
               disabled={disableButton}
@@ -442,7 +442,7 @@ export class DictionaryModal extends React.Component {
               {' '}
             </Button>
             <Button
-              className="btn btn-outline-danger test-btn-cancel"
+              className="btn btn-danger test-btn-cancel"
               id="cancel"
               onClick={this.hideModal}
               disabled={disableButton}

--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -203,11 +203,11 @@ const CreateConceptForm = (props) => {
           <br />
         </div>
         <div className="submit-button text-left">
-          <button className="btn btn-sm bg-blue col-2 mr-1" type="submit" disabled={props.disableButton}>
+          <button className="btn btn-primary mr-1" type="submit" disabled={props.disableButton}>
             {props.isEditConcept ? 'Update' : 'Create' }
           </button>
           <Link to={props.path} className="collection-name small-text">
-            <button className="btn btn-sm  col-2 btn-danger" type="submit" disabled={props.disableButton}>
+            <button className="btn btn-danger" type="submit" disabled={props.disableButton}>
             Cancel
             </button>
           </Link>

--- a/src/components/dictionaryConcepts/components/ViewMappingsModal.jsx
+++ b/src/components/dictionaryConcepts/components/ViewMappingsModal.jsx
@@ -90,7 +90,7 @@ export class ViewMappingsModal extends Component {
             </div>
           </ModalBody>
           <ModalFooter>
-            <Button color="secondary" onClick={() => handleToggle(false)}>
+            <Button color="danger" onClick={() => handleToggle(false)}>
               Close
             </Button>
           </ModalFooter>

--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -126,13 +126,19 @@ body {
 }
 
 .-pagination .-btn:not([disabled]){
-  color: #303438;
-  background: rgba(108, 117, 125, 0.5);
+  color: #ffffff;
+  background: #007bff;
 }
 
 .-pagination .-btn:not([disabled]):hover{
   color: #fff;
   background: #6c757d !important;
+}
+
+.ReactTable .-pagination .-previous,
+.ReactTable .-pagination .-center,
+.ReactTable .-pagination .-next {
+    flex: none;
 }
 
 .search-container .concept-search-wrapper .fa-search {

--- a/src/styles/dictionary_modal.scss
+++ b/src/styles/dictionary_modal.scss
@@ -54,21 +54,6 @@
     margin-left: 45%;
     padding-top: 1%
 }
-#conceptB{
-    /* margin-right: 58%; */
-    margin-top: 2%;
-    margin-bottom: 5%;
-    margin-right: 65%;
-    background-color: #506096;
-}
-#editB{
-    padding-left: 10%;
-    padding-right: 10%;
-    margin-top: 2%;
-    margin-bottom: 5%;
-    margin-right: 65%;
-    background-color: #506096;
-}
 #loader {
     padding-top: 20%;
 }
@@ -81,6 +66,7 @@
 }
 #conceptsCard {
     margin-bottom: 2%;
+    text-align: left;
 }
 #desc {
     text-align: left;
@@ -164,4 +150,9 @@ legend {
 button:disabled{
     cursor: not-allowed;
     background: #e9ecef !important;
+}
+#addDictionary {
+    color: #fff;
+    background-color: #007bff;
+    border-color: #007bff;
 }

--- a/src/styles/login.scss
+++ b/src/styles/login.scss
@@ -40,7 +40,7 @@ h4 {
 
 .form-wrapper .btn {
   box-shadow: none;
-  height: 3rem;
+  height: auto;
 }
 
 .form-wrapper a {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make all buttons consistent](https://issues.openmrs.org/browse/OCLOMRS-391)

# Summary:
The `add dictionary` and `cancel` buttons on the create new dictionary modal are of different colours and design as compared to the rest of the buttons in the application, they have to be similar to the other buttons for consistency.

The following buttons should all be consistent:
- Dictionary details page: "Edit" and "Go to Concepts" buttons
- Edit dictionary page: "Update" and "Cancel" buttons
- List of Concepts page: "Next" and "Previous" buttons
- Edit Concept page: "Update" and "Cancel" buttons
- View mapping page: "Cancel" button