### PR TITLE
OCLOMRS-399: Make checkbox on concepts page checked after concept edit

### DIFF
--- a/src/components/dictionaryConcepts/components/SideNavItem.jsx
+++ b/src/components/dictionaryConcepts/components/SideNavItem.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const SideNavItem = ({ item, handleChange, filterType }) => (
+const SideNavItem = ({
+  item, handleChange, filterType, checkValue,
+}) => (
   <div className="custom-control custom-checkbox">
     <input
       type="checkbox"
@@ -10,6 +12,7 @@ const SideNavItem = ({ item, handleChange, filterType }) => (
       name={[item, filterType]}
       id={item}
       onChange={handleChange}
+      checked={checkValue}
     />
     <label className="custom-control-label" htmlFor={item}>
       {filterType === 'source' && item !== 'CIEL' ? 'Custom' : item}
@@ -19,8 +22,13 @@ const SideNavItem = ({ item, handleChange, filterType }) => (
 
 SideNavItem.propTypes = {
   item: PropTypes.string.isRequired,
+  checkValue: PropTypes.bool,
   handleChange: PropTypes.func.isRequired,
   filterType: PropTypes.string.isRequired,
+};
+
+SideNavItem.defaultProps = {
+  checkValue: false,
 };
 
 export default SideNavItem;

--- a/src/components/dictionaryConcepts/components/Sidenav.jsx
+++ b/src/components/dictionaryConcepts/components/Sidenav.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SideNavItem from './SideNavItem';
 
-const Sidenav = ({ filteredClass, filteredSources, handleChange }) => (
+const Sidenav = ({
+  filteredClass, filteredSources, handleChange, toggleCheck,
+}) => (
   <div className="col-12 col-md-2 custom-full-width">
     <div className="sidenav-container">
       <div className="row">
@@ -20,6 +22,7 @@ const Sidenav = ({ filteredClass, filteredSources, handleChange }) => (
           key={classItem}
           filterType="classes"
           handleChange={handleChange}
+          checkValue={toggleCheck.includes(`"${classItem}"`)}
         />
       ))}
     </div>
@@ -29,8 +32,13 @@ const Sidenav = ({ filteredClass, filteredSources, handleChange }) => (
 /* eslint-disable */
 Sidenav.propTypes = {
   filteredSources: PropTypes.array.isRequired,
+  toggleCheck: PropTypes.array.isRequired,
   filteredClass: PropTypes.array.isRequired,
   handleChange: PropTypes.func.isRequired,
 };
+
+Sidenav.defaultProps = {
+  toggleCheck: []
+}
 
 export default Sidenav;

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -36,6 +36,7 @@ export class DictionaryConcepts extends Component {
     filteredClass: PropTypes.arrayOf(PropTypes.string).isRequired,
     loading: PropTypes.bool.isRequired,
     filterBySource: PropTypes.func.isRequired,
+    filteredByClass: PropTypes.array,
     filterByClass: PropTypes.func.isRequired,
     fetchMemberStatus: PropTypes.func.isRequired,
     userIsMember: PropTypes.bool.isRequired,
@@ -193,6 +194,7 @@ export class DictionaryConcepts extends Component {
       filteredSources,
       loading,
       userIsMember,
+      filteredByClass,
     } = this.props;
 
     const myConcepts = this.handleConcepts(concepts);
@@ -230,6 +232,7 @@ export class DictionaryConcepts extends Component {
             filteredClass={filteredClass}
             filteredSources={filteredSources}
             handleChange={this.handleSearch}
+            toggleCheck={filteredByClass}
           />
           <div className="col-12 col-md-10 custom-full-width">
             <ConceptTable
@@ -253,10 +256,15 @@ export class DictionaryConcepts extends Component {
   }
 }
 
+DictionaryConcepts.defaultProps = {
+  filteredByClass: [],
+};
+
 export const mapStateToProps = state => ({
   concepts: state.concepts.dictionaryConcepts,
   totalConceptCount: state.concepts.totalConceptCount,
   filteredClass: state.concepts.filteredClass,
+  filteredByClass: state.concepts.filteredByClass,
   filteredSources: state.concepts.filteredSources,
   loading: state.concepts.loading,
   filteredList: state.concepts.filteredList,


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make checkbox on concepts page checked after concept edit](https://issues.openmrs.org/browse/OCLOMRS-399)

# Summary:
Edit concept after filter does not indicate the filtered class when returning to the page from the edit concept page

