### PR TITLE
OCLOMRS-451: The remove button on the name and description column of creating new concept does not work

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -7,6 +7,8 @@ import locale from '../../dashboard/components/dictionary/common/Languages';
 class ConceptNameRows extends Component {
   static propTypes = {
     newRow: PropTypes.object,
+    nameRows: PropTypes.array,
+    index: PropTypes.number,
     addDataFromRow: PropTypes.func.isRequired,
     removeRow: PropTypes.func.isRequired,
     removeDataFromRow: PropTypes.func.isRequired,
@@ -24,6 +26,8 @@ class ConceptNameRows extends Component {
       locale_preferred: true,
       name_type: '',
     },
+    index: 0,
+    nameRows: [],
   };
 
   constructor(props) {
@@ -93,8 +97,19 @@ class ConceptNameRows extends Component {
   }
 
   handleRemove(event, id) {
-    this.props.removeRow(event, id);
-    this.props.removeDataFromRow(id, 'names');
+    const {
+      nameRows,
+      index,
+      removeRow,
+      removeDataFromRow,
+    } = this.props;
+    if (!id) {
+      removeRow(event, nameRows[index]);
+      removeDataFromRow(nameRows[index], 'names');
+    } else {
+      removeRow(event, id);
+      removeDataFromRow(id, 'names');
+    }
   }
 
   render() {

--- a/src/components/dictionaryConcepts/components/CreateConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptTable.jsx
@@ -18,8 +18,8 @@ const CreateConceptTable = props => (
         ? props.existingConcept.names.map(newRow => (
           <ConceptNameRows newRow={newRow} key={newRow.uuid} {...props} />
         ))
-        : props.nameRows.map(newRow => (
-          <ConceptNameRows key={newRow} {...props} />
+        : props.nameRows.map((newRow, index) => (
+          <ConceptNameRows key={newRow} index={index} {...props} />
         ))}
     </tbody>
   </table>

--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -2,30 +2,32 @@ import React, { Component } from 'react';
 import Select from 'react-select';
 import autoBind from 'react-autobind';
 import PropTypes from 'prop-types';
-import uuid from 'uuid/v4';
 import locale from '../../dashboard/components/dictionary/common/Languages';
 
 class DescriptionRow extends Component {
   static propTypes = {
-    newRow: PropTypes.shape({
-      uuid: PropTypes.string,
-      locale: PropTypes.string,
-      description: PropTypes.string,
-    }),
+    newRow: PropTypes.object,
+    newRowUuid: PropTypes.string,
     addDataFromDescription: PropTypes.func.isRequired,
     removeDescription: PropTypes.func.isRequired,
     removeDataFromRow: PropTypes.func.isRequired,
     pathName: PropTypes.object.isRequired,
-    existingConcept: PropTypes.object.isRequired,
+    // eslint-disable-next-line react/require-default-props
+    existingConcept: PropTypes.object,
   }
 
   static defaultProps = {
+    // eslint-disable-next-line react/default-props-match-prop-types
     newRow: {
-      uuid: String(uuid()),
+      id: '',
+      name: '',
       locale: 'en',
-      description: '',
+      locale_full: { value: 'en', label: 'English [en]' },
+      locale_preferred: true,
+      name_type: '',
     },
-  }
+    newRowUuid: '',
+  };
 
   constructor(props) {
     super(props);
@@ -124,7 +126,9 @@ class DescriptionRow extends Component {
             className=" btn btn-danger concept-form-table-link"
             id="remove-description"
             type="button"
-            onClick={event => this.handleRemove(event, this.props.newRow)}
+            onClick={event => ((this.props.newRowUuid === '')
+              ? this.handleRemove(event, this.props.newRow)
+              : this.handleRemove(event, this.props.newRowUuid))}
           >
             remove
           </button>

--- a/src/components/dictionaryConcepts/components/DescriptionTable.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionTable.jsx
@@ -22,6 +22,7 @@ const DescriptionTable = props => (
         ))
         : props.description.map(newRow => (
           <DescriptionRow
+            newRowUuid={newRow}
             key={newRow}
             {...props}
           />))

--- a/src/tests/dictionaryConcepts/components/DescriptionRow.test.js
+++ b/src/tests/dictionaryConcepts/components/DescriptionRow.test.js
@@ -9,7 +9,7 @@ const props = {
   addDataFromRow: jest.fn(),
   removeRow: jest.fn(),
   removeDataFromRow: jest.fn(),
-  existingConcept: {},
+  existingConcept: undefined,
   newRow: {
     uuid: '123',
   },


### PR DESCRIPTION
# JIRA TICKET NAME:
[The remove button on the name and description column of creating new concept does not work](https://issues.openmrs.org/browse/OCLOMRS-451)

# Summary:
On the create new concept page:
- The button for remove name does not function as expected. 
- Also the remove description button, not function as expected. 