### PR TITLE
OCLOMRS-450: Remove the message returned below search field when datatype/class filters are selected and pagination next button clicked

### DIFF
--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -108,7 +108,7 @@ export class BulkConceptsPage extends Component {
 
   searchOption = () => {
     const { searchInput } = this.state;
-    if (searchInput && searchInput.trim().length > 2) {
+    if ((searchInput && searchInput.trim().length > 2) || (searchInput.trim().length === 0)) {
       const query = `q=${searchInput.trim()}*`; // The asterisk permits partial search
       const { currentPage, fetchFilteredConcepts: fetchedFilteredConcepts } = this.props;
       fetchedFilteredConcepts(INTERNAL_MAPPING_DEFAULT_SOURCE, query, currentPage);

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -421,6 +421,10 @@ describe('Test suite for BulkConceptsPage component', () => {
     const typeWordInSearchField = { target: { name: 'searchInput', value: 'sample' } };
     wrapper.find('#search-concept').simulate('change', typeWordInSearchField);
     expect(wrapper.find('BulkConceptsPage').state().searchInput).toEqual('sample');
+
+    const searchForWordWithFewCharacters = { target: { name: 'searchInput', value: 'y' } };
+    wrapper.find('#search-concept').simulate('change', searchForWordWithFewCharacters);
+    expect(wrapper.find('BulkConceptsPage').state().searchInput).toEqual('y');
   });
 
   it('should filter search result', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix the "Search query must contain at least 3 characters" message returned below search field when datatype/class filters are selected and pagination next button clicked](https://issues.openmrs.org/browse/OCLOMRS-450)

# Summary:
On the "Add CIEL concepts page", when a datatype and class filter is selected, a "Search query must contain at least 3 characters" message is returned below the search concept field when the pagination next button is clicked. The message should not appear when the pagination next button is clicked. The message should be removed.