### PR TITLE
OCLOMRS-398: Fix bug with dictionary download

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -132,7 +132,9 @@ export class DictionaryOverview extends Component {
       owner: row.owner,
       source: row.source,
       preferredName: row.display_name,
-      description: row.descriptions.description,
+      description: row.descriptions ? row.descriptions.map(
+        description => description.description,
+      ).join(' ') : '',
       conceptClass: row.concept_class,
       datatype: row.datatype,
       retired: row.retired,

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -10,7 +10,7 @@ import {
 } from '../../components/dashboard/components/dictionary/DictionaryContainer';
 import dictionary from '../__mocks__/dictionaries';
 import versions, { customVersion, HeadVersion } from '../__mocks__/versions';
-import concepts from '../__mocks__/concepts';
+import concepts, { conceptWithoutDescriptions } from '../__mocks__/concepts';
 
 const store = createMockStore({
   organizations: {
@@ -329,7 +329,7 @@ describe('DictionaryOverview', () => {
       versions: [versions, customVersion],
       headVersion: [versions],
       url: '',
-      dictionaryConcepts: [concepts],
+      dictionaryConcepts: [concepts, conceptWithoutDescriptions],
       showEditModal: jest.fn(),
       hideSubModal: jest.fn(),
       showSubModal: jest.fn(),

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -34,6 +34,28 @@ export default {
   url: '/orgs/CIEL/sources/CIEL/concepts/146869/',
 };
 
+export const conceptWithoutDescriptions = {
+  id: '1468667',
+  external_id: '146869AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  concept_class: 'Diagnosis',
+  datatype: 'N/A',
+  retired: false,
+  source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+  descriptions: null,
+  owner: INTERNAL_MAPPING_DEFAULT_SOURCE,
+  owner_type: 'Organization',
+  owner_url: '/orgs/CIEL/',
+  display_name: 'Bronze Diabetes',
+  display_locale: 'en',
+  version: '5835c0e2955c3c0007e5fb79',
+  mappings: null,
+  is_latest_version: true,
+  locale: null,
+  version_url:
+    '/orgs/CIEL/sources/CIEL/concepts/146869/5835c0e2955c3c0007e5fb79/',
+  url: '/orgs/CIEL/sources/CIEL/concepts/146869/',
+};
+
 export const concept2 = {
   id: '1468667',
   external_id: '146869AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix bug with dictionary download](https://issues.openmrs.org/browse/OCLOMRS-398)

# Summary:
Previously,  the dictionary download button was throwing an error on console and doing nothing. This PR fixes that behavior.
