### PR TITLE
OCLOMRS-432: Add search function on dictionary concepts page

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import ReactTable from 'react-table';
 import 'react-table/react-table.css';
 import ActionButtons from './ActionButtons';
-import Loader from '../../Loader';
 import { conceptsProps } from '../proptypes';
 import { getUsername } from './helperFunction';
 import RemoveConcept from './RemoveConcept';
@@ -23,73 +22,61 @@ const ConceptTable = ({
   openDeleteModal,
   showDeleteMappingModal,
   handleDeleteMapping,
-}) => {
-  if (concepts.length > 0) {
-    return (
-      <div className="row col-12 custom-concept-list">
-        <RemoveConcept
-          collectionName={locationPath.collectionName}
-          conceptOwner={locationPath.typeName}
-          conceptUrl={url}
-          conceptType={locationPath.type}
-          handleDelete={handleDelete}
-          disableButton={loading}
-          openDeleteModal={openDeleteModal}
-          closeDeleteModal={closeDeleteModal}
-        />
-        <ReactTable
-          data={concepts}
-          loading={loading}
-          pageSizeOptions={[5, 10, 20, 25, 50, 100]}
-          defaultPageSize={conceptLimit}
-          noDataText="No concept!"
-          minRows={2}
-          columns={[
-            {
-              Header: 'Name',
-              accessor: 'display_name',
-              minWidth: 100,
-            },
-            {
-              Header: 'Class',
-              accessor: 'concept_class',
-            },
-            {
-              Header: 'Source',
-              accessor: 'source',
-            },
-            {
-              Header: 'Action',
-              width: 350,
-              Cell: ({ original: concept }) => {
-                const props = {
-                  showDeleteModal,
-                  handleDelete,
-                  handleDeleteMapping,
-                  mappingLimit: conceptLimit,
-                  showDeleteMappingModal,
-                };
-                const renderButtons = username === concept.owner || (
-                  concept.owner === org.name && org.userIsMember
-                );
-                return <ActionButtons actionButtons={renderButtons} {...concept} {...props} />;
-              },
-            },
-          ]}
-          className="-striped -highlight custom-table-width"
-        />
-      </div>
-    );
-  }
-  if (!loading && concepts.length <= 0) {
-    return <div>No concepts found</div>;
-  }
-  return (
-    <div className="mt-200 text-center">
-      <Loader />
-    </div>
-  );
-};
+}) => (
+  <div className="row col-12 custom-concept-list">
+    <RemoveConcept
+      collectionName={locationPath.collectionName}
+      conceptOwner={locationPath.typeName}
+      conceptUrl={url}
+      conceptType={locationPath.type}
+      handleDelete={handleDelete}
+      disableButton={loading}
+      openDeleteModal={openDeleteModal}
+      closeDeleteModal={closeDeleteModal}
+    />
+    <ReactTable
+      data={concepts}
+      loading={loading}
+      pageSizeOptions={[5, 10, 20, 25, 50, 100]}
+      defaultPageSize={conceptLimit}
+      noDataText="No concepts found!"
+      minRows={2}
+      columns={[
+        {
+          Header: 'Name',
+          accessor: 'display_name',
+          minWidth: 100,
+        },
+        {
+          Header: 'Class',
+          accessor: 'concept_class',
+        },
+        {
+          Header: 'Source',
+          accessor: 'source',
+        },
+        {
+          Header: 'Action',
+          width: 350,
+          Cell: ({ original: concept }) => {
+            const props = {
+              showDeleteModal,
+              handleDelete,
+              handleDeleteMapping,
+              mappingLimit: conceptLimit,
+              showDeleteMappingModal,
+            };
+            const renderButtons = username === concept.owner || (
+              concept.owner === org.name && org.userIsMember
+            );
+            return <ActionButtons actionButtons={renderButtons} {...concept} {...props} />;
+          },
+        },
+      ]}
+      className="-striped -highlight custom-table-width"
+    />
+  </div>
+);
 
 ConceptTable.propTypes = {
   concepts: PropTypes.arrayOf(PropTypes.shape(conceptsProps)).isRequired,

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -6,10 +6,12 @@ import Header from '../components/Header';
 import ConceptDropdown from '../components/ConceptDropdown';
 import SideNav from '../components/Sidenav';
 import ConceptTable from '../components/ConceptTable';
+import SearchBar from '../../bulkConcepts/component/SearchBar';
 import { conceptsProps } from '../proptypes';
 import { getUsername } from '../components/helperFunction';
 import {
   fetchDictionaryConcepts,
+  fetchConceptsByName,
   filterBySource,
   filterByClass,
   paginateConcepts,
@@ -43,6 +45,7 @@ export class DictionaryConcepts extends Component {
     userIsMember: PropTypes.bool.isRequired,
     removeDictionaryConcept: PropTypes.func.isRequired,
     removeConceptMappingAction: PropTypes.func.isRequired,
+    searchByName: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -182,6 +185,24 @@ export class DictionaryConcepts extends Component {
     return newConcepts;
   }
 
+  handleChange = (event) => {
+    const {
+      target: { value },
+    } = event;
+    this.setState(() => ({ searchInput: value }));
+    if (value.length === 0) {
+      this.fetchConcepts();
+    }
+  };
+
+  handleSearchByName = (event) => {
+    event.preventDefault();
+    const { searchInput } = this.state;
+    const query = `q=${searchInput.trim()}`;
+    const { searchByName } = this.props;
+    searchByName(query);
+  };
+
   render() {
     const {
       match: {
@@ -208,6 +229,7 @@ export class DictionaryConcepts extends Component {
     const {
       conceptLimit,
       openDeleteModal,
+      searchInput,
     } = this.state;
     localStorage.setItem('dictionaryPathName', pathname);
 
@@ -229,7 +251,6 @@ export class DictionaryConcepts extends Component {
           />
           )}
         </section>
-
         <section className="row mt-3">
           <SideNav
             typeName={typeName}
@@ -239,6 +260,11 @@ export class DictionaryConcepts extends Component {
             toggleCheck={filters}
           />
           <div className="col-12 col-md-10 custom-full-width">
+            <SearchBar
+              handleSearch={this.handleSearchByName}
+              handleChange={this.handleChange}
+              searchInput={searchInput}
+            />
             <ConceptTable
               concepts={myConcepts}
               loading={loading}
@@ -282,6 +308,7 @@ export default connect(
   mapStateToProps,
   {
     fetchDictionaryConcepts,
+    searchByName: fetchConceptsByName,
     filterBySource,
     filterByClass,
     paginateConcepts,

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -144,6 +144,23 @@ export const fetchDictionaryConcepts = (
   dispatch(isFetching(false));
 };
 
+export const fetchConceptsByName = query => async (dispatch) => {
+  dispatch(isFetching(true));
+  const CONCEPT_TYPE = localStorage.getItem('type');
+  const USER_TYPE_NAME = localStorage.getItem('typeName');
+  const DICTIONARY_ID = localStorage.getItem('dictionaryId');
+
+  const url = `${CONCEPT_TYPE}/${USER_TYPE_NAME}/collections/${DICTIONARY_ID}/concepts/?includeMappings=true&${query}*&verbose=true`;
+  try {
+    const response = await instance.get(url);
+    dispatch(isSuccess(response.data, FETCH_DICTIONARY_CONCEPT));
+    dispatch(isFetching(false));
+  } catch (error) {
+    dispatch(isFetching(false));
+    notify.show('Something went wrong with your search, please try again.', 'error', 3000);
+  }
+};
+
 export const filterBySource = (
   keyword,
   conceptType,

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -34,6 +34,7 @@ import {
 } from '../../../redux/actions/types';
 import {
   fetchDictionaryConcepts,
+  fetchConceptsByName,
   filterByClass,
   filterBySource,
   createNewName,
@@ -216,6 +217,49 @@ describe('Test suite for dictionary concept actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
+
+  it('should fetch dictionary concepts by name', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: [concepts],
+      });
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_DICTIONARY_CONCEPT, payload: [concepts] },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    const store = mockStore(mockConceptStore);
+
+    return store.dispatch(fetchConceptsByName('search')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should handle the error when search by name fails', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 404,
+      });
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    const store = mockStore(mockConceptStore);
+
+    return store.dispatch(fetchConceptsByName('search')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
 
   it('should handle CREATE_NEW_CONCEPT', () => {
     moxios.wait(() => {

--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -9,6 +9,7 @@ import {
   mapStateToProps,
 } from '../../../components/dictionaryConcepts/containers/DictionaryConcepts';
 import concepts, { concept3 } from '../../__mocks__/concepts';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 const store = createMockStore({
   organizations: {
@@ -47,6 +48,7 @@ describe('Test suite for dictionary concepts components', () => {
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
       removeConceptMappingAction: jest.fn(),
+      searchByName: jest.fn(),
     };
     const wrapper = mount(<Provider store={store}>
       <Router>
@@ -87,6 +89,7 @@ describe('Test suite for dictionary concepts components', () => {
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
       removeConceptMappingAction: jest.fn(),
+      searchByName: jest.fn(),
     };
     const wrapper = mount(<Provider store={store}>
       <Router>
@@ -97,43 +100,6 @@ describe('Test suite for dictionary concepts components', () => {
     jest.runAllTimers();
 
     expect(wrapper).toMatchSnapshot();
-  });
-
-  it('should render a loader', () => {
-    const props = {
-      match: {
-        params: {
-          typeName: 'dev-col',
-          type: 'orgs',
-          collectionName: 'dev-col',
-          dictionaryName: 'dev-col',
-        },
-      },
-      location: {
-        pathname: '/random/path',
-      },
-      fetchDictionaryConcepts: jest.fn(),
-      concepts: [],
-      filteredClass: ['Diagnosis'],
-      filteredSources: ['CIEL'],
-      loading: true,
-      conceptsCount: 1,
-      totalConceptsCount: 1,
-      filterBySource: jest.fn(),
-      filterByClass: jest.fn(),
-      fetchMemberStatus: jest.fn(),
-      paginateConcepts: jest.fn(),
-      totalConceptCount: 20,
-      userIsMember: true,
-      removeDictionaryConcept: jest.fn(),
-      removeConceptMappingAction: jest.fn(),
-    };
-    const wrapper = mount(<Provider store={store}>
-      <Router>
-        <DictionaryConcepts {...props} />
-      </Router>
-    </Provider>);
-    expect(wrapper.find('Loader')).toHaveLength(1);
   });
 
   it('should remove a dictionary concept', () => {
@@ -162,6 +128,7 @@ describe('Test suite for dictionary concepts components', () => {
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
       removeConceptMappingAction: jest.fn(),
+      searchByName: jest.fn(),
     };
 
     const wrapper = mount(<Provider store={store}>
@@ -200,6 +167,7 @@ describe('Test suite for dictionary concepts components', () => {
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
       removeConceptMappingAction: jest.fn(),
+      searchByName: jest.fn(),
     };
     const wrapper = shallow(<DictionaryConcepts {...props} />);
     wrapper.setState({ versionUrl: 'url' });
@@ -238,6 +206,7 @@ describe('Test suite for dictionary concepts components', () => {
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
       removeConceptMappingAction: jest.fn(),
+      searchByName: jest.fn(),
     };
     const wrapper = shallow(<DictionaryConcepts {...props} />);
     wrapper.setState({ data: { references: [props.url] } });
@@ -273,6 +242,7 @@ describe('Test suite for dictionary concepts components', () => {
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
       removeConceptMappingAction: jest.fn(),
+      searchByName: jest.fn(),
     };
     const wrapper = shallow(<DictionaryConcepts {...props} />);
     const instance = wrapper.instance();
@@ -308,6 +278,7 @@ describe('Test suite for dictionary concepts components', () => {
       handleToggle: jest.fn(),
       showDeleteMappingModal: jest.fn(),
       handleDeleteMapping: jest.fn(),
+      searchByName: jest.fn(),
     };
     const wrapper = shallow(<DictionaryConcepts {...props} />);
     const instance = wrapper.instance();
@@ -340,6 +311,7 @@ describe('Test suite for dictionary concepts components', () => {
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
       removeConceptMappingAction: jest.fn(),
+      searchByName: jest.fn(),
     };
     const wrapper = mount(<Provider store={store}>
       <Router>
@@ -390,6 +362,7 @@ describe('Test suite for dictionary concepts components', () => {
       userIsMember: true,
       removeDictionaryConcept: jest.fn(),
       removeConceptMappingAction: jest.fn(),
+      searchByName: jest.fn(),
     };
     const app = shallow(<DictionaryConcepts {...props} />);
     const newProps = {
@@ -429,5 +402,87 @@ describe('Test suite for dictionary concepts components', () => {
     expect(mapStateToProps(initialState).filteredSources).toEqual([]);
     expect(mapStateToProps(initialState).loading).toEqual(false);
     expect(mapStateToProps(initialState).dictionaries).toEqual([]);
+  });
+
+  it('should update the state with search term on change in the search bar', () => {
+    const props = {
+      match: {
+        params: {
+          typeName: 'dev-col',
+          type: 'orgs',
+          collectionName: 'dev-col',
+          dictionaryName: 'dev-col',
+        },
+      },
+      location: {
+        pathname: '/random/path',
+      },
+      fetchDictionaryConcepts: jest.fn(),
+      concepts: [],
+      filteredClass: ['Diagnosis'],
+      filteredSources: [INTERNAL_MAPPING_DEFAULT_SOURCE],
+      loading: false,
+      conceptsCount: 1,
+      totalConceptsCount: 1,
+      filterBySource: jest.fn(),
+      filterByClass: jest.fn(),
+      fetchMemberStatus: jest.fn(),
+      paginateConcepts: jest.fn(),
+      totalConceptCount: 20,
+      userIsMember: true,
+      removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
+      searchByName: jest.fn(),
+    };
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <DictionaryConcepts {...props} />
+      </Router>
+    </Provider>);
+    let event = { target: { name: 'searchInput', value: 'testing' } };
+    wrapper.find('#search-concept').simulate('change', event);
+    expect(wrapper.find('DictionaryConcepts').state().searchInput).toEqual('testing');
+    event = { target: { name: 'searchInput', value: '' } };
+    wrapper.find('#search-concept').simulate('change', event);
+    expect(wrapper.find('DictionaryConcepts').state().searchInput).toEqual('');
+  });
+
+  it('should call the search function when search form is submitted', () => {
+    const props = {
+      match: {
+        params: {
+          typeName: 'dev-col',
+          type: 'orgs',
+          collectionName: 'dev-col',
+          dictionaryName: 'dev-col',
+        },
+      },
+      location: {
+        pathname: '/random/path',
+      },
+      fetchDictionaryConcepts: jest.fn(),
+      concepts: [],
+      filteredClass: ['Diagnosis'],
+      filteredSources: [INTERNAL_MAPPING_DEFAULT_SOURCE],
+      loading: false,
+      conceptsCount: 1,
+      totalConceptsCount: 1,
+      filterBySource: jest.fn(),
+      filterByClass: jest.fn(),
+      fetchMemberStatus: jest.fn(),
+      paginateConcepts: jest.fn(),
+      totalConceptCount: 20,
+      userIsMember: true,
+      removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
+      searchByName: jest.fn(),
+    };
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <DictionaryConcepts {...props} />
+      </Router>
+    </Provider>);
+    wrapper.find('#submit-search-form').simulate('submit');
+    expect(wrapper.find('DictionaryConcepts').props().searchByName).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Add search function on dictionary concepts page](https://issues.openmrs.org/browse/OCLOMRS-432)

# Summary:
Currently, there's no way to search for a concept by name on the dictionary concepts page. This ticket adds a search input on the dictionary concepts page.
