### PR TITLE
OCLOMRS-458: Implement reading an OCL backend URL from a system environment property called OCL_API_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
 - Clone the forked repository to your computer ensure to run the command below in the directory you want to store the project.
     # git clone [the url of the repository] For example; 
     # git clone https://github.com/yourusername/openmrs-ocl-client.git
+    # Create a .env file in the root directory with the variables API URL and Traditional OCL URL as shown below to access app in dev mode;
+      REACT_APP_OCL_API_HOST=https://api.qa.openconceptlab.org/
+      REACT_APP_TRADITIONAL_OCL_HOST=https://qa.openconceptlab.org
+      
 - In the root directory of the project install all the dependencies using the command below 
     $ npm install
 ```

--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -1,3 +1,5 @@
+import urlConfig from '../../../config';
+
 export const getUsername = () => localStorage.getItem('username');
 
 export const classes = [
@@ -55,4 +57,4 @@ export const MAP_TYPE = {
   questionAndAnswer: 'Q-AND-A',
 };
 
-export const TRADITIONAL_OCL_BASE_URL = 'https://qa.openconceptlab.org';
+export const TRADITIONAL_OCL_BASE_URL = urlConfig.TRADITIONAL_OCL;

--- a/src/config/axiosConfig.js
+++ b/src/config/axiosConfig.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
+import urlConfig from './index';
 
 const instance = axios.create({
-  baseURL: 'https://api.qa.openconceptlab.org/',
+  baseURL: urlConfig.OCL_API_HOST,
 });
 
 instance.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded';

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,0 +1,4 @@
+export default {
+  OCL_API_HOST: process.env.REACT_APP_OCL_HOST || 'https://api.qa.openconceptlab.org/',
+  TRADITIONAL_OCL: process.env.REACT_APP_TRADITIONAL_OCL_HOST || 'https://qa.openconceptlab.org',
+};

--- a/src/redux/actions/auth/authActions.js
+++ b/src/redux/actions/auth/authActions.js
@@ -3,8 +3,9 @@ import {
   login, loginFailed, loginStarted, logout,
 } from './authActionCreators';
 import { showNetworkError } from '../dictionaries/dictionaryActionCreators';
+import urlConfig from '../../../config';
 
-const BASE_URL = 'https://api.qa.openconceptlab.org/';
+const BASE_URL = urlConfig.OCL_API_HOST;
 
 const loginAction = ({ username, password }) => (dispatch) => {
   dispatch(loginStarted());


### PR DESCRIPTION
# JIRA TICKET NAME:
[Implement reading an OCL backend URL from a system environment property called OCL_API_HOST](https://issues.openmrs.org/browse/OCLOMRS-458)

# Summary:
-  Rename the BASE_URL to OCL_API_HOST
-  Enable creating a `.env` file to save these URLs as environment variables so that it can be easily switched when the need arrives.
-  Update the read me to show users how to store the environment variables in the .env file.