### PR TITLE
OCLOMRS-424: Make source field autocomplete, with list of existing sources when adding mapping to concept

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-autobind": "^1.0.6",
+    "react-autocomplete-input": "^1.0.9",
     "react-dom": "^16.3.2",
     "react-helmet": "^5.2.0",
     "react-notifications": "^1.4.3",

--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -11,7 +11,7 @@ const CreateConceptForm = (props) => {
   const {
     concept, handleAsyncSelectChange, queryAnswers, selectedAnswers, handleAnswerChange,
     mappings, addMappingRow, updateEventListener, removeMappingRow, updateAsyncSelectValue,
-    isEditConcept,
+    isEditConcept, allSources, updateAutoCompleteListener,
   } = props;
   return (
     <form className="form-wrapper" onSubmit={props.handleSubmit} id="createConceptForm">
@@ -200,7 +200,6 @@ const CreateConceptForm = (props) => {
                   </tr>
                 </thead>
                 <tbody>
-
                   {mappings.map((mapping, i) => (
                     <CreateMapping
                       source={mapping.source}
@@ -208,12 +207,14 @@ const CreateConceptForm = (props) => {
                       to_concept_code={mapping.to_concept_code}
                       to_concept_name={mapping.to_concept_name}
                       updateEventListener={updateEventListener}
+                      updateAutoCompleteListener={updateAutoCompleteListener}
                       removeMappingRow={removeMappingRow}
                       updateAsyncSelectValue={updateAsyncSelectValue}
                       key={mapping.id}
                       index={i}
                       isEditConcept={isEditConcept}
                       isNew={mapping.isNew}
+                      allSources={allSources}
                     />
                   ))}
                 </tbody>
@@ -270,6 +271,8 @@ CreateConceptForm.propTypes = {
   updateEventListener: PropTypes.func,
   removeMappingRow: PropTypes.func,
   updateAsyncSelectValue: PropTypes.func,
+  allSources: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  updateAutoCompleteListener: PropTypes.func,
 };
 
 CreateConceptForm.defaultProps = {
@@ -285,6 +288,7 @@ CreateConceptForm.defaultProps = {
   updateEventListener: null,
   removeMappingRow: null,
   updateAsyncSelectValue: null,
+  updateAutoCompleteListener: null,
 };
 
 export default CreateConceptForm;

--- a/src/components/dictionaryConcepts/components/CreateMapping.jsx
+++ b/src/components/dictionaryConcepts/components/CreateMapping.jsx
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import AsyncSelect from 'react-select/lib/Async';
 import PropTypes from 'prop-types';
+import TextInput from 'react-autocomplete-input';
+import 'react-autocomplete-input/dist/bundle.css';
 import { fetchSourceConcepts } from '../../../redux/actions/concepts/dictionaryConcepts';
 import { INTERNAL_MAPPING_DEFAULT_SOURCE } from './helperFunction';
 import MapType from './MapType';
@@ -23,21 +25,42 @@ class CreateMapping extends Component {
     const {
       map_type, source, to_concept_code, to_concept_name, index,
       updateEventListener, removeMappingRow, updateAsyncSelectValue,
-      isNew,
+      isNew, updateAutoCompleteListener, allSources,
     } = this.props;
+    const mappingSources = allSources.map(src => src.name);
+    const customEvent = {
+      target: {
+        tabIndex: index,
+        name: 'source',
+        value: '',
+      },
+    };
+    let matchingSrc;
+    if (source) {
+      matchingSrc = allSources.filter(
+        src => src.url.trim().toUpperCase() === source.trim().toUpperCase(),
+      );
+    }
+
     return (
       <tr>
         <td>
-          {!isNew && source}
+          {!isNew && (matchingSrc && matchingSrc.length > 0 ? matchingSrc[0].name : source)}
           {
-            isNew && <input
+            isNew && <TextInput
+              id="source"
               tabIndex={index}
               className="form-control"
               placeholder="source"
               type="text"
               name="source"
-              onChange={updateEventListener}
-              defaultValue={source}
+              onChange={(event) => { updateAutoCompleteListener(event, customEvent); }}
+              trigger=""
+              regex="^[a-zA-Z0-9_\-/]+$"
+              matchAny
+              maxOptions={10}
+              options={mappingSources}
+              defaultValue={source || ''}
             />
         }
         </td>
@@ -116,6 +139,8 @@ CreateMapping.propTypes = {
   removeMappingRow: PropTypes.func,
   updateAsyncSelectValue: PropTypes.func,
   isNew: PropTypes.bool,
+  allSources: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  updateAutoCompleteListener: PropTypes.func.isRequired,
 };
 
 CreateMapping.defaultProps = {

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -516,3 +516,12 @@ export const nullConceptDescription = {
     '/orgs/OCL/sources/NameTypes/concepts/None/5821828444273a000717d00b/',
   url: '/orgs/OCL/sources/NameTypes/concepts/None/',
 };
+
+export const mockSource = {
+  short_code: 'HSTP-Indicators',
+  name: 'HSTP-Indicators',
+  url: '/orgs/EthiopiaMoH-test-zisasg/sources/HSTP-Indicators/',
+  owner: 'EthiopiaMoH-test-zisasg',
+  owner_type: 'Organization',
+  owner_url: '/orgs/EthiopiaMoH-test-zisasg/',
+};

--- a/src/tests/dictionaryConcepts/components/CreateConceptForm.test.jsx
+++ b/src/tests/dictionaryConcepts/components/CreateConceptForm.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import CreateConceptForm from '../../../components/dictionaryConcepts/components/CreateConceptForm';
+import { mockSource } from '../../__mocks__/concepts';
 
 describe('Test suite for CreateConceptForm', () => {
   it('should render CreateConceptForm Component', () => {
@@ -27,6 +28,7 @@ describe('Test suite for CreateConceptForm', () => {
         },
       },
       concept: '',
+      allSources: [mockSource],
     };
     const wrapper = shallow(<CreateConceptForm {...props} />);
     expect(wrapper).toMatchSnapshot();
@@ -50,6 +52,7 @@ describe('Test suite for CreateConceptForm', () => {
       addAnswer: jest.fn(),
       answer: [],
       disableButton: false,
+      allSources: [mockSource],
     };
     const wrapper = shallow(<CreateConceptForm {...props} />);
     expect(wrapper.find('select.set')).toHaveLength(1);
@@ -74,6 +77,7 @@ describe('Test suite for CreateConceptForm', () => {
       addAnswer: jest.fn(),
       answer: [],
       disableButton: false,
+      allSources: [mockSource],
     };
     const wrapper = shallow(<CreateConceptForm {...props} />);
     expect(wrapper.find('select.symptom-finding')).toHaveLength(1);
@@ -99,6 +103,7 @@ describe('Test suite for CreateConceptForm', () => {
       description: [],
       isEditConcept: true,
       disableButton: false,
+      allSources: [mockSource],
     };
     const wrapper = shallow(<CreateConceptForm {...props} />);
     expect(wrapper.find('.form-group.answer')).toHaveLength(1);

--- a/src/tests/dictionaryConcepts/components/CreateMapping.test.js
+++ b/src/tests/dictionaryConcepts/components/CreateMapping.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import Router from 'react-mock-router';
 import CreateMapping from '../../../components/dictionaryConcepts/components/CreateMapping';
 import { INTERNAL_MAPPING_DEFAULT_SOURCE } from '../../../components/dictionaryConcepts/components/helperFunction';
+import { mockSource } from '../../__mocks__/concepts';
 
 describe('Test suite for dictionary concepts components', () => {
   const props = {
@@ -14,12 +15,12 @@ describe('Test suite for dictionary concepts components', () => {
     updateEventListener: jest.fn(),
     removeMappingRow: jest.fn(),
     updateAsyncSelectValue: jest.fn(),
+    updateAutoCompleteListener: jest.fn(),
+    allSources: [mockSource],
   };
 
   let wrapper = mount(<Router>
-    <table>
-      <tbody><CreateMapping {...props} /></tbody>
-    </table>
+    <table><tbody><CreateMapping {...props} /></tbody></table>
   </Router>);
 
   it('should call handleInputChange', () => {
@@ -34,9 +35,7 @@ describe('Test suite for dictionary concepts components', () => {
     };
 
     wrapper = mount(<Router>
-      <table>
-        <tbody><CreateMapping {...newProps} /></tbody>
-      </table>
+      <table><tbody><CreateMapping {...newProps} /></tbody></table>
     </Router>);
 
     const inputField = wrapper.find('CreateMapping');
@@ -61,7 +60,9 @@ describe('Test suite for dictionary concepts components', () => {
       <table><tbody><CreateMapping {...newProps} /></tbody></table>
     </Router>);
     const inputs = wrapper.find('input');
-    expect(inputs).toHaveLength(3);
+    expect(inputs).toHaveLength(2);
+    const customTextInput = wrapper.find('textarea');
+    expect(customTextInput).toHaveLength(1);
   });
 
   it('should render when isNew is true and source equal to CIEL', () => {
@@ -73,7 +74,17 @@ describe('Test suite for dictionary concepts components', () => {
     wrapper = mount(<Router>
       <table><tbody><CreateMapping {...newProps} /></tbody></table>
     </Router>);
+    const inputs = wrapper.find('select');
+    expect(inputs).toHaveLength(1);
   });
-  const inputs = wrapper.find('select');
-  expect(inputs).toHaveLength(1);
+
+  it('should call updateAutoCompleteListener', () => {
+    const newProps = {
+      ...props,
+      isNew: true,
+    };
+    wrapper = mount(<Router><table><tbody><CreateMapping {...newProps} /></tbody></table></Router>);
+    wrapper.find('textarea#source').simulate('change');
+    expect(props.updateAutoCompleteListener).toHaveBeenCalled();
+  });
 });

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -5,7 +5,8 @@ import {
   CreateConcept,
   mapStateToProps,
 } from '../../../components/dictionaryConcepts/containers/CreateConcept';
-import { newConcept } from '../../__mocks__/concepts';
+import { newConcept, mockSource } from '../../__mocks__/concepts';
+import { CIEL_SOURCE_URL } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 jest.mock('uuid/v4', () => jest.fn(() => 1234));
 jest.mock('react-notify-toast');
@@ -53,6 +54,8 @@ describe('Test suite for dictionary concepts components', () => {
     getPossibleAnswers: jest.fn(),
     addSelectedAnswers: jest.fn(),
     changeAnswer: jest.fn(),
+    fetchAllConceptSources: jest.fn(),
+    allSources: [mockSource],
   };
 
   let wrapper;
@@ -91,6 +94,50 @@ describe('Test suite for dictionary concepts components', () => {
     };
     const instance = wrapper.find('CreateConcept').instance();
     instance.updateEventListener(event);
+  });
+
+  it('should call updateEventListener function with internal mapping', () => {
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'to_concept_name',
+        value: CIEL_SOURCE_URL,
+      },
+    };
+    const instance = wrapper.find('CreateConcept').instance();
+    const spy = jest.spyOn(instance, 'updateEventListener');
+    instance.updateEventListener(event);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should call updateAutoCompleteListener function', () => {
+    const value = 'test';
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'source',
+        value,
+      },
+    };
+    const instance = wrapper.find('CreateConcept').instance();
+    const spy = jest.spyOn(instance, 'updateAutoCompleteListener');
+    instance.updateAutoCompleteListener(value, event);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should call updateAutoCompleteListener with existing source', () => {
+    const value = mockSource.name;
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'source',
+        value,
+      },
+    };
+    const instance = wrapper.find('CreateConcept').instance();
+    const spy = jest.spyOn(instance, 'updateAutoCompleteListener');
+    instance.updateAutoCompleteListener(value, event);
+    expect(spy).toHaveBeenCalled();
   });
 
   it('should render without breaking', () => {
@@ -175,6 +222,9 @@ describe('Test suite for dictionary concepts components', () => {
         newName: ['1'],
         description: ['1'],
         newConcept,
+      },
+      sourceConcepts: {
+        conceptSources: [],
       },
     };
     expect(mapStateToProps(initialState).description).toEqual(['1']);

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -6,7 +6,7 @@ import {
   EditConcept,
   mapStateToProps,
 } from '../../../components/dictionaryConcepts/containers/EditConcept';
-import { newConcept, existingConcept } from '../../__mocks__/concepts';
+import { newConcept, existingConcept, mockSource } from '../../__mocks__/concepts';
 import { INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 jest.mock('uuid/v4', () => jest.fn(() => 1234));
@@ -57,6 +57,8 @@ describe('Test suite for dictionary concepts components', () => {
       }],
     },
     newRow: '1234',
+    fetchAllConceptSources: jest.fn(),
+    allSources: [mockSource],
   };
   it('should render without breaking', () => {
     const wrapper = mount(<Router>
@@ -183,6 +185,9 @@ describe('Test suite for dictionary concepts components', () => {
         existingConcept,
         disableButton: false,
       },
+      sourceConcepts: {
+        conceptSources: [],
+      },
     };
     expect(mapStateToProps(initialState).description).toEqual(['1']);
     expect(mapStateToProps(initialState).newConcept).toEqual(newConcept);
@@ -234,6 +239,8 @@ describe('Test suite for mappings on existing concepts', () => {
       }],
     },
     newRow: '1234',
+    fetchAllConceptSources: jest.fn(),
+    allSources: [mockSource],
   };
   const wrapper = mount(<Router>
     <EditConcept {...props} />
@@ -277,6 +284,20 @@ describe('Test suite for mappings on existing concepts', () => {
     expect(instance.state.mappings[0].to_concept_code).not.toEqual(null);
   });
 
+  it('should call updateEventListener function with internal mapping', () => {
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'to_concept_name',
+        value: CIEL_SOURCE_URL,
+      },
+    };
+    const instance = wrapper.find('EditConcept').instance();
+    const spy = jest.spyOn(instance, 'updateEventListener');
+    instance.updateEventListener(event);
+    expect(spy).toHaveBeenCalled();
+  });
+
   it('should test componentWillReceiveProps', () => {
     const newProps = {
       existingConcept: {
@@ -314,5 +335,35 @@ describe('Test suite for mappings on existing concepts', () => {
     instance.componentWillReceiveProps({ existingConcept: { mappings: undefined } });
     instance.componentWillReceiveProps(newProps);
     expect(instance.state.source).toEqual(INTERNAL_MAPPING_DEFAULT_SOURCE);
+  });
+
+  it('should call updateAutoCompleteListener function', () => {
+    const value = 'test';
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'source',
+        value,
+      },
+    };
+    const instance = wrapper.find('EditConcept').instance();
+    const spy = jest.spyOn(instance, 'updateAutoCompleteListener');
+    instance.updateAutoCompleteListener(value, event);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should call updateAutoCompleteListener with existing source', () => {
+    const value = mockSource.name;
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'source',
+        value,
+      },
+    };
+    const instance = wrapper.find('EditConcept').instance();
+    const spy = jest.spyOn(instance, 'updateAutoCompleteListener');
+    instance.updateAutoCompleteListener(value, event);
+    expect(spy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make source field autocomplete, with list of existing sources when adding mapping to concept](https://issues.openmrs.org/browse/OCLOMRS-424)

# Summary:
As the user types a source for any given mapping, the source field should automatically display all matching sources (from the existing list of sources).