### PR TITLE
OCLOMRS-455: Change remove labels on create concept and edit concept page to buttons

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -150,14 +150,14 @@ class ConceptNameRows extends Component {
           </select>
         </td>
         <td>
-          <a
-            href="#!"
-            className="concept-form-table-link"
+          <button
+            className="btn btn-danger concept-form-table-link"
             id="remove-name"
+            type="button"
             onClick={event => this.handleRemove(event, this.props.newRow.uuid)}
           >
             remove
-          </a>
+          </button>
         </td>
       </tr>
     );

--- a/src/components/dictionaryConcepts/components/CreateMapping.jsx
+++ b/src/components/dictionaryConcepts/components/CreateMapping.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
 import AsyncSelect from 'react-select/lib/Async';
 import PropTypes from 'prop-types';
 import { fetchSourceConcepts } from '../../../redux/actions/concepts/dictionaryConcepts';
@@ -98,9 +97,15 @@ class CreateMapping extends Component {
         </td>
 
         <td className="table-remove-link">
-          <Link id="remove" tabIndex={index} onClick={removeMappingRow} to="#">
+          <button
+            id="remove"
+            className="btn btn-danger "
+            tabIndex={index}
+            onClick={removeMappingRow}
+            type="button"
+          >
               remove
-          </Link>
+          </button>
         </td>
       </tr>
     );

--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -119,14 +119,15 @@ class DescriptionRow extends Component {
           />
         </th>
         <td>
-          <a
+          <button
             href="#!"
-            className="concept-form-table-link"
+            className=" btn btn-danger concept-form-table-link"
             id="remove-description"
+            type="button"
             onClick={event => this.handleRemove(event, this.props.newRow)}
           >
             remove
-          </a>
+          </button>
         </td>
       </tr>
     );


### PR DESCRIPTION
# JIRA TICKET NAME:
[Change remove labels on create concept and edit concept page to buttons](https://issues.openmrs.org/browse/OCLOMRS-455)

# Summary:
The buttons on the create concept and edit concept page are displaying as labels;
- Make them display as buttons that prompt a user to click them