### PR TITLE
OCLOMRS-443: Enable Partial word searching on create concept while mapping

### DIFF
--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -231,7 +231,7 @@ export const addConceptToDictionary = (id, dataUrl) => async (dispatch) => {
 };
 
 export const fetchSourceConcepts = async (source, query, index) => {
-  const url = `/orgs/${source}/sources/${source}/concepts/?q=${query}&limit=0&verbose=true`;
+  const url = `/orgs/${source}/sources/${source}/concepts/?q=${query}*&limit=0&verbose=true`;
   const response = await instance.get(url);
   const options = response.data.map(concept => ({
     value: concept.url,


### PR DESCRIPTION
# JIRA TICKET NAME:
[Enable Partial word searching on create concept while mapping](https://issues.openmrs.org/browse/OCLOMRS-443)

# Summary:
when the user only enters part of a concept name. The user should be able to get concepts that match the query.  The screenshot of the page is attached below.


![image](https://user-images.githubusercontent.com/27571135/52858969-dba6b080-312b-11e9-9d5d-dab93eb3e05a.png)
