### PR TITLE
OCLOMRS-447: Attach locale to the Synonyms displayed while previewing concept

### DIFF
--- a/src/components/bulkConcepts/component/PreviewCard.jsx
+++ b/src/components/bulkConcepts/component/PreviewCard.jsx
@@ -50,7 +50,7 @@ const PreviewCard = ({
   const mapping = mappings || 'none';
   const description = descriptions ? descriptions[0].description : 'none';
   const synonyms = names && names
-    .map(name => `<span className='synonym'>${name.name}</span>`)
+    .map(name => `<span className='synonym'>${name.name} (${name.locale})</span>`)
     .filter(name => name !== `<span className='synonym'>${display_name}</span>`)
     .join(' ');
   let setMembers;


### PR DESCRIPTION
# JIRA TICKET NAME:
[Attach locale to the Synonyms displayed while previewing concept](https://issues.openmrs.org/browse/OCLOMRS-447)

# Summary:
The primary Synonyms should be removed and other should have their locale attached to them.
