### PR TITLE
OCLOMRS-411: Refresh dictionary concepts page when search field is cleared

### DIFF
--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -94,6 +94,9 @@ export class BulkConceptsPage extends Component {
     const {
       target: { value },
     } = event;
+    if (!value) {
+      this.getBulkConcepts();
+    }
     this.setState(() => ({ searchInput: value }));
   };
 

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -334,6 +334,47 @@ describe('Test suite for BulkConceptsPage component', () => {
     expect(instance.componentDidUpdate(2)).toEqual(undefined);
   });
 
+  it('should refresh page when search input is empty', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      searchingOn: true,
+      fetchBulkConcepts: jest.fn(),
+      getBulkConcepts: jest.fn(),
+      concepts: [],
+      loading: true,
+      datatypes: [],
+      classes: [],
+      conceptLimit: 10,
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: 'CIEL',
+        },
+      },
+      addToFilterList: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      handleNextPage: jest.fn(),
+    };
+    const wrapper = mount(<Router>
+      <Provider store={store}>
+        <BulkConceptsPage {...props} />
+      </Provider>
+    </Router>);
+    const Wrapper = wrapper.find('BulkConceptsPage').instance();
+    const spy = jest.spyOn(Wrapper, 'getBulkConcepts');
+    Wrapper.forceUpdate();
+    wrapper.update();
+    const event = { target: { name: 'searchInput', value: '' } };
+    wrapper.find('#search-concept').simulate('change', event);
+    expect(spy).toHaveBeenCalled();
+  });
+
   it('should search for concepts', () => {
     const props = {
       setCurrentPage: jest.fn(),


### PR DESCRIPTION
# JIRA TICKET NAME:
[Refresh dictionary concepts page when search field is cleared](https://issues.openmrs.org/browse/OCLOMRS-411)

# Summary:
When a user clears the search field the dictionary concepts should refresh. 

Steps to reproduce

1) Open the ﻿﻿Add CIEL concepts page.

2) input the concept on the search bar and click the arrow button to search.

3) When the search results are showing on the table clear the search bar.

4) You will notice that the search result is still showing on the table.
