### PR TITLE
OCLOMRS-396: Implement remove mapping on the right interface

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -13,6 +13,7 @@ const CreateConceptForm = (props) => {
     mappings, addMappingRow, updateEventListener, removeMappingRow, updateAsyncSelectValue,
     isEditConcept, allSources,
   } = props;
+  const selectedMappings = mappings.filter(map => map.retired === false);
   return (
     <form className="form-wrapper" onSubmit={props.handleSubmit} id="createConceptForm">
       <div className="concept-form-body">
@@ -200,9 +201,10 @@ const CreateConceptForm = (props) => {
                   </tr>
                 </thead>
                 <tbody>
-                  {mappings.map((mapping, i) => (
+                  {selectedMappings.map((mapping, i) => (
                     <CreateMapping
                       source={mapping.source}
+                      url={mapping.url}
                       map_type={mapping.map_type}
                       to_concept_code={mapping.to_concept_code}
                       to_concept_name={mapping.to_concept_name}

--- a/src/components/dictionaryConcepts/components/CreateMapping.jsx
+++ b/src/components/dictionaryConcepts/components/CreateMapping.jsx
@@ -20,9 +20,8 @@ class CreateMapping extends Component {
     const {
       map_type, source, to_concept_code, to_concept_name, index,
       updateEventListener, removeMappingRow, updateAsyncSelectValue,
-      isNew, allSources,
+      isNew, allSources, url,
     } = this.props;
-
     return (
       <tr>
         <td>
@@ -31,7 +30,7 @@ class CreateMapping extends Component {
             tabIndex={index}
             className="form-control"
             name="source"
-            onChange={updateEventListener}
+            onChange={(event) => { updateEventListener(event, url); }}
             defaultValue={isNew ? '' : source}
           >
             <option value="" hidden>Select a source</option>
@@ -65,7 +64,7 @@ class CreateMapping extends Component {
                   type="text"
                   name="to_concept_code"
                   id="to_concept_code"
-                  onChange={updateEventListener}
+                  onChange={(event) => { updateEventListener(event, url); }}
                 />
               </div>
             </div>
@@ -77,7 +76,7 @@ class CreateMapping extends Component {
               loadOptions={async () => fetchSourceConcepts(
                 source,
                 inputValue,
-                index,
+                url,
               )}
               onChange={updateAsyncSelectValue}
               onInputChange={this.handleInputChange}
@@ -91,7 +90,7 @@ class CreateMapping extends Component {
               placeholder="Concept name (optional)"
               type="text"
               name="to_concept_name"
-              onChange={updateEventListener}
+              onChange={(event) => { updateEventListener(event, url); }}
             />
           )}
         </td>
@@ -101,7 +100,7 @@ class CreateMapping extends Component {
             id="remove"
             className="btn btn-danger "
             tabIndex={index}
-            onClick={removeMappingRow}
+            onClick={() => removeMappingRow(url, to_concept_name, to_concept_code)}
             type="button"
           >
               remove
@@ -117,6 +116,7 @@ CreateMapping.propTypes = {
   source: PropTypes.string,
   to_concept_code: PropTypes.string,
   to_concept_name: PropTypes.string,
+  url: PropTypes.string,
   index: PropTypes.number,
   updateEventListener: PropTypes.func,
   removeMappingRow: PropTypes.func,
@@ -132,6 +132,7 @@ CreateMapping.defaultProps = {
   to_concept_name: '',
   index: 0,
   isNew: false,
+  url: '',
   updateEventListener: () => {},
   removeMappingRow: () => {},
   updateAsyncSelectValue: () => {},

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -75,6 +75,8 @@ export class CreateConcept extends Component {
         id: 1,
         to_source_url: null,
         isNew: true,
+        retired: false,
+        url: uuid(),
       }],
     };
 
@@ -250,31 +252,48 @@ export class CreateConcept extends Component {
       id: mappings.length + 1,
       to_source_url: null,
       isNew: true,
+      retired: false,
+      url: uuid(),
     });
     this.setState({ mappings });
   }
 
-  updateEventListener = (event) => {
-    const { tabIndex, name, value } = event.target;
+  updateEventListener = (event, url) => {
+    const { value, name } = event.target;
     const { mappings } = this.state;
-    mappings[tabIndex][name] = value;
-    this.setState(mappings);
+    const newMappings = mappings.map((map) => {
+      const modifyMap = map;
+      if (modifyMap.url === url) {
+        modifyMap[name] = value;
+      }
+      return modifyMap;
+    });
+    this.setState({ mappings: newMappings });
   }
 
   updateAsyncSelectValue = (value) => {
     const { mappings } = this.state;
-    if (value !== null && value.index !== undefined) {
-      mappings[value.index].to_source_url = value.value;
-      mappings[value.index].to_concept_name = value.label;
-    }
-    this.setState({ mappings });
+    const updateAsyncMappings = mappings.map((map) => {
+      const updatedMap = map;
+      if (value !== null && value.index !== undefined && updatedMap.url === value.index) {
+        updatedMap.to_source_url = value.value;
+        updatedMap.to_concept_name = value.label;
+      }
+      return updatedMap;
+    });
+    this.setState({ mappings: updateAsyncMappings });
   }
 
-  removeMappingRow = (event) => {
-    const { tabIndex } = event.target;
+  removeMappingRow = (url) => {
     const { mappings } = this.state;
-    delete mappings[tabIndex];
-    this.setState({ mappings });
+    const selectedMappings = mappings.map((map) => {
+      const updatedMap = map;
+      if (updatedMap.url === url) {
+        updatedMap.retired = true;
+      }
+      return updatedMap;
+    });
+    this.setState({ mappings: selectedMappings });
   }
 
   render() {

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -8,7 +8,7 @@ import {
 import { newConcept, mockSource, mockCielSource } from '../../__mocks__/concepts';
 import { INTERNAL_MAPPING_DEFAULT_SOURCE } from '../../../components/dictionaryConcepts/components/helperFunction';
 
-jest.mock('uuid/v4', () => jest.fn(() => 1234));
+jest.mock('uuid/v4', () => jest.fn(() => '1234'));
 jest.mock('react-notify-toast');
 
 describe('Test suite for dictionary concepts components', () => {
@@ -73,27 +73,47 @@ describe('Test suite for dictionary concepts components', () => {
   });
 
   it('should call removeMappingRow function', () => {
-    const event = { target: 0 };
+    const url = '9999';
     const instance = wrapper.find('CreateConcept').instance();
-    instance.removeMappingRow(event);
+    instance.addMappingRow();
+    instance.state.mappings[1] = {
+      map_type: 'Same as',
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: 3,
+      to_source_url: null,
+      isNew: true,
+      retired: false,
+      url: '9999',
+    };
+    expect(instance.state.mappings.filter(_ => _ != null).length).toEqual(2);
+    instance.removeMappingRow(url);
+    expect(instance.state.mappings[1].retired).toEqual(true);
   });
 
   it('should call updateAsyncSelectValue function', () => {
-    const value = { index: 0, value: 'malaria 1', label: 'malaria 1' };
+    const value = { index: '1234', value: 'malaria 1', label: 'malaria 1' };
     const instance = wrapper.find('CreateConcept').instance();
+    instance.updateAsyncSelectValue(null);
+    expect(instance.state.mappings[0].to_concept_name).toEqual(null);
     instance.updateAsyncSelectValue(value);
+    expect(instance.state.mappings[0].to_concept_name).toEqual('malaria 1');
   });
 
   it('should call updateEventListener function', () => {
     const event = {
       target: {
         tabIndex: 0,
-        name: 'to_concept_name',
-        value: 'malaria',
+        name: 'to_concept_code',
+        value: 'a234',
       },
     };
+    const url = '1234';
     const instance = wrapper.find('CreateConcept').instance();
-    instance.updateEventListener(event);
+    instance.updateEventListener({ target: { tabIndex: 0, name: INTERNAL_MAPPING_DEFAULT_SOURCE, value: '' } });
+    instance.updateEventListener(event, url);
+    expect(instance.state.mappings[0].to_concept_code).not.toEqual(null);
   });
 
   it('should call updateEventListener function with internal mapping', () => {

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -9,7 +9,7 @@ import {
 import { newConcept, existingConcept, mockSource } from '../../__mocks__/concepts';
 import { INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL } from '../../../components/dictionaryConcepts/components/helperFunction';
 
-jest.mock('uuid/v4', () => jest.fn(() => 1234));
+jest.mock('uuid/v4', () => jest.fn(() => '1234'));
 jest.mock('react-notify-toast');
 
 localStorage.setItem('dictionaryPathName', '/');
@@ -39,6 +39,7 @@ describe('Test suite for dictionary concepts components', () => {
     removeDescriptionForEditConcept: jest.fn(),
     addDescriptionForEditConcept: jest.fn(),
     removeNameForEditConcept: jest.fn(),
+    removeConceptMappingAction: jest.fn(),
     updateConcept: jest.fn(),
     addNewAnswer: jest.fn(),
     removeAnswer: jest.fn(),
@@ -221,6 +222,10 @@ describe('Test suite for mappings on existing concepts', () => {
     removeDescriptionForEditConcept: jest.fn(),
     addDescriptionForEditConcept: jest.fn(),
     removeNameForEditConcept: jest.fn(),
+    removeConceptMappingAction: jest.fn(),
+    showGeneralModal: jest.fn(),
+    hideGeneralModal: jest.fn(),
+    confirmRemoveMappingRow: jest.fn(),
     updateConcept: jest.fn(),
     addNewAnswer: jest.fn(),
     removeAnswer: jest.fn(),
@@ -230,7 +235,7 @@ describe('Test suite for mappings on existing concepts', () => {
     loading: false,
     existingConcept: {
       names: [{
-        uuid: '1234',
+        uuid: '12345',
         name: 'dummy',
       }],
       descriptions: [{
@@ -252,17 +257,127 @@ describe('Test suite for mappings on existing concepts', () => {
     expect(instance.state.mappings.length).toEqual(1);
   });
 
-  it('should call removeMappingRow function', () => {
-    const event = { target: { tabIndex: 1 } };
+  it('should call removeConceptMappingAction function', () => {
+    const url = '9999';
     const instance = wrapper.find('EditConcept').instance();
     instance.addMappingRow();
+    instance.state.mappings[1] = {
+      map_type: 'Same as',
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: 3,
+      to_source_url: null,
+      isNew: true,
+      retired: false,
+      url: '9999',
+    };
     expect(instance.state.mappings.filter(_ => _ != null).length).toEqual(2);
-    instance.removeMappingRow(event);
-    expect(instance.state.mappings.filter(_ => _ != null).length).toEqual(1);
+    instance.removeMappingRow(url);
+    expect(instance.state.mappings[1].retired).toEqual(true);
+  });
+
+  it('should call removeUnsavedMappingRow function', () => {
+    const url = '9999';
+    const instance = wrapper.find('EditConcept').instance();
+    instance.state.mappings[1] = {
+      map_type: 'Same as',
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: 3,
+      to_source_url: null,
+      isNew: true,
+      retired: false,
+      url: '9999',
+    };
+    expect(instance.state.mappings.filter(_ => _ != null).length).toEqual(2);
+    instance.removeUnsavedMappingRow(url);
+    expect(instance.state.mappings[1].retired).toEqual(true);
+  });
+
+  it('should call removeMappingRow function', () => {
+    const url = '9999';
+    const instance = wrapper.find('EditConcept').instance();
+    instance.state.mappings[1] = {
+      map_type: 'Same as',
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: 3,
+      to_source_url: null,
+      retired: false,
+      url: '9999',
+      isEditConcept: true,
+    };
+    const spy = jest.spyOn(instance, 'showGeneralModal');
+    instance.removeMappingRow(url);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should show the delete modal', () => {
+    const url = '9999';
+    const instance = wrapper.find('EditConcept').instance();
+    instance.state.mappings[1] = {
+      map_type: 'Same as',
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: 3,
+      to_source_url: null,
+      retired: false,
+      url: '9999',
+      isEditConcept: true,
+    };
+    instance.removeMappingRow(url);
+    expect(instance.state.openGeneralModal).toEqual(true);
+  });
+
+  it('should call confirmRemoveMappingRow', () => {
+    const url = '9999';
+    const instance = wrapper.find('EditConcept').instance();
+    instance.state.mappings[1] = {
+      map_type: 'Same as',
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: 3,
+      to_source_url: null,
+      retired: false,
+      url: '9999',
+      isEditConcept: true,
+    };
+    const spy = jest.spyOn(instance, 'confirmRemoveMappingRow');
+    instance.removeMappingRow(url);
+    wrapper.find('.btn-danger').at(0).simulate('click');
+    wrapper.find('Button #generalConfirmButton').simulate('click');
+    expect(spy).toHaveBeenCalled();
+    expect(props.removeConceptMappingAction).toHaveBeenCalled();
+  });
+
+  it('should hide the delete modal', () => {
+    const url = '9999';
+    const instance = wrapper.find('EditConcept').instance();
+    instance.state.mappings[1] = {
+      map_type: 'Same as',
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      to_concept_code: null,
+      to_concept_name: null,
+      id: 3,
+      to_source_url: null,
+      retired: false,
+      url: '9999',
+      isEditConcept: true,
+    };
+    const spy = jest.spyOn(instance, 'hideGeneralModal');
+    instance.removeMappingRow(url);
+    wrapper.find('.btn-danger').at(0).simulate('click');
+    wrapper.find('Button #sub-cancel').simulate('click');
+    expect(spy).toHaveBeenCalled();
   });
 
   it('should call updateAsyncSelectValue function', () => {
-    const value = { index: 0, value: 'malaria 1', label: 'malaria 1' };
+    const value = { index: '1234', value: 'malaria 1', label: 'malaria 1' };
     const instance = wrapper.find('EditConcept').instance();
     instance.updateAsyncSelectValue(null);
     expect(instance.state.mappings[0].to_concept_name).toEqual(null);
@@ -278,9 +393,10 @@ describe('Test suite for mappings on existing concepts', () => {
         value: 'a234',
       },
     };
+    const url = '1234';
     const instance = wrapper.find('EditConcept').instance();
     instance.updateEventListener({ target: { tabIndex: 0, name: INTERNAL_MAPPING_DEFAULT_SOURCE, value: '' } });
-    instance.updateEventListener(event);
+    instance.updateEventListener(event, url);
     expect(instance.state.mappings[0].to_concept_code).not.toEqual(null);
   });
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[Implement remove mapping on the right interface](https://issues.openmrs.org/browse/OCLOMRS-396)

# Summary:
"Remove mapping" is currently implemented in the view mappings interface. It needs to be implemented in the edit concept interface similar to implementation on create concept interface.
