### PR TITLE
OCLOMRS-403: fix wrong error message with invalid authentication token

### DIFF
--- a/src/components/userDasboard/container/UserDashboard.jsx
+++ b/src/components/userDasboard/container/UserDashboard.jsx
@@ -35,7 +35,11 @@ export class UserDashboard extends Component {
 
   componentDidMount() {
     const username = getUsername();
-    this.props.fetchUserData(username);
+    if (!username) {
+      this.props.history.push('/');
+      return;
+    }
+    this.props.fetchUserData(username, this.props);
   }
 
   componentWillUnmount() {

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -120,8 +120,9 @@ export const removeDictionaryConcept = (data, type, owner, collectionId) => disp
       );
     }
     )
-    .catch(() => {
-      notify.show("Network Error. Please try again later!", 'error', 6000)
+    .catch((error) => {
+      error.response ? notify.show(error.response.data.detail, 'error', 6000):
+      showNetworkError();
       });
     };
 
@@ -140,7 +141,8 @@ export const removeConceptMapping = (data, source) => dispatch => {
       }
     )
     .catch((error) => {
-      notify.show("Network Error. Please try again later!",'error', 6000)
+      error.response ? notify.show(error.response.data.detail, 'error', 6000):
+      showNetworkError();
     });
 };
 

--- a/src/redux/actions/user/index.js
+++ b/src/redux/actions/user/index.js
@@ -11,30 +11,43 @@ import {
 } from '../types';
 import instance from '../../../config/axiosConfig';
 import { filterUserPayload } from '../../reducers/util';
+import { logout } from '../auth/authActionCreators';
 
