### PR TITLE
OCLOMRS-449: Show distinction between active and retired concepts

### DIFF
--- a/src/components/dictionaryConcepts/components/ActionButtons.jsx
+++ b/src/components/dictionaryConcepts/components/ActionButtons.jsx
@@ -8,6 +8,7 @@ const ActionButtons = ({
   concept_class,
   showDeleteModal,
   version_url,
+  retired,
 }) => {
   const dictionaryPathName = localStorage.getItem('dictionaryPathName');
   let showExtra;
@@ -16,7 +17,7 @@ const ActionButtons = ({
   }
 
   return (
-    <React.Fragment>
+    !retired && <React.Fragment>
       {showExtra && (
         <React.Fragment>
           <Link
@@ -51,12 +52,14 @@ ActionButtons.propTypes = {
   mappings: PropTypes.array,
   source: PropTypes.string,
   mappingLimit: PropTypes.number,
+  retired: PropTypes.bool,
 };
 
 ActionButtons.defaultProps = {
   source: '',
   mappings: [],
   mappingLimit: null,
+  retired: false,
 };
 
 export default ActionButtons;

--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -8,6 +8,9 @@ import { getUsername } from './helperFunction';
 import RemoveConcept from './RemoveConcept';
 
 const username = getUsername();
+const showCellContents = cell => <span>
+  {cell.value[1] ? <del className="text-muted">{cell.value[0]}</del> : cell.value[0]}
+</span>;
 
 const ConceptTable = ({
   concepts,
@@ -44,16 +47,22 @@ const ConceptTable = ({
       columns={[
         {
           Header: 'Name',
-          accessor: 'display_name',
+          id: 'nameCol',
+          accessor: concept => [concept.display_name, concept.retired],
           minWidth: 100,
+          Cell: cell => showCellContents(cell),
         },
         {
           Header: 'Class',
-          accessor: 'concept_class',
+          id: 'classCol',
+          accessor: concept => [concept.concept_class, concept.retired],
+          Cell: cell => showCellContents(cell),
         },
         {
           Header: 'Source',
-          accessor: 'source',
+          id: 'sourceCol',
+          accessor: concept => [concept.source, concept.retired],
+          Cell: cell => showCellContents(cell),
         },
         {
           Header: 'Action',

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -129,7 +129,7 @@ export const fetchDictionaryConcepts = (
     url = `${conceptType}/${conceptOwner}/collections/${conceptName}/concepts/?q=${query}&limit=${limit}&page=${page}&verbose=true&conceptClass=${filterByClass.join(',')}`;
   }
   try {
-    const response = await instance.get(url);
+    const response = await instance.get(`${url}&includeRetired=1`);
     dispatch(getDictionaryConcepts(response.data, FETCH_DICTIONARY_CONCEPT));
     dispatch(paginateConcepts(response.data));
     if (query === '' && filterByClass.length === 0 && filterBySource.length === 0) {

--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -10,6 +10,7 @@ import {
 } from '../../../components/dictionaryConcepts/containers/DictionaryConcepts';
 import concepts, { concept3 } from '../../__mocks__/concepts';
 import { INTERNAL_MAPPING_DEFAULT_SOURCE } from '../../../components/dictionaryConcepts/components/helperFunction';
+import ConceptTable from '../../../components/dictionaryConcepts/components/ConceptTable';
 
 const store = createMockStore({
   organizations: {
@@ -59,6 +60,25 @@ describe('Test suite for dictionary concepts components', () => {
     jest.runAllTimers();
 
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should contain strikethrough text for retired concepts', () => {
+    const props = {
+      concepts: [{ ...concepts, retired: true }],
+      loading: false,
+      org: {},
+      locationPath: {},
+      showDeleteModal: jest.fn(),
+      handleDelete: jest.fn(),
+      conceptLimit: 1,
+      closeDeleteModal: jest.fn(),
+      handleDeleteMapping: jest.fn(),
+      showDeleteMappingModal: jest.fn(),
+    };
+    const wrapper = mount(<ConceptTable {...props} />);
+    expect(wrapper).toMatchSnapshot();
+    const strikethroughText = wrapper.find('del.text-muted');
+    expect(strikethroughText.length).toBeGreaterThan(0);
   });
 
   it('should render component without breaking when the type is not specified', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Show distinction between active and retired concepts](https://issues.openmrs.org/browse/OCLOMRS-449)

# Summary:
Show retired concepts as strikethrough text