### PR TITLE
OCLOMRS-410: Enable Partial word searching on dictionary concepts page

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-autobind": "^1.0.6",
     "react-dom": "^16.3.2",
     "react-helmet": "^5.2.0",
+    "react-notifications": "^1.4.3",
     "react-notify-toast": "^0.4.0",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",

--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { NotificationContainer, NotificationManager } from 'react-notifications';
 import SideNav from '../component/Sidenav';
 import SearchBar from '../component/SearchBar';
 import ConceptTable from '../component/ConceptTable';
@@ -14,6 +15,8 @@ import {
   setCurrentPage,
 } from '../../../redux/actions/concepts/addBulkConcepts';
 import { conceptsProps } from '../../dictionaryConcepts/proptypes';
+import { MIN_CHARACTERS_WARNING, MILLISECONDS_TO_SHOW_WARNING } from '../../../redux/reducers/generalSearchReducer';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE } from '../../dictionaryConcepts/components/helperFunction';
 
 export class BulkConceptsPage extends Component {
   static propTypes = {
@@ -105,9 +108,11 @@ export class BulkConceptsPage extends Component {
 
   searchOption = () => {
     const { searchInput } = this.state;
-    const query = `q=${searchInput.trim()}`;
-    const { currentPage, fetchFilteredConcepts: fetchedFilteredConcepts } = this.props;
-    fetchedFilteredConcepts('CIEL', query, currentPage);
+    if (searchInput && searchInput.trim().length > 2) {
+      const query = `q=${searchInput.trim()}*`; // The asterisk permits partial search
+      const { currentPage, fetchFilteredConcepts: fetchedFilteredConcepts } = this.props;
+      fetchedFilteredConcepts(INTERNAL_MAPPING_DEFAULT_SOURCE, query, currentPage);
+    } else NotificationManager.warning(MIN_CHARACTERS_WARNING, '', MILLISECONDS_TO_SHOW_WARNING);
   }
 
   handleSearch = async (event) => {
@@ -166,6 +171,7 @@ export class BulkConceptsPage extends Component {
               handleChange={this.handleChange}
               searchInput={searchInput}
             />
+            <NotificationContainer />
             <ConceptTable
               concepts={concepts}
               loading={loading}

--- a/src/components/dashboard/container/DictionariesDisplay.jsx
+++ b/src/components/dashboard/container/DictionariesDisplay.jsx
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import autoBind from 'react-autobind';
 import propTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { NotificationContainer, NotificationManager } from 'react-notifications';
 import {
   fetchDictionaries,
   searchDictionaries,
@@ -11,6 +12,7 @@ import ListDictionaries from '../components/dictionary/ListDictionaries';
 import SearchDictionaries from '../components/dictionary/DictionariesSearch';
 import Paginations from '../components/DictionariesPaginations';
 import Title from '../../Title';
+import { MIN_CHARACTERS_WARNING, MILLISECONDS_TO_SHOW_WARNING } from '../../../redux/reducers/generalSearchReducer';
 
 export class DictionaryDisplay extends Component {
   static propTypes = {
@@ -40,10 +42,13 @@ export class DictionaryDisplay extends Component {
     this.props.fetchDictionaries();
   }
 
-  onSubmit(event) {
+  onSubmit = (event) => {
     event.preventDefault();
     this.props.clearDictionaries();
-    this.props.searchDictionaries(this.state.searchInput);
+    const { searchInput } = this.state;
+    if (searchInput && searchInput.trim().length > 2) {
+      this.props.searchDictionaries(`${searchInput}*`); // asterisk added to allow partial search
+    } else NotificationManager.warning(MIN_CHARACTERS_WARNING, '', MILLISECONDS_TO_SHOW_WARNING);
   }
 
   onSearch(event) {
@@ -91,6 +96,7 @@ export class DictionaryDisplay extends Component {
               searchValue={searchInput}
               fetching={isFetching}
             />
+            <NotificationContainer />
           </div>
         </div>
         <Paginations

--- a/src/components/dashboard/container/OwnerDictionary.jsx
+++ b/src/components/dashboard/container/OwnerDictionary.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { NotificationContainer, NotificationManager } from 'react-notifications';
 import autoBind from 'react-autobind';
 import propTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -12,6 +13,7 @@ import SearchDictionaries from '../components/dictionary/DictionariesSearch';
 import UserDashboard from '../components/dictionary/user/UserDashboard';
 import AddDictionary from '../components/dictionary/AddDictionary';
 import Title from '../../Title';
+import { MIN_CHARACTERS_WARNING, MILLISECONDS_TO_SHOW_WARNING } from '../../../redux/reducers/generalSearchReducer';
 
 export class OwnerDictionary extends Component {
   static propTypes = {
@@ -61,10 +63,13 @@ export class OwnerDictionary extends Component {
     this.props.fetchDictionaries();
   }
 
-  onSubmit(event) {
+  onSubmit = (event) => {
     event.preventDefault();
     this.props.clearDictionaries();
-    this.props.searchDictionaries(this.state.searchInput);
+    const { searchInput } = this.state;
+    if (searchInput && searchInput.trim().length > 2) {
+      this.props.searchDictionaries(`${searchInput}*`); // asterisk added to allow partial search
+    } else NotificationManager.warning(MIN_CHARACTERS_WARNING, '', MILLISECONDS_TO_SHOW_WARNING);
   }
 
   onSearch(event) {
@@ -102,6 +107,7 @@ export class OwnerDictionary extends Component {
             searchValue={searchInput}
             fetching={isFetching}
           />
+          <NotificationContainer />
           <div className="row justify-content-center">
             <div className="offset-sm-1 col-10">
               <OwnerListDictionaries

--- a/src/redux/reducers/generalSearchReducer.js
+++ b/src/redux/reducers/generalSearchReducer.js
@@ -1,5 +1,8 @@
 import { SEARCH_RESULTS, IS_FETCHING } from '../actions/types';
 
+export const MIN_CHARACTERS_WARNING = 'Search query must contain at least 3 characters';
+export const MILLISECONDS_TO_SHOW_WARNING = 4000;
+
 const initialState = { dictionaries: [], loading: false };
 
 export default (state = initialState, action) => {

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -38,7 +38,7 @@ import {
   createVersion,
   editMapping,
 } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
-import dictionaries from '../../__mocks__/dictionaries';
+import dictionaries, { sampleDictionaries } from '../../__mocks__/dictionaries';
 import versions, { HeadVersion } from '../../__mocks__/versions';
 import concepts from '../../__mocks__/concepts';
 
@@ -266,13 +266,13 @@ describe('Test suite for dictionary actions', () => {
       const request = moxios.requests.mostRecent();
       request.respondWith({
         status: 200,
-        response: [dictionaries],
+        response: sampleDictionaries,
       });
     });
 
     const expectedActions = [
       { type: IS_FETCHING, payload: true },
-      { type: FETCHING_DICTIONARIES, payload: [dictionaries] },
+      { type: FETCHING_DICTIONARIES, payload: sampleDictionaries },
       { type: IS_FETCHING, payload: false },
     ];
 

--- a/src/tests/Dashboard/container/DictionaryDisplay.test.jsx
+++ b/src/tests/Dashboard/container/DictionaryDisplay.test.jsx
@@ -104,28 +104,38 @@ describe('DictionaryDisplay', () => {
     expect(mapStateToProps(initialState).isFetching).toEqual(false);
   });
   it('should search for a dictionary', () => {
+    const searchDictionaries = jest.fn();
+    const clearDictionaries = jest.fn();
     const props = {
       fetchDictionaries: jest.fn(),
       dictionaries: [],
       isFetching: true,
-      clearDictionaries: jest.fn(),
-      searchDictionaries: jest.fn(),
+      clearDictionaries,
+      searchDictionaries,
       onSearch: jest.fn(),
       onSubmit: jest.fn(),
       organizations: [organizations],
       history: { push: jest.fn() },
-      searchValue: '',
     };
-    const wrapper = mount(<MemoryRouter>
-      <DictionaryDisplay {...props} />
-    </MemoryRouter>);
+    const wrapper = mount(<DictionaryDisplay {...props} />);
     const event = { target: { name: 'searchInput', value: 'openmrs' } };
     const event2 = { target: { name: 'searchInput', value: '', type: 'checkbox' } };
     wrapper.find('#search').simulate('change', event);
     wrapper.find('#search').simulate('change', event2);
-    wrapper.find('#submit-search-form').simulate('submit', {
-      preventDefault: () => {},
+    const onSubmitEvent = { preventDefault: jest.fn() };
+    wrapper.setState({ searchInput: 'ka' }, () => {
+      wrapper.update();
+      wrapper.find('#submit-search-form').simulate('submit', onSubmitEvent);
+      expect(clearDictionaries).toHaveBeenCalled();
     });
+    wrapper.setState({ searchInput: 'test' }, () => {
+      wrapper.update();
+      wrapper.find('#submit-search-form').simulate('submit', onSubmitEvent);
+      expect(searchDictionaries).toHaveBeenCalled();
+    });
+    // test wheather an asterisk (*) is automatically added to the search query
+    expect(wrapper.state().searchInput).toEqual('test');
+    expect(searchDictionaries).toHaveBeenCalledWith(`${wrapper.state().searchInput}*`);
   });
   it('should render the Dictionary search component', () => {
     const properties = {

--- a/src/tests/Dashboard/container/OwnerDisplay.test.jsx
+++ b/src/tests/Dashboard/container/OwnerDisplay.test.jsx
@@ -162,19 +162,19 @@ describe('DictionaryDisplay', () => {
         <OwnerDictionary />
       </MemoryRouter>
     </Provider>);
-    const event = { target: { name: 'searchInput', value: 'openmrs' } };
+    const event = { target: { name: 'searchInput', value: 'k' } };
     const event2 = { target: { name: 'searchInput', value: '', type: 'checkbox' } };
     wrapper.find('#search').simulate('change', event);
     wrapper.find('#search').simulate('change', event2);
     const spy = jest.spyOn(wrapper.find('OwnerDictionary').instance(), 'onSubmit');
-    wrapper.find('#search').simulate('change', event);
     wrapper
       .find('OwnerDictionary')
       .instance()
       .forceUpdate();
-    wrapper.find('#submit-search-form').simulate('submit', {
-      preventDefault: () => {},
-    });
+    wrapper.find('#submit-search-form').simulate('submit', { preventDefault: jest.fn() });
+    const event3 = { target: { name: 'searchInput', value: 'test' } };
+    wrapper.find('#search').simulate('change', event3);
+    wrapper.find('#submit-search-form').simulate('submit', { preventDefault: jest.fn() });
     expect(spy).toHaveBeenCalled();
   });
   it('should render the Dictionary search component', () => {

--- a/src/tests/GeneralSearch/Reducers/generalSearchReducer.test.jsx
+++ b/src/tests/GeneralSearch/Reducers/generalSearchReducer.test.jsx
@@ -2,7 +2,10 @@ import reducer from '../../../redux/reducers/generalSearchReducer';
 import { SEARCH_RESULTS, IS_FETCHING } from '../../../redux/actions/types';
 import dictionaries from '../../__mocks__/dictionaries';
 
-const initialState = { dictionaries: [], loading: false };
+const initialState = {
+  dictionaries: [],
+  loading: false,
+};
 describe('Test suite for search result', () => {
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual(initialState);

--- a/src/tests/__mocks__/dictionaries.js
+++ b/src/tests/__mocks__/dictionaries.js
@@ -46,4 +46,22 @@ export const mockDictionaries = (() => {
   return dictionaries;
 })();
 
+export const sampleDictionaries = [
+  dictionary,
+  {
+    ...dictionary,
+    uuid: '8883946bc38fb30049835888',
+    id: 'main1',
+    short_code: 'main1',
+    name: 'Main Dictionary 1',
+  },
+  {
+    ...dictionary,
+    uuid: '1113946bc38fb30049835111',
+    id: 'main2',
+    short_code: 'main2',
+    name: 'Main Dictionary 2',
+  },
+];
+
 export default dictionary;

--- a/src/tests/bulkConcepts/components/ActionButtons.test.js
+++ b/src/tests/bulkConcepts/components/ActionButtons.test.js
@@ -18,6 +18,7 @@ describe('Test suite for ActionButton in BulkConceptsPage component', () => {
         display_name: '',
       },
       addConcept: jest.fn(),
+      url: '',
     };
 
     const wrapper = shallow(<ActionButtons {...props} />);

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -75,7 +75,6 @@ describe('Test suite for BulkConceptsPage component', () => {
       fetchFilteredConcepts: jest.fn(),
       addConcept: jest.fn(),
       previewConcept: jest.fn(),
-
     };
     const wrapper = mount(<Provider store={store}>
       <Router>
@@ -418,6 +417,10 @@ describe('Test suite for BulkConceptsPage component', () => {
 
     const clearForm = { target: { name: 'searchInput', value: '' } };
     wrapper.find('#search-concept').simulate('change', clearForm);
+
+    const typeWordInSearchField = { target: { name: 'searchInput', value: 'sample' } };
+    wrapper.find('#search-concept').simulate('change', typeWordInSearchField);
+    expect(wrapper.find('BulkConceptsPage').state().searchInput).toEqual('sample');
   });
 
   it('should filter search result', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Enable Partial word searching on dictionary concepts page](https://issues.openmrs.org/browse/OCLOMRS-410)

# Summary:
Enable users to search for concepts by entering one or more letters as opposed to complete words only.