### PR TITLE
OCLOMRS-415: Modify preview of convenient-set concept types to have set members, answers and other items as shown in the mock-ups

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-notifications": "^1.4.3",
     "react-notify-toast": "^0.4.0",
     "react-redux": "^5.0.7",
+    "react-render-html": "^0.6.0",
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.1.4",
     "react-select": "^2.0.0-beta.7",

--- a/src/components/bulkConcepts/component/CardBody.jsx
+++ b/src/components/bulkConcepts/component/CardBody.jsx
@@ -1,20 +1,55 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import renderHTML from 'react-render-html';
 
-const CardBody = ({ title, body }) => (
-  <React.Fragment>
-    <p className="synonyms">{title}</p>
-    <div className="pop-up-description rounded">{body}</div>
-  </React.Fragment>
-);
+class CardBody extends Component {
+  state = {
+    showMore: false,
+  }
+
+  handleClick = () => this.setState({ showMore: true });
+
+  render() {
+    const {
+      title,
+      body,
+      remainingCount,
+      remainingItems,
+    } = this.props;
+
+    return (
+      <React.Fragment>
+        <p className="synonyms">{title}</p>
+        {remainingCount > 0 && !this.state.showMore
+          ? <div className="pop-up-description rounded">
+            {renderHTML(body)}
+            <div className="showOthers" onClick={this.handleClick}>
+            ...and &nbsp;
+              {remainingCount}
+            &nbsp;more
+            </div>
+          </div>
+          : <div className="pop-up-description rounded">
+            {renderHTML(body.concat(remainingItems))}
+          </div>
+        }
+      </React.Fragment>
+    );
+  }
+}
+
 
 CardBody.propTypes = {
   title: PropTypes.string.isRequired,
   body: PropTypes.string,
+  remainingCount: PropTypes.number,
+  remainingItems: PropTypes.string,
 };
 
 CardBody.defaultProps = {
-  body: null,
+  body: '',
+  remainingCount: null,
+  remainingItems: '',
 };
 
 export default CardBody;

--- a/src/components/bulkConcepts/component/PreviewCard.jsx
+++ b/src/components/bulkConcepts/component/PreviewCard.jsx
@@ -5,6 +5,32 @@ import {
 } from 'reactstrap';
 import CardBody from './CardBody';
 import MappingPreview from './MappingPreview';
