### PR TITLE
OCLOMRS-420: fix buffering of add concept on Add CIEL Concepts page

### DIFF
--- a/src/components/bulkConcepts/component/ActionButtons.jsx
+++ b/src/components/bulkConcepts/component/ActionButtons.jsx
@@ -7,6 +7,8 @@ export class ActionButtons extends Component {
   static propTypes = {
     previewConcept: PropTypes.func.isRequired,
     id: PropTypes.string.isRequired,
+    display_name: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
     params: PropTypes.shape({
       type: PropTypes.string,
       typeName: PropTypes.string,
@@ -59,6 +61,7 @@ export class ActionButtons extends Component {
 
   render() {
     const { disableButton } = this.state;
+    const { id, url, display_name } = this.props;
     return (
       <React.Fragment>
         <button
@@ -66,9 +69,9 @@ export class ActionButtons extends Component {
           className="btn btn-sm mb-1 actionaButtons"
           id="add-button"
           onClick={() => this.addConceptButton(
-            this.props.id,
-            this.props.preview.url,
-            this.props.preview.display_name,
+            id,
+            url,
+            display_name,
           )
           }
           disabled={disableButton}

--- a/src/tests/bulkConcepts/components/ActionButtons.test.js
+++ b/src/tests/bulkConcepts/components/ActionButtons.test.js
@@ -7,6 +7,7 @@ describe('Test suite for ActionButton in BulkConceptsPage component', () => {
     const props = {
       previewConcept: jest.fn(),
       id: '',
+      display_name: '',
       params: {
         type: '',
         typeName: '',


### PR DESCRIPTION
# JIRA TICKET NAME:
[fix buffering of add concept on Add CIEL Concepts page](https://issues.openmrs.org/browse/OCLOMRS-420)

# Summary:
When adding an existing CIEL concept:

- When one clicks the `add concept` button
  *The button is disabled but the concept is not added
- Then when one clicks on another concept to add it.
 *The previous concept is added but the current concept is not added.
- Also when you click the button to add another concept
 *Again the previous concept is added but the current concept is not added.