### PR TITLE
OCLOMRS-413: Modify concept preview modal to show synonyms of concept name

### DIFF
--- a/src/components/bulkConcepts/component/PreviewCard.jsx
+++ b/src/components/bulkConcepts/component/PreviewCard.jsx
@@ -20,6 +20,7 @@ const PreviewCard = ({
     created_on,
     concept_class,
     datatype,
+    names,
   } = concept;
 
   const DATE_OPTIONS = {
@@ -33,6 +34,7 @@ const PreviewCard = ({
 
   const mapping = mappings || 'none';
   const description = descriptions ? descriptions[0].description : 'none';
+  const synonyms = names && names.map(name => name.name).join();
   return (
     <div className="col-9">
       <Modal isOpen={open} className="modal-lg">
@@ -61,6 +63,7 @@ const PreviewCard = ({
             </small>
           </p>
           <div className="pop-up-description rounded">{display_name}</div>
+          <CardBody title="Synonyms" body={synonyms} />
           <CardBody title="Description" body={description} />
           <div className="row preview-row">
             <div><CardBody title="Class" body={concept_class} /></div>

--- a/src/tests/bulkConcepts/components/PreviewCard.test.js
+++ b/src/tests/bulkConcepts/components/PreviewCard.test.js
@@ -16,6 +16,7 @@ describe('Test suite for ActionButton in BulkConceptsPage component', () => {
       display_locale: 'en',
       concept_class: 'diagnosis',
       datatype: 'coded',
+      names: [{ name: 'TEST SYNONYM' }, { name: 'TEST SYNONYM' }],
     },
   };
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[Modify concept preview modal to show synonyms of concept name](https://issues.openmrs.org/browse/OCLOMRS-413)

# Summary:
A synonym is any valid, alternative name for the concept. This includes acronyms, abbreviations, and other names that reference the primary name. The preview concept card should show the concept's synonym as well.
