### PR TITLE
OCLOMRS-430: Make checkboxes appear as checked when they are checked under sources on the sidebar found on dictionary concepts page

### DIFF
--- a/src/components/dictionaryConcepts/components/Sidenav.jsx
+++ b/src/components/dictionaryConcepts/components/Sidenav.jsx
@@ -11,7 +11,13 @@ const Sidenav = ({
         <h6 className="sidenav-header">Sources</h6>
       </div>
       {filteredSources.map(source => (
-        <SideNavItem item={source} key={source} filterType="source" handleChange={handleChange} />
+        <SideNavItem
+          item={source}
+          key={source}
+          filterType="source"
+          handleChange={handleChange}
+          checkValue={toggleCheck.includes(`${source}`)}
+        />
       ))}
       <div className="row mt-3">
         <h6 className="sidenav-header">Class</h6>

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -37,6 +37,7 @@ export class DictionaryConcepts extends Component {
     loading: PropTypes.bool.isRequired,
     filterBySource: PropTypes.func.isRequired,
     filteredByClass: PropTypes.array,
+    filteredBySource: PropTypes.array,
     filterByClass: PropTypes.func.isRequired,
     fetchMemberStatus: PropTypes.func.isRequired,
     userIsMember: PropTypes.bool.isRequired,
@@ -195,6 +196,7 @@ export class DictionaryConcepts extends Component {
       loading,
       userIsMember,
       filteredByClass,
+      filteredBySource,
     } = this.props;
 
     const myConcepts = this.handleConcepts(concepts);
@@ -208,6 +210,8 @@ export class DictionaryConcepts extends Component {
       openDeleteModal,
     } = this.state;
     localStorage.setItem('dictionaryPathName', pathname);
+
+    const filters = [...filteredByClass, ...filteredBySource];
     return (
       <div className="container-fluid custom-dictionary-concepts custom-max-width">
         <Header locationPath={this.props.match.params} />
@@ -232,7 +236,7 @@ export class DictionaryConcepts extends Component {
             filteredClass={filteredClass}
             filteredSources={filteredSources}
             handleChange={this.handleSearch}
-            toggleCheck={filteredByClass}
+            toggleCheck={filters}
           />
           <div className="col-12 col-md-10 custom-full-width">
             <ConceptTable
@@ -258,6 +262,7 @@ export class DictionaryConcepts extends Component {
 
 DictionaryConcepts.defaultProps = {
   filteredByClass: [],
+  filteredBySource: [],
 };
 
 export const mapStateToProps = state => ({
@@ -265,6 +270,7 @@ export const mapStateToProps = state => ({
   totalConceptCount: state.concepts.totalConceptCount,
   filteredClass: state.concepts.filteredClass,
   filteredByClass: state.concepts.filteredByClass,
+  filteredBySource: state.concepts.filteredBySource,
   filteredSources: state.concepts.filteredSources,
   loading: state.concepts.loading,
   filteredList: state.concepts.filteredList,


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make checkboxes appear as checked when they are checked under sources on the sidebar found on dictionary concepts page](https://issues.openmrs.org/browse/OCLOMRS-430)

# Summary:
Currenly, when you filter dictionary concepts by sources for example CIEL, CIEL concepts will be returned but the checkbox will remain unchecked.