### PR TITLE
OCLOMRS-445: Fix pagination on Add CIEL concepts page when datatype/class filters are selected.

### DIFF
--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -56,6 +56,7 @@ export class BulkConceptsPage extends Component {
       searchInput: '',
       conceptLimit: 10,
       searchingOn: false,
+      filterOn: false,
     };
   }
 
@@ -64,18 +65,25 @@ export class BulkConceptsPage extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { searchingOn } = this.state;
-    const { currentPage } = this.props;
+    const { searchingOn, searchInput, filterOn } = this.state;
+    const { currentPage, fetchFilteredConcepts: fetchedFilteredConcepts } = this.props;
     if (currentPage !== prevProps.currentPage) {
-      if (searchingOn) {
+      if (filterOn) {
+        const query = `q=${searchInput}`;
+        return fetchedFilteredConcepts(INTERNAL_MAPPING_DEFAULT_SOURCE, query, currentPage);
+      }
+
+      if (searchingOn && !filterOn) {
         return this.searchOption();
       }
+
       return this.getBulkConcepts();
     }
     return null;
   }
 
   handleFilter = (event) => {
+    this.setState({ searchingOn: true, filterOn: true });
     const {
       target: { name },
     } = event;

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -8,6 +8,7 @@ import {
   mapStateToProps,
 } from '../../../components/bulkConcepts/container/BulkConceptsPage';
 import concepts from '../../__mocks__/concepts';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 const store = createMockStore({
   bulkConcepts: {
@@ -331,6 +332,39 @@ describe('Test suite for BulkConceptsPage component', () => {
     const wrapper = shallow(<BulkConceptsPage {...props} />).setState({ searchingOn: true });
     const instance = wrapper.instance();
     expect(instance.componentDidUpdate(2)).toEqual(undefined);
+  });
+
+  it('it should fetch filtered concepts when filter is true using the currently set page', () => {
+    const props = {
+      setCurrentPage: jest.fn(),
+      currentPage: 1,
+      fetchBulkConcepts: jest.fn(),
+      filterConcept: jest.fn(),
+      concepts: [],
+      loading: true,
+      datatypes: [],
+      classes: [],
+      conceptLimit: 10,
+      match: {
+        params: {
+          type: 'users',
+          typeName: 'emasys',
+          collectionName: 'dev-org',
+          language: 'en',
+          dictionaryName: INTERNAL_MAPPING_DEFAULT_SOURCE,
+        },
+      },
+      addToFilterList: jest.fn(),
+      fetchFilteredConcepts: jest.fn(),
+      addConcept: jest.fn(),
+      previewConcept: jest.fn(),
+      handleNextPage: jest.fn(),
+    };
+    const wrapper = shallow(<BulkConceptsPage {...props} />);
+    const instance = wrapper.instance();
+    wrapper.setState({ filterOn: true });
+    instance.componentDidUpdate(props.currentPage);
+    expect(instance.props.fetchFilteredConcepts).toHaveBeenCalled();
   });
 
   it('should refresh page when search input is empty', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix pagination on Add CIEL concepts page when datatype/class filters are selected.](https://issues.openmrs.org/browse/OCLOMRS-445)

# Summary:
On the Add CIEL concepts page;
- Once a user selects concept by datatype or class.
 * The pagination buttons at the right bottom corner of the table stop functioning.
 * That is they change the pagination number but the concepts being displayed do not change.


 * Fix the pagination by ensuring that a user can select a  specific datatype/class and view the next and previous page when they click the pagination buttons.
