### PR TITLE
OCLOMRS-401: Browse released dictionary version shows 404

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
@@ -12,12 +12,13 @@ const DictionaryVersionsTable = (version) => {
   const DATE_OPTIONS = {
     weekday: 'long', year: 'numeric', month: 'short', day: 'numeric',
   };
+  const traditionalOclUrl = 'https://qa.openconceptlab.org';
   return (
     <tr id="versiontable">
       <td>{id}</td>
       <td>{ (new Date(updated_on)).toLocaleDateString('en-US', DATE_OPTIONS)}</td>
       <td>
-        <a className="btn btn-sm" href={version_url}>Browse in OCL</a>
+        <a className="btn btn-sm" target="_blank" rel="noopener noreferrer" href={traditionalOclUrl + version_url}>Browse in OCL</a>
         {' '}
         <Link className="downloadConcepts btn btn-sm" onClick={download} to="#">Download</Link>
         {' '}


### PR DESCRIPTION
# JIRA TICKET NAME:
[Browse released dictionary version shows 404](https://issues.openmrs.org/browse/OCLOMRS-401)

# Summary:
When you click browse on a released dictionary, it directs to 404 page