### PR TITLE
OCLOMRS-404: make source name case insensitive on mappings

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateMapping.jsx
+++ b/src/components/dictionaryConcepts/components/CreateMapping.jsx
@@ -16,6 +16,8 @@ class CreateMapping extends Component {
     this.setState({ inputValue: value });
   }
 
+  sourceNameToUpperCase = source => source.trim().toUpperCase();
+
   render() {
     const { inputValue } = this.state;
     const {
@@ -47,7 +49,7 @@ class CreateMapping extends Component {
             source={source}
           />}
 
-          {source && source !== INTERNAL_MAPPING_DEFAULT_SOURCE && (
+          {source && this.sourceNameToUpperCase(source) !== INTERNAL_MAPPING_DEFAULT_SOURCE && (
             <div className="row concept-code">
               <div className="col-2"> Code</div>
               <div className="col-10">
@@ -68,11 +70,15 @@ class CreateMapping extends Component {
 
         <td className="react-async">
           {!isNew && to_concept_name}
-          {source === INTERNAL_MAPPING_DEFAULT_SOURCE ? (
+          {source && this.sourceNameToUpperCase(source) === INTERNAL_MAPPING_DEFAULT_SOURCE ? (
             isNew && <AsyncSelect
               cacheOptions
               isClearable
-              loadOptions={async () => fetchSourceConcepts(source, inputValue, index)}
+              loadOptions={async () => fetchSourceConcepts(
+                this.sourceNameToUpperCase(source),
+                inputValue,
+                index,
+              )}
               onChange={updateAsyncSelectValue}
               onInputChange={this.handleInputChange}
               placeholder="search concept name"

--- a/src/tests/bulkConcepts/components/ActionButtons.test.js
+++ b/src/tests/bulkConcepts/components/ActionButtons.test.js
@@ -8,6 +8,7 @@ describe('Test suite for ActionButton in BulkConceptsPage component', () => {
       previewConcept: jest.fn(),
       id: '',
       display_name: '',
+      url: '',
       params: {
         type: '',
         typeName: '',


### PR DESCRIPTION
# JIRA TICKET NAME:
[make source name case insensitive on mappings](https://issues.openmrs.org/browse/OCLOMRS-404)

# Summary:
When a user enters a source, the text field:

- Should be case insensitive, that is, allows both upper and lower case