### PR TITLE
OCLOMRS-400: Fix the need for manual refresh with dictionary edit

### DIFF
--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -161,18 +161,6 @@ export class DictionaryModal extends React.Component {
 
   hideModal = () => {
     this.setState({
-      data: {
-        id: '',
-        preferred_source: 'CIEL',
-        public_access: 'View',
-        name: '',
-        owner: '',
-        description: '',
-        default_locale: 'en',
-        supported_locales: '',
-        repository_type: 'OpenMRSDictionary',
-        conceptUrl: '',
-      },
       errors: {},
       supportedLocalesOptions: [],
       disableButton: false,


### PR DESCRIPTION
# JIRA TICKET NAME:
[fix the need for manual refresh with dictionary edit](https://issues.openmrs.org/browse/OCLOMRS-400)

# Summary:
Edit page for dictionary does not populate without manual refresh after first edit