### PR TITLE
OCLOMRS-460: Remove source column on Add CIEL Page

### DIFF
--- a/src/components/bulkConcepts/component/ConceptTable.jsx
+++ b/src/components/bulkConcepts/component/ConceptTable.jsx
@@ -42,10 +42,6 @@ const ConceptTable = ({
             accessor: 'datatype',
           },
           {
-            Header: 'Source',
-            accessor: 'source',
-          },
-          {
             Header: 'ID',
             accessor: 'id',
           },


### PR DESCRIPTION
# JIRA TICKET NAME:
[Remove source column on Add CIEL Page ](https://issues.openmrs.org/browse/OCLOMRS-460)

# Summary:
The source column on the " Add CIEL concepts Page" should be removed given the fact that all concepts listed are "CIEL concepts". There is no need for the source column.