### PR TITLE
OCLOMRS-406: implement edit mapping on the right interface

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -11,6 +11,7 @@ const CreateConceptForm = (props) => {
   const {
     concept, handleAsyncSelectChange, queryAnswers, selectedAnswers, handleAnswerChange,
     mappings, addMappingRow, updateEventListener, removeMappingRow, updateAsyncSelectValue,
+    isEditConcept,
   } = props;
   return (
     <form className="form-wrapper" onSubmit={props.handleSubmit} id="createConceptForm">
@@ -199,6 +200,8 @@ const CreateConceptForm = (props) => {
                 updateAsyncSelectValue={updateAsyncSelectValue}
                 key={mapping.id}
                 index={i}
+                isEditConcept={isEditConcept}
+                isNew={mapping.isNew}
               />
             ))}
             <Link to="#" onClick={addMappingRow}>Add Another Mapping</Link>

--- a/src/components/dictionaryConcepts/components/CreateMapping.jsx
+++ b/src/components/dictionaryConcepts/components/CreateMapping.jsx
@@ -21,22 +21,26 @@ class CreateMapping extends Component {
     const {
       map_type, source, to_concept_code, to_concept_name, index,
       updateEventListener, removeMappingRow, updateAsyncSelectValue,
+      isNew,
     } = this.props;
-
     return (
       <div>
         <table className="table table-striped table-bordered concept-form-table">
           <tbody>
             <tr>
               <td>
-                <input
-                  tabIndex={index}
-                  className="form-control"
-                  placeholder="source"
-                  type="text"
-                  name="source"
-                  onChange={updateEventListener}
-                />
+                {!isNew && source}
+                {
+                  isNew && <input
+                    tabIndex={index}
+                    className="form-control"
+                    placeholder="source"
+                    type="text"
+                    name="source"
+                    onChange={updateEventListener}
+                    defaultValue={source}
+                  />
+              }
               </td>
               <td>
                 {<MapType
@@ -62,17 +66,18 @@ class CreateMapping extends Component {
               )}
               {source && (
                 <td className="react-async">
+                  {!isNew && to_concept_name}
                   {source === INTERNAL_MAPPING_DEFAULT_SOURCE ? (
-                    <AsyncSelect
+                    isNew && <AsyncSelect
                       cacheOptions
                       isClearable
                       loadOptions={async () => fetchSourceConcepts(source, inputValue, index)}
                       onChange={updateAsyncSelectValue}
                       onInputChange={this.handleInputChange}
-                      placeholder="concept name"
+                      placeholder="search concept name"
                     />
                   ) : (
-                    <input
+                    isNew && <input
                       tabIndex={index}
                       defaultValue={to_concept_name}
                       className="form-control"
@@ -106,6 +111,7 @@ CreateMapping.propTypes = {
   updateEventListener: PropTypes.func,
   removeMappingRow: PropTypes.func,
   updateAsyncSelectValue: PropTypes.func,
+  isNew: PropTypes.bool,
 };
 
 CreateMapping.defaultProps = {
@@ -114,6 +120,7 @@ CreateMapping.defaultProps = {
   to_concept_code: '',
   to_concept_name: '',
   index: 0,
+  isNew: false,
   updateEventListener: () => {},
   removeMappingRow: () => {},
   updateAsyncSelectValue: () => {},

--- a/src/components/dictionaryConcepts/components/MapType.jsx
+++ b/src/components/dictionaryConcepts/components/MapType.jsx
@@ -7,12 +7,15 @@ const mapType = (props) => {
     source, index, map_type, updateEventListener,
   } = props;
   const mapTypeInput = source === INTERNAL_MAPPING_DEFAULT_SOURCE
-    ? (<textarea
+    ? (<input
       type="text"
       rows="3"
       className="form-control concept-description"
       name="map_type"
+      placeholder="Relationship"
       onChange={updateEventListener}
+      defaultValue={map_type}
+      tabIndex={index}
     />)
     : (
       <select

--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -33,3 +33,4 @@ export const classes = [
 ];
 
 export const INTERNAL_MAPPING_DEFAULT_SOURCE = 'CIEL';
+export const CIEL_SOURCE_URL = '/orgs/CIEL/sources/CIEL/';

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -72,6 +72,7 @@ export class CreateConcept extends Component {
         to_concept_name: null,
         id: 1,
         to_source_url: null,
+        isNew: true,
       }],
     };
 
@@ -245,6 +246,7 @@ export class CreateConcept extends Component {
       to_concept_name: null,
       id: mappings.length + 1,
       to_source_url: null,
+      isNew: true,
     });
     this.setState({ mappings });
   }

--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import autoBind from 'react-autobind';
 import { notify } from 'react-notify-toast';
 import PropTypes from 'prop-types';
+import uuid from 'uuid/v4';
 import CreateConceptForm from '../components/CreateConceptForm';
 import {
   createNewName,
@@ -18,6 +19,7 @@ import {
   createNewNameForEditConcept,
   removeNameForEditConcept,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL } from '../components/helperFunction';
 
 export class EditConcept extends Component {
   static propTypes = {
@@ -59,6 +61,7 @@ export class EditConcept extends Component {
       names: [],
       descriptions: [],
       isEditConcept: true,
+      mappings: [],
     };
     this.conceptUrl = '';
 
@@ -77,12 +80,21 @@ export class EditConcept extends Component {
         },
       },
     } = this.props;
-    this.conceptUrl = `/${type}/${typeName}/sources/${collectionName}/concepts/${conceptId}/`;
+    this.conceptUrl = `/${type}/${typeName}/sources/${collectionName}/concepts/${conceptId}/?includeMappings=true`;
     this.props.fetchExistingConcept(this.conceptUrl);
   }
 
   componentWillUnmount() {
     this.props.clearSelections();
+  }
+
+  componentWillReceiveProps(newProps) {
+    const { existingConcept } = newProps;
+    const { mappings } = this.state;
+    if (existingConcept.mappings !== undefined
+      && existingConcept.mappings.length > mappings.length) {
+      this.organizeMappings(existingConcept.mappings);
+    }
   }
 
   updateState() {
@@ -104,9 +116,9 @@ export class EditConcept extends Component {
     event.preventDefault();
   }
 
-  removeNewName(event, uuid) {
+  removeNewName(event, universalUniqueIdentifier) {
     event.preventDefault();
-    this.props.removeNameForEditConcept(uuid);
+    this.props.removeNameForEditConcept(universalUniqueIdentifier);
   }
 
   addNewDescription(event) {
@@ -187,6 +199,76 @@ export class EditConcept extends Component {
     }
   }
 
+  addMappingRow = () => {
+    const { mappings } = this.state;
+    mappings.push({
+      map_type: 'Same as',
+      source: null,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: mappings.length + 1,
+      to_source_url: null,
+      isNew: true,
+    });
+    this.setState({ mappings });
+  }
+
+  updateEventListener = (event) => {
+    const { tabIndex, name, value } = event.target;
+    const { mappings } = this.state;
+    mappings[tabIndex][name] = value;
+    if (name !== INTERNAL_MAPPING_DEFAULT_SOURCE && mappings[tabIndex].to_concept_code === null) {
+      mappings[tabIndex].to_concept_code = String(uuid());
+    }
+    this.setState(mappings);
+  }
+
+  updateAsyncSelectValue = (value) => {
+    const { mappings } = this.state;
+    if (value !== null && value.index !== undefined) {
+      mappings[value.index].to_source_url = value.value;
+      mappings[value.index].to_concept_name = value.label;
+    }
+    this.setState({ mappings });
+  }
+
+  removeMappingRow = (event) => {
+    const { tabIndex } = event.target;
+    const { mappings } = this.state;
+    delete mappings[tabIndex];
+    this.setState({ mappings });
+  }
+
+  organizeMappings = (mappings) => {
+    const filteredMappings = mappings.map((mapping, i) => {
+      if (mapping.to_source_url === CIEL_SOURCE_URL) {
+        return {
+          id: i,
+          map_type: mapping.map_type,
+          source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+          to_concept_code: mapping.to_concept_code,
+          to_concept_name: mapping.to_concept_name,
+          to_source_url: mapping.to_concept_url,
+          url: mapping.url,
+        };
+      }
+      return {
+        id: i,
+        map_type: mapping.map_type,
+        source: mapping.to_source_url,
+        to_concept_code: mapping.to_concept_code,
+        to_concept_name: mapping.to_concept_name,
+        to_source_url: mapping.to_concept_url,
+        url: mapping.url,
+      };
+    });
+    this.setState({
+      mappings: filteredMappings,
+      from_concept_url: mappings[0].from_concept_url,
+      source: mappings[0].source,
+    });
+  }
+
   render() {
     const {
       match: {
@@ -199,6 +281,7 @@ export class EditConcept extends Component {
     } = this.props;
     const concept = conceptType ? ` ${conceptType}` : '';
     const path = localStorage.getItem('dictionaryPathName');
+    const { mappings } = this.state;
     return (
       <div className="container create-custom-concept">
         <div className="row create-concept-header">
@@ -243,6 +326,11 @@ Concept
                 isEditConcept={this.state.isEditConcept}
                 answer={this.props.answer}
                 disableButton={loading}
+                mappings={mappings}
+                addMappingRow={this.addMappingRow}
+                updateEventListener={this.updateEventListener}
+                removeMappingRow={this.removeMappingRow}
+                updateAsyncSelectValue={this.updateAsyncSelectValue}
               />
               )
               }

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -363,6 +363,7 @@ export const newConceptData = {
       to_concept_code: 'dce20834-a9d7-41c6-be70-587f5246d41a',
       to_concept_name: 'MALARIA SMEAR, QUALITATIVE',
       to_source_url: '/orgs/CIEL/sources/CIEL/concepts/1366/',
+      isNew: false,
     },
     {
       map_type: 'Narrower than',
@@ -370,6 +371,7 @@ export const newConceptData = {
       to_concept_code: '67c0bc01-4f16-4424-80fd-f08b122bcef2',
       to_concept_name: 'MALARIA DIAGNOSIS IN THE LAST TWELVE MONTHS',
       to_source_url: '/orgs/CIEL/sources/CIEL/concepts/1476/',
+      isNew: true,
     },
     {
       id: 3,
@@ -378,6 +380,7 @@ export const newConceptData = {
       to_concept_code: '92eebf0a-df73-4c17-985f-0347c7dee768',
       to_concept_name: 'malaria',
       to_source_url: null,
+      isNew: false,
     },
   ],
 };
@@ -448,7 +451,34 @@ export const existingConcept = {
       // eslint-disable-next-line max-len
       'Family planning register; Service delivery tally (for HP), RH register (for primary private clinics), Pre-ART, ART registers',
   },
-  mappings: 'mappings',
+  mappings: [
+    {
+      id: 1,
+      map_type: 'Same as',
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      to_concept_code: 'dce20834-a9d7-41c6-be70-587f5246d41a',
+      to_concept_name: 'MALARIA SMEAR, QUALITATIVE',
+      to_source_url: '/orgs/CIEL/sources/CIEL/concepts/1366/',
+      isNew: false,
+    },
+    {
+      map_type: 'Narrower than',
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      to_concept_code: '67c0bc01-4f16-4424-80fd-f08b122bcef2',
+      to_concept_name: 'MALARIA DIAGNOSIS IN THE LAST TWELVE MONTHS',
+      to_source_url: '/orgs/CIEL/sources/CIEL/concepts/1476/',
+      isNew: true,
+    },
+    {
+      id: 3,
+      map_type: 'Same as',
+      source: 'SNOMED',
+      to_concept_code: '92eebf0a-df73-4c17-985f-0347c7dee768',
+      to_concept_name: 'malaria',
+      to_source_url: null,
+      isNew: false,
+    },
+  ],
   is_latest_version: true,
   locale: null,
   version_url:

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -68,6 +68,7 @@ import concepts, {
   multipleConceptsMockStore,
   existingConcept,
 } from '../../__mocks__/concepts';
+import { CIEL_SOURCE_URL } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 jest.mock('uuid/v4', () => jest.fn(() => 1));
 jest.mock('react-notify-toast');
@@ -769,7 +770,7 @@ describe('Add answer mappings to concept', () => {
         to_source_name: 'CIEL',
         to_source_owner: 'CIEL',
         to_source_owner_type: 'Organization',
-        to_source_url: '/orgs/CIEL/sources/CIEL/',
+        to_source_url: CIEL_SOURCE_URL,
         type: 'Mapping',
         updated_at: '2018-12-17T13:32:26.769',
         updated_by: 'admin',
@@ -801,7 +802,7 @@ describe('Add answer mappings to concept', () => {
         to_source_name: 'CIEL',
         to_source_owner: 'CIEL',
         to_source_owner_type: 'Organization',
-        to_source_url: '/orgs/CIEL/sources/CIEL/',
+        to_source_url: CIEL_SOURCE_URL,
         type: 'Mapping',
         updated_at: '2018-12-17T13:32:26.769',
         updated_by: 'admin',

--- a/src/tests/dictionaryConcepts/components/CreateMapping.test.js
+++ b/src/tests/dictionaryConcepts/components/CreateMapping.test.js
@@ -45,4 +45,31 @@ describe('Test suite for dictionary concepts components', () => {
     inputField.find('#remove').first().simulate('click');
     expect(props.removeMappingRow).toHaveBeenCalled();
   });
+
+  it('should render when isNew is true and source not CIEL', () => {
+    const newProps = {
+      ...props,
+      isNew: true,
+      source: 'Snomed',
+    };
+
+    wrapper = mount(<Router>
+      <CreateMapping {...newProps} />
+    </Router>);
+    const inputs = wrapper.find('input');
+    expect(inputs).toHaveLength(3);
+  });
+
+  it('should render when isNew is true and source equal to CIEL', () => {
+    const newProps = {
+      ...props,
+      isNew: true,
+    };
+
+    wrapper = mount(<Router>
+      <CreateMapping {...newProps} />
+    </Router>);
+  });
+  const inputs = wrapper.find('input');
+  expect(inputs).toHaveLength(1);
 });

--- a/src/tests/dictionaryConcepts/components/MapType.test.js
+++ b/src/tests/dictionaryConcepts/components/MapType.test.js
@@ -9,7 +9,7 @@ describe('<MapType />', () => {
     };
     const wrapper = shallow(<MapType {...props} />);
     expect(wrapper.find('select')).toHaveLength(0);
-    expect(wrapper.find('textarea')).toHaveLength(1);
+    expect(wrapper.find('input')).toHaveLength(1);
   });
 
   it('should render select drop down for any other source', () => {
@@ -18,6 +18,6 @@ describe('<MapType />', () => {
     };
     const wrapper = shallow(<MapType {...props} />);
     expect(wrapper.find('select')).toHaveLength(1);
-    expect(wrapper.find('textarea')).toHaveLength(0);
+    expect(wrapper.find('input')).toHaveLength(0);
   });
 });

--- a/src/tests/dictionaryConcepts/components/MappingModal.test.js
+++ b/src/tests/dictionaryConcepts/components/MappingModal.test.js
@@ -52,6 +52,14 @@ describe('render MappingModal', () => {
     expect(wrapper.state().type).toBe('Internal Mapping');
   });
 
+  it('should call submitMapping onclick', () => {
+    wrapper.setState({
+      type: 'External Mapping',
+    });
+    wrapper.find('#mappingSubmit').simulate('click');
+    expect(wrapper.state().type).toBe('External Mapping');
+  });
+
   it('should close handleToggle onclick', () => {
     wrapper.find('#CloseModal').simulate('click');
     expect(props.handleToggle).toBeCalled();

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -7,6 +7,7 @@ import {
   mapStateToProps,
 } from '../../../components/dictionaryConcepts/containers/EditConcept';
 import { newConcept, existingConcept } from '../../__mocks__/concepts';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 jest.mock('uuid/v4', () => jest.fn(() => 1234));
 jest.mock('react-notify-toast');
@@ -187,5 +188,120 @@ describe('Test suite for dictionary concepts components', () => {
     expect(mapStateToProps(initialState).newConcept).toEqual(newConcept);
     expect(mapStateToProps(initialState).newName).toEqual(['1']);
     expect(mapStateToProps(initialState).existingConcept).toEqual(existingConcept);
+  });
+});
+
+describe('Test suite for mappings on existing concepts', () => {
+  const props = {
+    match: {
+      params: {
+        conceptType: 'question',
+        collectionName: 'dev-col',
+        type: 'users',
+        typeName: 'emmabaye',
+        language: 'en',
+        conceptId: '1',
+        name: '',
+      },
+    },
+    history: {
+      push: jest.fn(),
+    },
+    createNewName: jest.fn(),
+    addNewDescription: jest.fn(),
+    clearSelections: jest.fn(),
+    fetchExistingConcept: jest.fn(),
+    clearPreviousConcept: jest.fn(),
+    createNewNameForEditConcept: jest.fn(),
+    removeDescriptionForEditConcept: jest.fn(),
+    addDescriptionForEditConcept: jest.fn(),
+    removeNameForEditConcept: jest.fn(),
+    updateConcept: jest.fn(),
+    addNewAnswer: jest.fn(),
+    removeAnswer: jest.fn(),
+    newName: ['1'],
+    description: ['1'],
+    answer: ['78'],
+    loading: false,
+    existingConcept: {
+      names: [{
+        uuid: '1234',
+        name: 'dummy',
+      }],
+      descriptions: [{
+        uuid: '1234',
+        name: 'dummy',
+      }],
+    },
+    newRow: '1234',
+  };
+  const wrapper = mount(<Router>
+    <EditConcept {...props} />
+  </Router>);
+
+  it('should call addMappingRow function', () => {
+    const instance = wrapper.find('EditConcept').instance();
+    instance.addMappingRow();
+  });
+
+  it('should call removeMappingRow function', () => {
+    const event = { target: 0 };
+    const instance = wrapper.find('EditConcept').instance();
+    instance.removeMappingRow(event);
+  });
+
+  it('should call updateAsyncSelectValue function', () => {
+    const value = { index: 0, value: 'malaria 1', label: 'malaria 1' };
+    const instance = wrapper.find('EditConcept').instance();
+    instance.updateAsyncSelectValue(value);
+  });
+
+  it('should call updateEventListener function', () => {
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'to_concept_name',
+        value: 'malaria',
+      },
+    };
+    const instance = wrapper.find('EditConcept').instance();
+    instance.updateEventListener(event);
+  });
+
+  it('should test componentWillReceiveProps', () => {
+    const newProps = {
+      existingConcept: {
+        mappings: [
+          {
+            id: 1,
+            map_type: 'Same as',
+            source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+            to_concept_code: 'dce20834-a9d7-41c6-be70-587f5246d41a',
+            to_concept_name: 'MALARIA SMEAR, QUALITATIVE',
+            to_source_url: '/orgs/CIEL/sources/CIEL/concepts/1366/',
+            isNew: false,
+          },
+          {
+            map_type: 'Narrower than',
+            source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+            to_concept_code: '67c0bc01-4f16-4424-80fd-f08b122bcef2',
+            to_concept_name: 'MALARIA DIAGNOSIS IN THE LAST TWELVE MONTHS',
+            to_source_url: CIEL_SOURCE_URL,
+            isNew: true,
+          },
+          {
+            id: 3,
+            map_type: 'Same as',
+            source: 'SNOMED',
+            to_concept_code: '92eebf0a-df73-4c17-985f-0347c7dee768',
+            to_concept_name: 'malaria',
+            to_source_url: null,
+            isNew: false,
+          },
+        ],
+      },
+    };
+    const instance = wrapper.find('EditConcept').instance();
+    instance.componentWillReceiveProps(newProps);
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[implement edit mapping on the right interface](https://issues.openmrs.org/browse/OCLOMRS-406)

# Summary:
"edit mapping" is currently implemented in the view mappings interface. It needs to be implemented in the edit concept interface