-export const fetchUser = username => async (dispatch) => {
+const REQUEST_DENIED_MESSAGE = 'Request failed with status code 401';
+
+export const fetchUser = (username, props) => async (dispatch) => {
   const url = `users/${username}/`;
   try {
     const response = await instance.get(url);
     dispatch(isSuccess(response.data, GET_USER));
   } catch (error) {
+    if (error.message === REQUEST_DENIED_MESSAGE) {
+      dispatch(logout());
+      props.history.push('/');
+      return;
+    }
     const message = 'An error occurred with your internet connection, please fix it and try reloading the page.';
     notify.show(message, 'error', 3000);
     dispatch(isErrored(message, NETWORK_ERROR));
   }
 };
 
-export const fetchUserOrganizations = username => async (dispatch) => {
+export const fetchUserOrganizations = (username, props) => async (dispatch) => {
   const url = `users/${username}/orgs/`;
   try {
     const response = await instance.get(url);
     dispatch(isSuccess(response.data, FETCH_USER_ORGANIZATION));
   } catch (error) {
+    if (error.message === REQUEST_DENIED_MESSAGE) {
+      dispatch(logout());
+      props.history.push('/');
+      return;
+    }
     notify.show('An error occurred with your internet connection, please fix it and try reloading the page.', 'error', 3000);
   }
 };
 
-export const fetchsUserDictionaries = username => async (dispatch) => {
+export const fetchsUserDictionaries = (username, props) => async (dispatch) => {
   const url = `/users/${username}/collections/?q=${''}&limit=${0}&page=${1}&verbose=true`;
   dispatch(isFetching(true));
   try {
@@ -42,15 +55,20 @@ export const fetchsUserDictionaries = username => async (dispatch) => {
     const result = filterUserPayload(username, response.data);
     dispatch(isSuccess(result, FETCH_USER_DICTIONARY));
   } catch (error) {
+    if (error.message === REQUEST_DENIED_MESSAGE) {
+      dispatch(logout());
+      props.history.push('/');
+      return;
+    }
     notify.show('An error occurred with your internet connection, please fix it and try reloading the page.', 'error', 3000);
   }
 };
 
-export const fetchUserData = username => async (dispatch) => {
+export const fetchUserData = (username, props) => async (dispatch) => {
   dispatch(isFetching(true));
-  await dispatch(fetchUser(username));
-  await dispatch(fetchsUserDictionaries(username));
-  await dispatch(fetchUserOrganizations(username));
+  await dispatch(fetchUser(username, props));
+  await dispatch(fetchsUserDictionaries(username, props));
+  await dispatch(fetchUserOrganizations(username, props));
   dispatch(isFetching(false));
 };
 

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -303,8 +303,31 @@ describe('Test suite for dictionary concept actions', () => {
       const request = moxios.requests.mostRecent();
       request.reject({
         status: 599,
+        response: newConcept.version_url,
+      });
+    });
+
+    const expectedActions = [
+      { type: REMOVE_MAPPING, payload: '/users/admin/sources/858738987555379984/mappings/5bff9fb3bdfb8801a1702975/' },
+    ];
+
+    const store = mockStore(mockConceptStore);
+    const data = { references: ['/users/admin/sources/858738987555379984/mappings/5bff9fb3bdfb8801a1702975/'] };
+    const type = 'users';
+    const owner = 'alexmochu';
+    const collectionId = 'Tech';
+    return store.dispatch(removeConceptMapping(data, type, owner, collectionId)).catch(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should handle REMOVE_MAPPING forbidden error', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        status: 403,
         response: {
-          data: { detail: 'Cannot remove mapping' },
+          data: { detail: 'You do not have permission to perform this action.' },
         },
       });
     });
@@ -335,6 +358,26 @@ describe('Test suite for dictionary concept actions', () => {
     const expectedActions = [
       { type: REMOVE_CONCEPT, payload: newConcept.version_url },
     ];
+
+    const store = mockStore(mockConceptStore);
+    const data = { references: ['/orgs/IHTSDO/sources/SNOMED-CT/concepts/12845003/73jifjibL83/'] };
+    const type = 'users';
+    const owner = 'alexmochu';
+    const collectionId = 'Tech';
+    return store.dispatch(removeDictionaryConcept(data, type, owner, collectionId)).catch(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should handle REMOVE_CONCEPT forbidden error', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        status: 403,
+        response: { data: { detail: 'You do not have permission to perform this action.' } },
+      });
+    });
+
+    const expectedActions = [];
 
     const store = mockStore(mockConceptStore);
     const data = { references: ['/orgs/IHTSDO/sources/SNOMED-CT/concepts/12845003/73jifjibL83/'] };

--- a/src/tests/userDashboard/actions/index.test.js
+++ b/src/tests/userDashboard/actions/index.test.js
@@ -12,6 +12,7 @@ import {
   USER_IS_MEMBER,
   USER_IS_NOT_MEMBER,
   NETWORK_ERROR,
+  LOGGED_OUT,
 } from '../../../redux/actions/types';
 import {
   fetchUserData,
@@ -85,6 +86,31 @@ describe('Test suite for user dashboard actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
+  it('should handle request failure of status code 401 in FETCH_USER_DICTIONARY', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 401,
+        response: { message: 'Request failed with status code 401' },
+      });
+    });
+
+    const expectedActions = [
+      {
+        payload: true,
+        type: IS_FETCHING,
+      },
+      {
+        type: LOGGED_OUT,
+        payload: {},
+      },
+    ];
+
+    const store = mockStore({});
+    return store.dispatch(fetchsUserDictionaries('chriskala', { history: { push: jest.fn } })).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
   it('should handle FETCH_USER_ORGANIZATION', () => {
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();
@@ -119,6 +145,27 @@ describe('Test suite for user dashboard actions', () => {
 
     const store = mockStore({});
     return store.dispatch(fetchUserOrganizations('emasys')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should handle request failure of status code 401 in FETCH_USER_ORGANIZATION', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 401,
+        response: { message: 'Request failed with status code 401' },
+      });
+    });
+
+    const expectedActions = [
+      {
+        type: LOGGED_OUT,
+        payload: {},
+      },
+    ];
+
+    const store = mockStore({});
+    return store.dispatch(fetchUserOrganizations('emasys', { history: { push: jest.fn } })).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
@@ -161,6 +208,27 @@ describe('Test suite for user dashboard actions', () => {
 
     const store = mockStore({});
     return store.dispatch(fetchUser('emasys')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should handle request failure of status code 401 in GET_USER', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 401,
+        response: { message: 'Request failed with status code 401' },
+      });
+    });
+
+    const expectedActions = [
+      {
+        type: LOGGED_OUT,
+        payload: {},
+      },
+    ];
+
+    const store = mockStore({});
+    return store.dispatch(fetchUser('emasys', { history: { push: jest.fn } })).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/src/tests/userDashboard/container/UserDashboard.test.jsx
+++ b/src/tests/userDashboard/container/UserDashboard.test.jsx
@@ -56,6 +56,18 @@ describe('Test suite for dictionary concepts components', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should render without breaking without username specified', () => {
+    localStorage.removeItem('username', 'chriskala');
+    const wrapper = mount(<Provider store={store}>
+      <MemoryRouter>
+        <UserDashboard {...props} />
+      </MemoryRouter>
+    </Provider>);
+    expect(wrapper.find('.greetings h5').text()).toEqual('Welcome emasys nd');
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('should handle hide function', () => {
     const wrapper = mount(<Provider store={store}>
       <MemoryRouter>


### PR DESCRIPTION
# JIRA TICKET NAME:
[fix wrong error message with invalid authentication token](https://issues.openmrs.org/browse/OCLOMRS-403)

# Summary:
The first time the application url (for a developer; localhost:<port>/home. Currently deployed; https://openmrs.qa.openconceptlab.org/home) is visited on a browser, it shows network error message on the login page.
When an invalid token is supplied during authentication by the browser, it keeps showing network error on refresh until you click logout to get to the login page and login.

The application should show login page without network error message when a user visits the application url the first time.
Invalid token should redirect to login page.
