### PR TITLE
OCLOMRS-393 : Add mapping for existing concept

### DIFF
--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import autoBind from 'react-autobind';
 import { notify } from 'react-notify-toast';
 import PropTypes from 'prop-types';
+import uuid from 'uuid/v4';
 import CreateConceptForm from '../components/CreateConceptForm';
 import {
   createNewName,
@@ -18,6 +19,8 @@ import {
   createNewNameForEditConcept,
   removeNameForEditConcept,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE } from '../components/helperFunction';
+
 
 export class EditConcept extends Component {
   static propTypes = {
@@ -59,6 +62,14 @@ export class EditConcept extends Component {
       names: [],
       descriptions: [],
       isEditConcept: true,
+      mappings: [{
+        map_type: 'Same as',
+        source: null,
+        to_concept_code: null,
+        to_concept_name: null,
+        id: 1,
+        to_source_url: null,
+      }],
     };
     this.conceptUrl = '';
 
@@ -104,9 +115,9 @@ export class EditConcept extends Component {
     event.preventDefault();
   }
 
-  removeNewName(event, uuid) {
+  removeNewName(event, id) {
     event.preventDefault();
-    this.props.removeNameForEditConcept(uuid);
+    this.props.removeNameForEditConcept(id);
   }
 
   addNewDescription(event) {
@@ -187,6 +198,45 @@ export class EditConcept extends Component {
     }
   }
 
+  addMappingRow = () => {
+    const { mappings } = this.state;
+    mappings.push({
+      map_type: 'Same as',
+      source: null,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: mappings.length + 1,
+      to_source_url: null,
+    });
+    this.setState({ mappings });
+  }
+
+  updateEventListener = (event) => {
+    const { tabIndex, name, value } = event.target;
+    const { mappings } = this.state;
+    mappings[tabIndex][name] = value;
+    if (name !== INTERNAL_MAPPING_DEFAULT_SOURCE && mappings[tabIndex].to_concept_code === null) {
+      mappings[tabIndex].to_concept_code = String(uuid());
+    }
+    this.setState(mappings);
+  }
+
+  updateAsyncSelectValue = (value) => {
+    const { mappings } = this.state;
+    if (value !== null && value.index !== undefined) {
+      mappings[value.index].to_source_url = value.value;
+      mappings[value.index].to_concept_name = value.label;
+    }
+    this.setState({ mappings });
+  }
+
+  removeMappingRow = (event) => {
+    const { tabIndex } = event.target;
+    const { mappings } = this.state;
+    delete mappings[tabIndex];
+    this.setState({ mappings });
+  }
+
   render() {
     const {
       match: {
@@ -197,6 +247,7 @@ export class EditConcept extends Component {
       existingConcept,
       loading,
     } = this.props;
+    const { mappings } = this.state;
     const concept = conceptType ? ` ${conceptType}` : '';
     const path = localStorage.getItem('dictionaryPathName');
     return (
@@ -241,7 +292,12 @@ Concept
                 pathName={this.props.match.params}
                 existingConcept={existingConcept}
                 isEditConcept={this.state.isEditConcept}
+                addMappingRow={this.addMappingRow}
+                removeMappingRow={this.removeMappingRow}
+                updateEventListener={this.updateEventListener}
+                updateAsyncSelectValue={this.updateAsyncSelectValue}
                 answer={this.props.answer}
+                mappings={mappings}
                 disableButton={loading}
               />
               )

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -112,6 +112,14 @@ describe('Test suite for dictionary concepts components', () => {
     expect(props.removeNameForEditConcept).toHaveBeenCalled();
   });
 
+  it('should handle remove name  elements for edit concept', () => {
+    const wrapper = mount(<Router>
+      <EditConcept {...props} />
+    </Router>);
+    wrapper.find('#remove-name').simulate('click');
+    expect(props.removeNameForEditConcept).toHaveBeenCalled();
+  });
+
   it('should handle handleUUID', () => {
     const wrapper = mount(<Router>
       <EditConcept {...props} />
@@ -154,6 +162,211 @@ describe('Test suite for dictionary concepts components', () => {
     expect(notify.show).toHaveBeenCalledWith('enter a valid uuid', 'error', 3000);
   });
 
+  it('should call addMappingRow function', () => {
+    const wrapper = mount(<Router>
+      <EditConcept {...props} />
+    </Router>);
+    const instance = wrapper.find('EditConcept').instance();
+    instance.addMappingRow();
+
+    const mappingValue = [{
+      map_type: 'Same as',
+      source: null,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: 1,
+      to_source_url: null,
+    },
+    {
+      map_type: 'Same as',
+      source: null,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: 2,
+      to_source_url: null,
+    }];
+    expect(wrapper.find('EditConcept').state().mappings).toEqual(mappingValue);
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it('should call removeMappingRow function', () => {
+    const wrapper = mount(<Router>
+      <EditConcept {...props} />
+    </Router>);
+    const event = { target: 0 };
+    const instance = wrapper.find('EditConcept').instance();
+    instance.removeMappingRow(event);
+    expect(wrapper.length).toEqual(1);
+    const mappingValue = [{
+      map_type: 'Same as',
+      source: null,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: 1,
+      to_source_url: null,
+    }];
+    expect(wrapper.find('EditConcept').state().mappings).toEqual(mappingValue);
+  });
+
+  it('should call updateAsyncSelectValue function', () => {
+    const wrapper = mount(<Router>
+      <EditConcept {...props} />
+    </Router>);
+    const value = { index: 0, value: 'malaria 1', label: 'malaria 1' };
+    const instance = wrapper.find('EditConcept').instance();
+    instance.updateAsyncSelectValue(value);
+    const mappingValue = [{
+      map_type: 'Same as',
+      source: null,
+      to_concept_code: null,
+      to_concept_name: 'malaria 1',
+      id: 1,
+      to_source_url: 'malaria 1',
+    }];
+    expect(wrapper.find('EditConcept').state().mappings).toEqual(mappingValue);
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it('should cover updateAsyncSelectValue function', () => {
+    const wrapper = mount(<Router>
+      <EditConcept {...props} />
+    </Router>);
+    const value = null;
+    const instance = wrapper.find('EditConcept').instance();
+    instance.updateAsyncSelectValue(value);
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it('should call addDataFromDescription function', () => {
+    const wrapper = mount(<Router>
+      <EditConcept {...props} />
+    </Router>);
+    const data = {
+      id: {
+        uuid: '1234',
+        name: 'dummy',
+      },
+      locale: 'en',
+      locale_full: undefined,
+      description: 'test',
+      uuid: '1234',
+    };
+    const instance = wrapper.find('EditConcept').instance();
+    const description = [{
+      id: { uuid: '123', name: 'testing' },
+      locale: 'en',
+      locale_full: undefined,
+      description: undefined,
+      uuid: '123',
+    },
+    {
+      id: { uuid: '1234', name: 'dummy' },
+      locale: 'en',
+      locale_full: undefined,
+      description: undefined,
+      uuid: '1234',
+    }];
+    wrapper.find('EditConcept').instance().setState({
+      descriptions: description,
+    });
+    instance.addDataFromDescription(data);
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it('should call addDataFromRow function', () => {
+    const wrapper = mount(<Router>
+      <EditConcept {...props} />
+    </Router>);
+    const data = {
+      id: undefined,
+      name: 'dummy',
+      locale: undefined,
+      locale_preferred: 'Yes',
+      name_type: 'Fully Specified',
+      uuid: '1234',
+      locale_full: undefined,
+    };
+    const instance = wrapper.find('EditConcept').instance();
+    const names = [{
+      id: undefined,
+      name: 'dummy',
+      locale: undefined,
+      locale_full: undefined,
+      locale_preferred: 'Yes',
+      name_type: 'Fully Specified',
+      uuid: '1234',
+    },
+    {
+      id: undefined,
+      name: 'testing',
+      locale: undefined,
+      locale_full: undefined,
+      locale_preferred: 'Yes',
+      name_type: 'Fully Specified',
+      uuid: '123',
+    }];
+    wrapper.find('EditConcept').instance().setState({
+      names,
+    });
+    instance.addDataFromRow(data);
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it('should call updateEventListener function', () => {
+    const wrapper = mount(<Router>
+      <EditConcept {...props} />
+    </Router>);
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'to_concept_name',
+        value: 'malaria',
+      },
+    };
+    const instance = wrapper.find('EditConcept').instance();
+    instance.updateEventListener(event);
+    expect(wrapper.length).toEqual(1);
+    const mappingValue = [
+      {
+        map_type: 'Same as',
+        source: null,
+        to_concept_code: '1234',
+        to_concept_name: 'malaria',
+        id: 1,
+        to_source_url: null,
+      },
+    ];
+    expect(wrapper.find('EditConcept').state().mappings).toEqual(mappingValue);
+  });
+
+
+  it('should cover updateEventListener function', () => {
+    const wrapper = mount(<Router>
+      <EditConcept {...props} />
+    </Router>);
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'CIEL',
+        value: 'malaria',
+      },
+    };
+    const mappingValue = [{
+      map_type: 'Same as',
+      source: null,
+      to_concept_code: '',
+      to_concept_name: null,
+      id: 1,
+      to_source_url: null,
+    }];
+    wrapper.find('EditConcept').instance().setState({
+      mappings: mappingValue,
+    });
+    const instance = wrapper.find('EditConcept').instance();
+    instance.updateEventListener(event);
+    expect(wrapper.length).toEqual(1);
+  });
+
   it('it should handle submit event with invalid datatype', () => {
     jest.mock('react-notify-toast');
     notify.show = jest.fn();
@@ -164,15 +377,42 @@ describe('Test suite for dictionary concepts components', () => {
     wrapper.find(EditConcept).instance().setState({
       datatype: '',
     });
-
     const submitForm = wrapper.find('#createConceptForm');
     submitForm.simulate('submit', {
       preventDefault: () => {},
     });
-
     expect(notify.show).toHaveBeenCalledWith('choose a datatype', 'error', 3000);
   });
 
+  it('it should render with a null conceptType', () => {
+    const newProps = {
+      ...props,
+    };
+    newProps.match.params.conceptType = null;
+    const NewWrapper = mount(<Router>
+      <EditConcept {...newProps} />
+    </Router>);
+    const instance = NewWrapper.find('EditConcept').instance();
+    instance.addMappingRow();
+    expect(NewWrapper.length).toEqual(1);
+    const mappingValue = [{
+      map_type: 'Same as',
+      source: null,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: 1,
+      to_source_url: null,
+    },
+    {
+      map_type: 'Same as',
+      source: null,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: 2,
+      to_source_url: null,
+    }];
+    expect(NewWrapper.find('EditConcept').state().mappings).toEqual(mappingValue);
+  });
   it('should test mapStateToProps', () => {
     const initialState = {
       concepts: {


### PR DESCRIPTION
# JIRA TICKET NAME:
[implement add mappings to existing concepts](https://issues.openmrs.org/browse/OCLOMRS-393)

# Summary:

Currently, mappings cannot be added to existing concepts, this has to be implemented.This is because some missing props for createform.jsx component.