### PR TITLE
OCLOMRS-457: Make search consistent across the entire application

### DIFF
--- a/src/components/bulkConcepts/addBulkConcepts.jsx
+++ b/src/components/bulkConcepts/addBulkConcepts.jsx
@@ -40,6 +40,8 @@ export class AddBulkConcepts extends Component {
       conceptIds: '',
       openResultModal: false,
       otherSelected: false,
+      value: '',
+      sourceValue: '',
     };
     this.invalidConceptIds = [];
     this.sourceUrl = 'orgs/CIEL/sources/CIEL/';
@@ -112,6 +114,19 @@ export class AddBulkConcepts extends Component {
   closeResultModal = () => {
     this.invalidConceptIds = [];
     this.setState({ openResultModal: false });
+  }
+
+  onKeyDown = (event, onKeyDown, onChange) => {
+    if (event.target.name === 'source') {
+      this.setState({ sourceValue: event.target.value });
+    } else {
+      this.setState({ value: event.target.value });
+    }
+    if (event.keyCode === 13) {
+      event.preventDefault();
+      onChange(event);
+      onKeyDown(event);
+    }
   }
 
   render() {
@@ -195,12 +210,27 @@ export class AddBulkConcepts extends Component {
                           <i className="fas fa-search" />
                           {otherSelected && <input
                             {
-                              ...getInputProps()
-                              }
+                            ...getInputProps()
+                            }
                             className="form-control search"
                             id="sourceSearch"
                             placeholder="Search"
                             aria-label="Search"
+                            name="source"
+                            value={this.state.sourceValue}
+
+                            onKeyDown={
+                              e => this.onKeyDown(
+                                e,
+                                getInputProps().onKeyDown,
+                                getInputProps().onChange,
+                              )}
+                            onChange={e => this.onKeyDown(
+                              e,
+                              getInputProps().onKeyDown,
+                              getInputProps().onChange,
+                            )}
+                            {...getInputProps().rest}
                           />
                             }
                           {isFetching
@@ -275,12 +305,25 @@ export class AddBulkConcepts extends Component {
                           <i className="fas fa-search" />
                           <input
                             {
-                              ...getInputProps()
-                              }
+                            ...getInputProps()
+                            }
                             className="form-control search"
                             id="search"
                             placeholder="search"
+                            value={this.state.value}
                             aria-label="Search"
+                            onChange={e => this.onKeyDown(
+                              e,
+                              getInputProps().onKeyDown,
+                              getInputProps().onChange,
+                            )}
+                            onKeyDown={
+                              e => this.onKeyDown(
+                                e,
+                                getInputProps().onKeyDown,
+                                getInputProps().onChange,
+                              )}
+                            {...getInputProps().rest}
                           />
                           {isLoading
                               && <div className="ml-auto text-right">

--- a/src/components/dictionaryConcepts/components/CreateMapping.jsx
+++ b/src/components/dictionaryConcepts/components/CreateMapping.jsx
@@ -75,11 +75,11 @@ class CreateMapping extends Component {
             isNew && <AsyncSelect
               cacheOptions
               isClearable
-              loadOptions={async () => fetchSourceConcepts(
-                source,
-                inputValue,
-                index,
-              )}
+              loadOptions={async () => {
+                // console.log(e.keycode, "fhfjfnbjkfjfhjkfgfjkgfjkghjkf")
+                if (true) { return fetchSourceConcepts(source, inputValue, index); }
+                // return false;
+              }}
               onChange={updateAsyncSelectValue}
               onInputChange={this.handleInputChange}
               placeholder="search concept name or id"


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make search consistent across the entire application](https://issues.openmrs.org/browse/OCLOMRS-457)

# Summary:
When adding a CIEL mapping, execute a search only when ENTER is pressed in order to be consistent with other searches, and to avoid multiple calls to the backend at every keystroke. Repeat the same behavior for the Add Bulk Concepts search fields.

