### PR TITLE
OCLOMRS-397: Fix inaccurate total concept counts on some dictionary detail card page

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -14,7 +14,6 @@ const DictionaryDetailCard = (props) => {
       public_access,
       owner,
       owner_type,
-      active_concepts,
       description,
       owner_url,
       short_code,
@@ -141,7 +140,7 @@ Dictionary
               <b>Total Concepts</b>
 :
               {' '}
-              {active_concepts}
+              {Number(customConcepts) + Number(cielConcepts)}
             </p>
             <p className="points">
               <b>Custom Concepts</b>


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix inaccurate total concept counts on dictionary detail card page](https://issues.openmrs.org/browse/OCLOMRS-397)

# Summary:
On the dictionary overview page, the dictionary overview card shows total concepts count that doesn't match the sum between custom concepts and CIEL concepts. With some dictionaries this sum is fine and the total concepts count is representative, however, some like [this one](https://openmrs.qa.openconceptlab.org/dictionaryOverview/users/admin/collections/ME101/) show this discrepancy.

The issue is that active_concepts field that is sent with the dictionary from the backend is used to represent total concepts on the frontend. This is not right.