### PR TITLE
OCLMRS-418: change the default number of rows to 20 on dictionary concepts page

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -40,7 +40,8 @@ const ConceptTable = ({
         <ReactTable
           data={concepts}
           loading={loading}
-          defaultPageSize={concepts.length <= conceptLimit ? concepts.length : conceptLimit}
+          pageSizeOptions={[5, 10, 20, 25, 50, 100]}
+          defaultPageSize={conceptLimit}
           noDataText="No concept!"
           minRows={2}
           columns={[

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -47,7 +47,7 @@ export class DictionaryConcepts extends Component {
     super(props);
     this.state = {
       searchInput: '',
-      conceptLimit: 10,
+      conceptLimit: 20,
       versionUrl: '',
       data: {
         references: [],


### PR DESCRIPTION
# JIRA TICKET NAME:
[change the default number of rows to 20 on dictionary concepts page](https://issues.openmrs.org/browse/OCLOMRS-418)

# Summary:
Currently, the default number of rows is 5 when viewing concepts belonging to a dictionary. This is too small.