### PR TITLE
OCLOMRS-429: Fix the error that displays while searching on add CIEL Concepts page

### DIFF
--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -108,10 +108,10 @@ export class BulkConceptsPage extends Component {
     fetchedFilteredConcepts('CIEL', query, currentPage);
   }
 
-  handleSearch = (event) => {
+  handleSearch = async (event) => {
     const { setCurrentPage: settingCurrentPage } = this.props;
     event.preventDefault();
-    settingCurrentPage(1);
+    await settingCurrentPage(1);
     this.setState({ searchingOn: true }, () => this.searchOption());
   };
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix the error that displays while searching on add CIEL Concepts page](https://issues.openmrs.org/browse/OCLOMRS-429)

# Summary:
Fix the error message that displays while searching

Steps to reproduce

1) Go to  add CIEL concepts page and search for a concept (example blood) with many occurrences

2) Click on the pagination arrow to get to the next page.

3) Search for another concept that has a very little occurrence

4) You will notice the page throws an error