### PR TITLE
OCLOMRS-427: Enable the selection of more than one class or data type on add CIEL concepts page.

### DIFF
--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -32,5 +32,20 @@ export const classes = [
   'Procedure',
 ];
 
+export const DATA_TYPES = [
+  'Boolean',
+  'Coded',
+  'Complex',
+  'Document',
+  'Date',
+  'Time',
+  'Datetime',
+  'Structured-Numeric',
+  'Rule',
+  'Numeric',
+  'N/A',
+  'Text',
+];
+
 export const INTERNAL_MAPPING_DEFAULT_SOURCE = 'CIEL';
 export const CIEL_SOURCE_URL = '/orgs/CIEL/sources/CIEL/';

--- a/src/redux/reducers/bulkConceptReducer.js
+++ b/src/redux/reducers/bulkConceptReducer.js
@@ -8,7 +8,8 @@ import {
   SET_NEXT_PAGE,
   SET_CURRENT_PAGE,
 } from '../actions/types';
-import { getDatatypes, filterClass, normalizeList } from './util';
+import { normalizeList } from './util';
+import { classes as classList, DATA_TYPES as dataTypesList } from '../../components/dictionaryConcepts/components/helperFunction';
 
 const userInitialState = {
   bulkConcepts: [],
@@ -24,15 +25,15 @@ const bulkConcepts = (state = userInitialState, action) => {
       return {
         ...state,
         bulkConcepts: action.payload,
-        datatypes: getDatatypes(action.payload),
-        classes: filterClass(action.payload),
+        datatypes: dataTypesList,
+        classes: classList,
       };
     case FETCH_FILTERED_CONCEPTS:
       return {
         ...state,
         bulkConcepts: action.payload,
-        datatypes: getDatatypes(action.payload),
-        classes: filterClass(action.payload),
+        datatypes: dataTypesList,
+        classes: classList,
       };
     case PREVIEW_CONCEPT:
       return {

--- a/src/redux/reducers/util.js
+++ b/src/redux/reducers/util.js
@@ -1,19 +1,5 @@
 import { countBy } from 'lodash';
 
-
-export const getDatatypes = (concepts) => {
-  const datatypes = [];
-  if (Array.isArray(concepts)) {
-    concepts.map((concept) => {
-      if (!datatypes.includes(concept.datatype)) {
-        return datatypes.push(concept.datatype);
-      }
-      return null;
-    });
-  }
-  return datatypes;
-};
-
 export const filterSources = (concepts) => {
   const filteredSources = [];
   if (Array.isArray(concepts)) {

--- a/src/tests/bulkConcepts/reducer/index.test.js
+++ b/src/tests/bulkConcepts/reducer/index.test.js
@@ -11,6 +11,7 @@ import {
   SET_PERVIOUS_PAGE,
 } from '../../../redux/actions/types';
 import concepts, { concept2, multipleConceptsMockStore } from '../../__mocks__/concepts';
+import { classes as classList, DATA_TYPES as dataTypesList } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 let state;
 let action;
@@ -43,8 +44,8 @@ describe('Test suite for bulkConcepts reducer', () => {
 
     expect(reducer(state, action)).toEqual({
       ...state,
-      classes: ['Diagnosis'],
-      datatypes: ['N/A'],
+      classes: classList,
+      datatypes: dataTypesList,
       bulkConcepts: action.payload,
     });
   });
@@ -130,8 +131,8 @@ describe('Test suite for bulkConcepts reducer', () => {
     expect(reducer(state, action)).toEqual({
       ...state,
       bulkConcepts: action.payload,
-      classes: [undefined],
-      datatypes: [undefined],
+      classes: classList,
+      datatypes: dataTypesList,
     });
   });
   it('should handle PREVIEW_CONCEPT', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Enable the selection of more than one class or data type on add CIEL concepts page.](https://issues.openmrs.org/browse/OCLOMRS-427)

# Summary:
Currently, on the add CIEL concepts page, a user is not able to select multiple classes or data types from the sidebar. After selecting a class or a data type, others disappear as shown in the attached video.