### PR TITLE
OCLOMRS-408: Display change 'concepts' to 'active_concepts' on the home page dictionary card

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryCard.jsx
@@ -44,7 +44,7 @@ const DictionaryCard = (dictionary) => {
           <div className="description col-12 text-left">
             <p>
               <span className="source-type">
-Concepts:
+Active Concepts:
                 {' '}
                 {active_concepts}
               </span>


### PR DESCRIPTION
# JIRA TICKET NAME:
[Display change 'concepts' to 'active_concepts' on the home page dictionary card](https://issues.openmrs.org/browse/OCLOMRS-408)

# Summary:
Currently, the concepts count displayed in dictionary card on the home page is the number of 'active_concepts' on that dictionary. Simply displaying 'concepts' doesn't give the user an idea what type of concepts they are looking at because some are active and some might be retired. This ticket is based on feedback from this [thread.](https://talk.openmrs.org/t/developing-the-ocl-for-openmrs-application/17771/537)
