### PR TITLE
OCLOMRS-426: remove autogenerated value from Code field when adding mappings

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateMapping.jsx
+++ b/src/components/dictionaryConcepts/components/CreateMapping.jsx
@@ -55,7 +55,7 @@ class CreateMapping extends Component {
                   tabIndex={index}
                   defaultValue={to_concept_code}
                   className="form-control"
-                  placeholder="to_concept_code"
+                  placeholder="To concept code"
                   type="text"
                   name="to_concept_code"
                   id="to_concept_code"
@@ -82,7 +82,7 @@ class CreateMapping extends Component {
               tabIndex={index}
               defaultValue={to_concept_name}
               className="form-control"
-              placeholder="concept name (optional)"
+              placeholder="Concept name (optional)"
               type="text"
               name="to_concept_name"
               onChange={updateEventListener}

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -16,7 +16,6 @@ import {
   addSelectedAnswersToState,
   changeSelectedAnswer,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
-import { INTERNAL_MAPPING_DEFAULT_SOURCE } from '../components/helperFunction';
 
 export class CreateConcept extends Component {
   static propTypes = {
@@ -255,9 +254,6 @@ export class CreateConcept extends Component {
     const { tabIndex, name, value } = event.target;
     const { mappings } = this.state;
     mappings[tabIndex][name] = value;
-    if (name !== INTERNAL_MAPPING_DEFAULT_SOURCE && mappings[tabIndex].to_concept_code === null) {
-      mappings[tabIndex].to_concept_code = String(uuid());
-    }
     this.setState(mappings);
   }
 

--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import autoBind from 'react-autobind';
 import { notify } from 'react-notify-toast';
 import PropTypes from 'prop-types';
-import uid from 'uuid/v4';
 import CreateConceptForm from '../components/CreateConceptForm';
 import {
   createNewName,
@@ -217,9 +216,6 @@ export class EditConcept extends Component {
     const { tabIndex, name, value } = event.target;
     const { mappings } = this.state;
     mappings[tabIndex][name] = value;
-    if (name !== INTERNAL_MAPPING_DEFAULT_SOURCE && mappings[tabIndex].to_concept_code === null) {
-      mappings[tabIndex].to_concept_code = String(uid());
-    }
     this.setState(mappings);
   }
 

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -267,8 +267,8 @@ describe('Test suite for mappings on existing concepts', () => {
     const event = {
       target: {
         tabIndex: 0,
-        name: 'to_concept_name',
-        value: 'malaria',
+        name: 'to_concept_code',
+        value: 'a234',
       },
     };
     const instance = wrapper.find('EditConcept').instance();


### PR DESCRIPTION
# JIRA TICKET NAME:
[remove autogenerated value from Code field when adding mappings](https://issues.openmrs.org/browse/OCLOMRS-426)

# Summary:
Remove auto-generated code for to concept code when adding an external mapping
- A user should be able to add an already existing to concept code.