### PR TITLE
OCLOMRS-456: Use the traditional OCL url constant defined in HelperFunction.js to replace the traditional url scattered in the codebase.

### DIFF
--- a/src/components/Signup/components/container/index.jsx
+++ b/src/components/Signup/components/container/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { TRADITIONAL_OCL_BASE_URL } from '../../../dictionaryConcepts/components/helperFunction';
 
 export class Signup extends Component {
   state = {
@@ -118,7 +119,7 @@ export class Signup extends Component {
             <div className="container text-right pt-3">
               Or Sign Up on
               {' '}
-              <a href="https://qa.openconceptlab.org/accounts/signup/">Traditional OCL</a>
+              <a href={`${TRADITIONAL_OCL_BASE_URL}/accounts/signup/`}>Traditional OCL</a>
             </div>
           </form>
         </div>

--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import DictionaryVersionsTable from './DictionaryVersionsTable';
 import ReleaseVersionModal from './common/ReleaseVersionModal';
 import SubscriptionModal from './common/SubscriptionModal';
+import { TRADITIONAL_OCL_BASE_URL } from '../../../dictionaryConcepts/components/helperFunction';
 
 const DictionaryDetailCard = (props) => {
   const {
@@ -55,7 +56,7 @@ const DictionaryDetailCard = (props) => {
     minute: 'numeric',
   };
 
-  const traditionalUrl = `https://qa.openconceptlab.org${url}`;
+  const traditionalUrl = `${TRADITIONAL_OCL_BASE_URL}${url}`;
   const releasedVersions = versions.filter(version => version.released === true);
 
   return (

--- a/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { TRADITIONAL_OCL_BASE_URL } from '../../../dictionaryConcepts/components/helperFunction';
 
 const DictionaryVersionsTable = (version) => {
   const {
@@ -12,13 +13,13 @@ const DictionaryVersionsTable = (version) => {
   const DATE_OPTIONS = {
     weekday: 'long', year: 'numeric', month: 'short', day: 'numeric',
   };
-  const traditionalOclUrl = 'https://qa.openconceptlab.org';
+
   return (
     <tr id="versiontable">
       <td>{id}</td>
       <td>{ (new Date(updated_on)).toLocaleDateString('en-US', DATE_OPTIONS)}</td>
       <td>
-        <a className="btn btn-sm" target="_blank" rel="noopener noreferrer" href={traditionalOclUrl + version_url}>Browse in OCL</a>
+        <a className="btn btn-sm" target="_blank" rel="noopener noreferrer" href={TRADITIONAL_OCL_BASE_URL + version_url}>Browse in OCL</a>
         {' '}
         <Link className="downloadConcepts btn btn-sm" onClick={download} to="#">Download</Link>
         {' '}

--- a/src/components/dashboard/components/dictionary/common/SubscriptionModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/SubscriptionModal.jsx
@@ -3,10 +3,11 @@ import PropTypes from 'prop-types';
 import {
   Button, Modal, ModalHeader, ModalBody, ModalFooter, FormGroup, Input,
 } from 'reactstrap';
+import { TRADITIONAL_OCL_BASE_URL } from '../../../../dictionaryConcepts/components/helperFunction';
 
 const SubscriptionModal = (props) => {
   const { show, click, url } = props;
-  const subUrl = `https://qa.openconceptlab.org${url}`;
+  const subUrl = `${TRADITIONAL_OCL_BASE_URL}${url}`;
   return (
     <div className="modal-container">
       <Modal

--- a/src/components/login/container/LoginDetails.jsx
+++ b/src/components/login/container/LoginDetails.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import newVideo from '../styles/video/newInstructions.mp4';
+import { TRADITIONAL_OCL_BASE_URL } from '../../dictionaryConcepts/components/helperFunction';
 
 const LoginDetails = () => (
   <div className=" container login-details">
@@ -11,7 +12,7 @@ const LoginDetails = () => (
       <div className="card-body">
         Ensure you have an account from the traditional OCL. After that,
         {' '}
-        <a href="https://qa.openconceptlab.org/accounts/login/">
+        <a href={`${TRADITIONAL_OCL_BASE_URL}/accounts/login/`}>
           Login into the traditional OCL
         </a>
         <br />

--- a/src/components/login/container/index.jsx
+++ b/src/components/login/container/index.jsx
@@ -6,6 +6,7 @@ import { withRouter, Link } from 'react-router-dom';
 import Title from '../../Title';
 import { loginAction } from '../../../redux/actions/auth/authActions';
 import SubmitButton from '../components/SubmitButton';
+import { TRADITIONAL_OCL_BASE_URL } from '../../dictionaryConcepts/components/helperFunction';
 
 export class Login extends Component {
   state = {
@@ -94,7 +95,7 @@ export class Login extends Component {
 have an account?
                     {' '}
                     <a
-                      href="https://qa.openconceptlab.org/accounts/signup/"
+                      href={`${TRADITIONAL_OCL_BASE_URL}/accounts/signup/`}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
@@ -102,7 +103,7 @@ have an account?
                     </a>
                     <br />
                     <a
-                      href="https://qa.openconceptlab.org"
+                      href={TRADITIONAL_OCL_BASE_URL}
                       target="_blank"
                       rel="noopener noreferrer"
                     >

--- a/src/components/userDasboard/components/DashboardDetails.jsx
+++ b/src/components/userDasboard/components/DashboardDetails.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { TRADITIONAL_OCL_BASE_URL } from '../../dictionaryConcepts/components/helperFunction';
 
 const DashboardDetails = ({ numberOfOrgs, numberOfDictionary, organizations }) => {
   const nameOfOrganizations = organizations.map(organization => organization.name).join(',');
@@ -15,7 +16,7 @@ const DashboardDetails = ({ numberOfOrgs, numberOfDictionary, organizations }) =
             {' '}
 organization. This can be changed via
             {' '}
-            <a href="https://qa.openconceptlab.org/" target="_blank" rel="noopener noreferrer">
+            <a href={TRADITIONAL_OCL_BASE_URL} target="_blank" rel="noopener noreferrer">
             the traditional OCL
             </a>
 .
@@ -40,7 +41,7 @@ organizations:
           {organizations.map(organization => (
             <span className="lead org-name text-capitalize" key={organization.id}>
               <a
-                href={`https://qa.openconceptlab.org${organization.url}`}
+                href={`${TRADITIONAL_OCL_BASE_URL}${organization.url}`}
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -54,7 +55,7 @@ organizations:
           <span className="d-block">
           This can be changed via
             {' '}
-            <a href="https://qa.openconceptlab.org/" target="_blank" rel="noopener noreferrer">
+            <a href={TRADITIONAL_OCL_BASE_URL} target="_blank" rel="noopener noreferrer">
             the traditional OCL
             </a>
 .
@@ -69,7 +70,7 @@ organizations:
         <p className="lead">
         You do not belong to any organization. This can be changed via
           {' '}
-          <a href="https://qa.openconceptlab.org/" target="_blank" rel="noopener noreferrer">
+          <a href={TRADITIONAL_OCL_BASE_URL} target="_blank" rel="noopener noreferrer">
           the traditional OCL
           </a>
 .

--- a/src/tests/Dictionary/DictionaryModal.test.jsx
+++ b/src/tests/Dictionary/DictionaryModal.test.jsx
@@ -189,6 +189,52 @@ describe('Test suite for dictionary modal', () => {
     expect(wrapper3.instance().state.errors).toEqual({});
   });
 
+  it('it should handle undefined submit error response', async () => {
+    const error = {
+      response: undefined,
+    };
+
+    const newProps = {
+      title: 'Add Dictionary',
+      buttonname: 'Add Dictionary',
+      show: true,
+      modalhide: jest.fn(),
+      submit: jest.fn().mockImplementation(() => Promise.reject(error)),
+      organizations: [],
+      fetchingOrganizations: jest.fn(),
+      fetchSources: jest.fn(),
+      createDictionary: jest.fn(),
+      createDictionaryUser: jest.fn(),
+      handleHide: jest.fn(),
+      name: jest.fn(),
+      dictionary,
+      sources: [{ name: 'source', id: '1' }],
+      dictionaries: [],
+      userDictionaries: [],
+      searchDictionaries: jest.fn(),
+    };
+    const wrapper3 = shallow(<DictionaryModal {...newProps} />);
+
+    wrapper3.setState({
+      data: {
+        ...wrapper3.state().data,
+        id: '1',
+        preferred_source: 'CIEL',
+        public_access: 'None',
+        name: 'OpenMRSDictionary',
+        owner: 'indiviual',
+        description: 'OpenMRSDictionary',
+        default_locale: 'en',
+        supported_locales: 'us',
+        repository_type: 'OpenMRSDictionary',
+      },
+      errors: {},
+    });
+
+    await wrapper3.instance().onSubmit(preventDefault);
+    expect(wrapper3.instance().state.errors).toEqual({});
+  });
+
   it('it should handle search input values', () => {
     props.isEditingDictionary = false;
     const wrapper2 = mount(<DictionaryModal {...props} />);


### PR DESCRIPTION
# JIRA TICKET NAME:
[Use the traditional OCL url constant defined in HelperFunction.js to replace the traditional url scattered in the codebase.](https://issues.openmrs.org/browse/OCLOMRS-456)

# Summary:
The URL(https://qa.openconceptlab.org) to the traditional OCL site is scattered in the code base as seen in the attached screenshot. A constant defined in HelperFunction.js should be used instead.
