### PR TITLE
 OCLOMRS-419: Fix search error with search on Add CIEL Concepts page.

### DIFF
--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -95,7 +95,8 @@ export class BulkConceptsPage extends Component {
       target: { value },
     } = event;
     if (!value) {
-      this.getBulkConcepts();
+      const { fetchBulkConcepts: bulkConceptsFetched } = this.props;
+      bulkConceptsFetched(1);
     }
     this.setState(() => ({ searchInput: value }));
   };
@@ -108,11 +109,10 @@ export class BulkConceptsPage extends Component {
   }
 
   handleSearch = (event) => {
-    event.preventDefault();
     const { setCurrentPage: settingCurrentPage } = this.props;
+    event.preventDefault();
     settingCurrentPage(1);
-    this.setState({ searchingOn: true });
-    this.searchOption();
+    this.setState({ searchingOn: true }, () => this.searchOption());
   };
 
   handleNextPage = (e) => {

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -341,6 +341,7 @@ describe('Test suite for BulkConceptsPage component', () => {
       searchingOn: true,
       fetchBulkConcepts: jest.fn(),
       getBulkConcepts: jest.fn(),
+      bulkConceptsFetched: jest.fn(),
       concepts: [],
       loading: true,
       datatypes: [],
@@ -367,7 +368,7 @@ describe('Test suite for BulkConceptsPage component', () => {
       </Provider>
     </Router>);
     const Wrapper = wrapper.find('BulkConceptsPage').instance();
-    const spy = jest.spyOn(Wrapper, 'getBulkConcepts');
+    const spy = jest.spyOn(Wrapper.props, 'fetchBulkConcepts');
     Wrapper.forceUpdate();
     wrapper.update();
     const event = { target: { name: 'searchInput', value: '' } };


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix search error with search on Add CIEL Concepts page](https://issues.openmrs.org/browse/OCLOMRS-419)

# Summary:
Fix the error message that displays while searching

Steps to reproduce

1) Go to  add CIEL concepts page and search for a concept (example blood) with many occurrences

2) Click on the pagination arrow to get to the next page.

3) Search for another concept that has a very little occurrence

4) You will notice the page throws an error
