### PR TITLE
OCLOMRS-409: Add display for active concepts on the dictionary detail card

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -144,6 +144,12 @@ Dictionary
               {active_concepts}
             </p>
             <p className="points">
+              <b>Active Concepts</b>
+:
+              {' '}
+              {active_concepts}
+            </p>
+            <p className="points">
               <b>Custom Concepts</b>
 :
               {' '}


### PR DESCRIPTION
# JIRA TICKET NAME:
[Add display for active concepts on the dictionary detail card](https://issues.openmrs.org/browse/OCLOMRS-409)

# Summary:
In order to tell the user what type of concepts they are looking at, there's a need to also add a display that explicitly tells the user the active concepts count on the dictionary detail card. This ticket is based on feedback from this [thread.](https://talk.openmrs.org/t/developing-the-ocl-for-openmrs-application/17771/537)
