### PR TITLE
OCLOMRS-412: Make Datatypes and Classes sidebar filters work as expected

### DIFF
--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -78,10 +78,12 @@ export class BulkConceptsPage extends Component {
     } = event;
     const targetName = name.split(',');
     const query = `q=${this.state.searchInput}`;
+    this.setState({ searchingOn: true });
+    const { currentPage } = this.props;
     if ((targetName[1]).trim() === 'datatype') {
-      this.props.addToFilterList(targetName[0], 'datatype', query);
+      this.props.addToFilterList(targetName[0], 'datatype', query, currentPage);
     } else {
-      this.props.addToFilterList(targetName[0], 'classes', query);
+      this.props.addToFilterList(targetName[0], 'classes', query, currentPage);
     }
   };
 

--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -56,13 +56,13 @@ export const fetchFilteredConcepts = (source = 'CIEL', query = '', currentPage) 
   }
 };
 
-export const addToFilterList = (item, type, query) => (dispatch) => {
+export const addToFilterList = (item, type, query, currentPage) => (dispatch) => {
   if (type === 'datatype') {
     dispatch(isSuccess(item, ADD_TO_DATATYPE_LIST));
-    return dispatch(fetchFilteredConcepts('CIEL', query));
+    return dispatch(fetchFilteredConcepts('CIEL', query, currentPage));
   }
   dispatch(isSuccess(item, ADD_TO_CLASS_LIST));
-  return dispatch(fetchFilteredConcepts('CIEL', query));
+  return dispatch(fetchFilteredConcepts('CIEL', query, currentPage));
 };
 
 export const previewConcept = id => (dispatch, getState) => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make Datatypes and Classes sidebar filters work as expected](https://issues.openmrs.org/browse/OCLOMRS-412)

# Summary:
On Add CIEL concepts page when one tries to filter the results with Datatypes and Classes sidebar filters, nothing happens and an error is displayed.
