### PR TITLE
OCLOMRS-387: Make the CIEL select dropdown a text input field

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateMapping.jsx
+++ b/src/components/dictionaryConcepts/components/CreateMapping.jsx
@@ -4,6 +4,7 @@ import AsyncSelect from 'react-select/lib/Async';
 import PropTypes from 'prop-types';
 import { fetchSourceConcepts } from '../../../redux/actions/concepts/dictionaryConcepts';
 import { INTERNAL_MAPPING_DEFAULT_SOURCE } from './helperFunction';
+import MapType from './MapType';
 
 class CreateMapping extends Component {
   constructor(props) {
@@ -38,18 +39,12 @@ class CreateMapping extends Component {
                 />
               </td>
               <td>
-                <select
-                  tabIndex={index}
-                  defaultValue={map_type}
-                  className="form-control"
-                  placeholder="map type"
-                  type="text"
-                  name="map_type"
-                  onChange={updateEventListener}
-                >
-                  <option>Same as</option>
-                  <option>Narrower than</option>
-                </select>
+                {<MapType
+                  updateEventListener={updateEventListener}
+                  index={index}
+                  map_type={map_type}
+                  source={source}
+                />}
               </td>
               {source && source !== INTERNAL_MAPPING_DEFAULT_SOURCE && (
                 <td>

--- a/src/components/dictionaryConcepts/components/MapType.jsx
+++ b/src/components/dictionaryConcepts/components/MapType.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE } from './helperFunction';
+
+const mapType = (props) => {
+  const {
+    source, index, map_type, updateEventListener,
+  } = props;
+  const mapTypeInput = source === INTERNAL_MAPPING_DEFAULT_SOURCE
+    ? (<textarea
+      type="text"
+      rows="3"
+      className="form-control concept-description"
+      name="map_type"
+      onChange={updateEventListener}
+    />)
+    : (
+      <select
+        tabIndex={index}
+        defaultValue={map_type}
+        className="form-control"
+        placeholder="map type"
+        type="text"
+        name="map_type"
+        onChange={updateEventListener}
+      >
+        <option>Same as</option>
+        <option>Narrower than</option>
+      </select>
+    );
+  return mapTypeInput;
+};
+
+mapType.propTypes = {
+  source: PropTypes.string,
+  index: PropTypes.number,
+  updateEventListener: PropTypes.func,
+};
+
+mapType.defaultProps = {
+  source: '',
+  index: 0,
+  updateEventListener: () => {},
+};
+
+export default mapType;

--- a/src/tests/dictionaryConcepts/components/MapType.test.js
+++ b/src/tests/dictionaryConcepts/components/MapType.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import MapType from '../../../components/dictionaryConcepts/components/MapType';
+
+describe('<MapType />', () => {
+  it('should render text area for map type when source is CIEL', () => {
+    const props = {
+      source: 'CIEL',
+    };
+    const wrapper = shallow(<MapType {...props} />);
+    expect(wrapper.find('select')).toHaveLength(0);
+    expect(wrapper.find('textarea')).toHaveLength(1);
+  });
+
+  it('should render select drop down for any other source', () => {
+    const props = {
+      source: 'test source',
+    };
+    const wrapper = shallow(<MapType {...props} />);
+    expect(wrapper.find('select')).toHaveLength(1);
+    expect(wrapper.find('textarea')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make the CIEL select dropdown a text input field](https://issues.openmrs.org/browse/OCLOMRS-387)

# Summary:
The map-type input field should have no default values and should be open to the user to type in any map-type when it is an internal mapping (one with the source as CIEL). Therefore, it should be a text input field and not a select dropdown.
