### PR TITLE
OCLOMRS-453: Fix inability to create more than one Name or Description while Creating and Editing Concepts

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -14,6 +14,7 @@ class ConceptNameRows extends Component {
     removeDataFromRow: PropTypes.func.isRequired,
     pathName: PropTypes.object.isRequired,
     existingConcept: PropTypes.object.isRequired,
+    rowId: PropTypes.string,
   };
 
   static defaultProps = {
@@ -28,6 +29,7 @@ class ConceptNameRows extends Component {
     },
     index: 0,
     nameRows: [],
+    rowId: '',
   };
 
   constructor(props) {
@@ -35,8 +37,9 @@ class ConceptNameRows extends Component {
     const defaultLocale = locale.find(
       currentLocale => currentLocale.value === props.pathName.language,
     );
+    const { rowId } = this.props;
     this.state = {
-      id: this.props.newRow.id,
+      id: rowId,
       name: '',
       locale: defaultLocale.value,
       locale_full: defaultLocale,
@@ -62,12 +65,12 @@ class ConceptNameRows extends Component {
     const { newRow } = this.props;
     const defaultLocale = locale.find(
       currentLocale => currentLocale.value === newRow.locale,
-    );
+    ) || locale[0];
     this.setState({
       ...this.state,
       uuid: newRow.uuid || '',
       name: newRow.name || '',
-      locale: newRow.locale || defaultLocale,
+      locale: newRow.locale || defaultLocale.value,
       locale_full: defaultLocale,
       name_type: newRow.name_type || 'Fully Specified',
       locale_preferred: newRow.locale_preferred || 'Yes',
@@ -98,21 +101,15 @@ class ConceptNameRows extends Component {
 
   handleRemove(event, id) {
     const {
-      nameRows,
-      index,
       removeRow,
       removeDataFromRow,
     } = this.props;
-    if (!id) {
-      removeRow(event, nameRows[index]);
-      removeDataFromRow(nameRows[index], 'names');
-    } else {
-      removeRow(event, id);
-      removeDataFromRow(id, 'names');
-    }
+    removeRow(event, id);
+    removeDataFromRow({ uuid: id }, 'names');
   }
 
   render() {
+    const { rowId } = this.props;
     return (
       <tr>
         <td>
@@ -169,7 +166,7 @@ class ConceptNameRows extends Component {
             className="btn btn-danger concept-form-table-link"
             id="remove-name"
             type="button"
-            onClick={event => this.handleRemove(event, this.props.newRow.uuid)}
+            onClick={event => this.handleRemove(event, rowId)}
           >
             remove
           </button>

--- a/src/components/dictionaryConcepts/components/CreateConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptTable.jsx
@@ -16,10 +16,10 @@ const CreateConceptTable = props => (
     <tbody>
       {props.existingConcept && props.existingConcept.names
         ? props.existingConcept.names.map(newRow => (
-          <ConceptNameRows newRow={newRow} key={newRow.uuid} {...props} />
+          <ConceptNameRows newRow={newRow} rowId={newRow.uuid} key={newRow.uuid} {...props} />
         ))
         : props.nameRows.map((newRow, index) => (
-          <ConceptNameRows key={newRow} index={index} {...props} />
+          <ConceptNameRows key={newRow} rowId={newRow} index={index} {...props} />
         ))}
     </tbody>
   </table>

--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -6,6 +6,7 @@ import locale from '../../dashboard/components/dictionary/common/Languages';
 
 class DescriptionRow extends Component {
   static propTypes = {
+    rowId: PropTypes.string,
     newRow: PropTypes.object,
     newRowUuid: PropTypes.string,
     addDataFromDescription: PropTypes.func.isRequired,
@@ -27,6 +28,7 @@ class DescriptionRow extends Component {
       name_type: '',
     },
     newRowUuid: '',
+    rowId: '',
   };
 
   constructor(props) {
@@ -34,8 +36,9 @@ class DescriptionRow extends Component {
     const defaultLocale = locale.find(
       currentLocale => currentLocale.value === props.pathName.language,
     );
+    const { rowId } = this.props;
     this.state = {
-      id: this.props.newRow,
+      id: rowId,
       locale: defaultLocale.value,
       locale_full: defaultLocale,
       description: '',

--- a/src/components/dictionaryConcepts/components/DescriptionTable.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionTable.jsx
@@ -16,6 +16,7 @@ const DescriptionTable = props => (
         ? props.existingConcept.descriptions.map(newRow => (
           <DescriptionRow
             newRow={newRow}
+            rowId={newRow.uuid}
             key={newRow.uuid}
             {...props}
           />
@@ -23,6 +24,7 @@ const DescriptionTable = props => (
         : props.description.map(newRow => (
           <DescriptionRow
             newRowUuid={newRow}
+            rowId={newRow}
             key={newRow}
             {...props}
           />))


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix inability to create more than one Name or Description while Creating and Editing Concepts](https://issues.openmrs.org/browse/OCLOMRS-453)

# Summary:
This bug prevents the creation of more than one name and more than one description while creating or editing a custom concept. The concept itself is saved successfully, but the new name or new description is not saved.

This happens because:

- The identifiers for each new name-row and description-row were not passed correctly.
- The default locale (a required field) wasn't being passed correctly.