+import {
+  MAP_TYPE,
+  TRADITIONAL_OCL_BASE_URL,
+} from '../../dictionaryConcepts/components/helperFunction';
+
+const getSetMembers = mappings => (
+  mappings.filter(mapping => mapping.map_type === MAP_TYPE.conceptSet))
+  .map(
+    mapping => `<div>${mapping.to_concept_name}(${mapping.to_concept_code})</div>`,
+  );
+
+const getAnswers = mappings => (
+  mappings.filter(mapping => mapping.map_type === MAP_TYPE.questionAndAnswer))
+  .map(
+    mapping => `<div>${mapping.to_concept_name}(${mapping.to_concept_code})</div>`,
+  );
+
+const getOtherMappings = mappings => (
+  mappings.filter(
+    mapping => (
+      mapping.map_type !== MAP_TYPE.conceptSet)
+      && (mapping.map_type !== MAP_TYPE.questionAndAnswer),
+  )
+);
+
+const NUMBER_OF_ITEMS_TO_DISPLAY = 5;
 
 const PreviewCard = ({
   open, concept, closeModal, addConcept,
@@ -16,60 +42,78 @@ const PreviewCard = ({
     display_locale,
     id,
     url,
-    version,
-    created_on,
     concept_class,
     datatype,
     names,
   } = concept;
 
-  const DATE_OPTIONS = {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-  };
-
   const mapping = mappings || 'none';
   const description = descriptions ? descriptions[0].description : 'none';
-  const synonyms = names && names.map(name => name.name).join();
+  const synonyms = names && names
+    .map(name => `<span className='synonym'>${name.name}</span>`)
+    .filter(name => name !== `<span className='synonym'>${display_name}</span>`)
+    .join(' ');
+  let setMembers;
+  let answers;
+  let otherMappings = mapping;
+  let remainingCount;
+  if (mapping !== 'none') {
+    setMembers = getSetMembers(mapping);
+    answers = getAnswers(mapping);
+    otherMappings = getOtherMappings(mapping);
+  }
+
+  const displaySetMembersOrAnswers = () => {
+    if (setMembers && setMembers.length > 0) {
+      remainingCount = setMembers.length - NUMBER_OF_ITEMS_TO_DISPLAY;
+      return <CardBody
+        remainingCount={remainingCount}
+        title="Set members"
+        body={setMembers.slice(0, NUMBER_OF_ITEMS_TO_DISPLAY).join(' ')}
+        remainingItems={setMembers.slice(NUMBER_OF_ITEMS_TO_DISPLAY).join(' ')}
+      />;
+    }
+    if (answers && answers.length > 0) {
+      remainingCount = answers.length - NUMBER_OF_ITEMS_TO_DISPLAY;
+      return <CardBody
+        remainingCount={remainingCount}
+        title="Answers"
+        body={answers.slice(0, NUMBER_OF_ITEMS_TO_DISPLAY).join(' ')}
+        remainingItems={answers.slice(NUMBER_OF_ITEMS_TO_DISPLAY).join(' ')}
+      />;
+    }
+    return '';
+  };
+
   return (
     <div className="col-9">
       <Modal isOpen={open} className="modal-lg">
         <ModalBody className="preview-modal">
           <h6>
-            {id}
+            {`${display_name}(${id})`}
             <div className="card-version">
               <small>
-                <em>
-                  Version:&nbsp;
-                  {version}
-                </em>
-                <em>
-                  Created on:&nbsp;
-                  {new Date(created_on).toLocaleDateString('en-US', DATE_OPTIONS)}
-                </em>
+                <a href={`${TRADITIONAL_OCL_BASE_URL}${url}`} target="_blank" rel="noopener noreferrer">
+                  <i className="fas fa-external-link-alt" />
+View in traditional OCL
+                </a>
               </small>
             </div>
           </h6>
           <div className="header-divider" />
           <p className="synonyms">
-            Name
-            {''}
             <small>
               <em className="float-right">{display_locale}</em>
             </small>
           </p>
-          <div className="pop-up-description rounded">{display_name}</div>
           <CardBody title="Synonyms" body={synonyms} />
           <CardBody title="Description" body={description} />
           <div className="row preview-row">
             <div><CardBody title="Class" body={concept_class} /></div>
             <div><CardBody title="Data Type" body={datatype} /></div>
           </div>
-          <MappingPreview title="Mappings" body={mapping} />
+          {displaySetMembersOrAnswers()}
+          <MappingPreview title="Mappings" body={otherMappings.length > 0 ? otherMappings : 'none'} />
         </ModalBody>
         <ModalFooter>
           <Button

--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -34,3 +34,10 @@ export const classes = [
 
 export const INTERNAL_MAPPING_DEFAULT_SOURCE = 'CIEL';
 export const CIEL_SOURCE_URL = '/orgs/CIEL/sources/CIEL/';
+
+export const MAP_TYPE = {
+  conceptSet: 'CONCEPT-SET',
+  questionAndAnswer: 'Q-AND-A',
+};
+
+export const TRADITIONAL_OCL_BASE_URL = 'https://qa.openconceptlab.org';

--- a/src/styles/bulk_concepts.scss
+++ b/src/styles/bulk_concepts.scss
@@ -188,10 +188,18 @@
   font-size: .9rem !important;
 }
 
+.synonym {
+  margin-right: 1em;
+}
+
+.showOthers:hover {
+  cursor: pointer;
+}
+
 .card-version{
   display: block;
   float: right;
-  max-width: 18rem;
+  width: 20%;
 }
 
 .card-version small em {

--- a/src/tests/bulkConcepts/components/PreviewCard.test.js
+++ b/src/tests/bulkConcepts/components/PreviewCard.test.js
@@ -48,6 +48,112 @@ describe('Test suite for ActionButton in BulkConceptsPage component', () => {
     expect(wrapper.length).toEqual(1);
   });
 
+  it('should render with mappings containing set members', () => {
+    const newProps = {
+      ...props,
+      concept: {
+        mappings: [
+          {
+            map_type: 'CONCEPT-SET',
+            to_concept_code: '1',
+            to_concept_name: 'LIVER FUNCTION TESTS',
+            source: '',
+          },
+        ],
+        descriptions: [{ description: '' }],
+      },
+    };
+    const wrapper = mount(<Router>
+      <PreviewCard {...newProps} />
+    </Router>);
+    expect(
+      wrapper.find('.synonyms').filterWhere(
+        node => node.text() === 'Set members',
+      ).length,
+    ).toEqual(1);
+  });
+
+  it('should render with mappings containing answers', () => {
+    const newProps = {
+      ...props,
+      concept: {
+        mappings: [
+          {
+            map_type: 'Q-AND-A',
+            to_concept_code: '1',
+            to_concept_name: 'LIVER FUNCTION TESTS',
+            source: '',
+          },
+        ],
+        descriptions: [{ description: '' }],
+      },
+    };
+    const wrapper = mount(<Router>
+      <PreviewCard {...newProps} />
+    </Router>);
+    expect(
+      wrapper.find('.synonyms').filterWhere(
+        node => node.text() === 'Answers',
+      ).length,
+    ).toEqual(1);
+  });
+
+  it('should call handleClick when a link that displays other set members/answers is clicked', () => {
+    const newProps = {
+      ...props,
+      concept: {
+        mappings: [
+          {
+            map_type: 'Q-AND-A',
+            to_concept_code: '1',
+            to_concept_name: 'LIVER FUNCTION TESTS',
+            source: '',
+          },
+          {
+            map_type: 'Q-AND-A',
+            to_concept_code: '1566',
+            to_concept_name: 'RIFAMPICIN/ISONIAZID PROPHYLAXI',
+            source: '',
+          },
+          {
+            map_type: 'Q-AND-A',
+            to_concept_code: '1366',
+            to_concept_name: 'RIFAMPICIN/ISONIAZID/ETHAMBUTOL PROPHYLAXIS',
+            source: 'd3h7d3e4g6d3e4',
+          },
+          {
+            map_type: 'Q-AND-A',
+            to_concept_code: '667',
+            to_concept_name: 'ISONIAZID PROPHYLAXIS',
+            source: 'd3h7d3e4g6d3e4',
+          },
+          {
+            map_type: 'Q-AND-A',
+            to_concept_code: '1652',
+            to_concept_name: 'RIFAMPICIN/ISONIAZID/ETHAMBUTOL',
+            source: 'd3h7d3e4g6d3e4',
+          },
+          {
+            map_type: 'Q-AND-A',
+            to_concept_code: '1234',
+            to_concept_name: 'PROPHYLAXIS RIFAMPICIN',
+            source: 'd3h7d3e4g6d3e4',
+          },
+        ],
+        descriptions: [{ description: '' }],
+      },
+    };
+    const wrapper = mount(<Router>
+      <PreviewCard {...newProps} />
+    </Router>);
+    const cardBody = wrapper.find('CardBody')
+      .filterWhere(node => node.props().title === 'Answers').instance();
+    const spy = jest.spyOn(cardBody, 'handleClick');
+    cardBody.forceUpdate();
+    wrapper.find('.showOthers').simulate('click');
+    expect(spy).toHaveBeenCalled();
+  });
+
   it('should render on clicks', () => {
     const wrapper = mount(<Router>
       <PreviewCard {...props} />


### PR DESCRIPTION

# JIRA TICKET NAME:
[Modify preview of convenient-set concept types to have set members, answers and other items as shown in the mock-ups](https://issues.openmrs.org/browse/OCLOMRS-415)

# Summary:
Any concept with set members should show the set members.   The same as true for any concept with coded answers.  These should show up when previewing a concept. Add items shown in the mocks-ups.
