### PR TITLE
OCLOMRS-448: Fix the issue with the preview concept button.

### DIFF
--- a/src/components/bulkConcepts/component/ActionButtons.jsx
+++ b/src/components/bulkConcepts/component/ActionButtons.jsx
@@ -19,27 +19,22 @@ export class ActionButtons extends Component {
       display_name: PropTypes.string,
     }).isRequired,
     addConcept: PropTypes.func.isRequired,
+    openModal: PropTypes.func.isRequired,
+    closeModal: PropTypes.func.isRequired,
+    modalId: PropTypes.string.isRequired,
   };
 
   constructor(props) {
     super(props);
     this.state = {
-      open: false,
       disableButton: false,
     };
   }
 
-  openModal = () => {
-    this.setState({ open: true });
-  };
-
-  closeModal = () => {
-    this.setState({ open: false });
-  };
-
   fetchPreview = (id) => {
-    this.props.previewConcept(id);
-    this.openModal();
+    const { previewConcept, openModal } = this.props;
+    previewConcept(id);
+    openModal(id);
   };
 
   addConcept = (conceptUrl, name) => {
@@ -50,10 +45,11 @@ export class ActionButtons extends Component {
 
   addConceptButton = (id, url, display_name) => {
     this.setState({ disableButton: true });
+    const { closeModal } = this.props;
     notify.show('Adding...', 'warning', 800);
 
     this.fetchPreview(id);
-    this.closeModal();
+    closeModal();
     setTimeout(() => {
       this.addConcept(url, display_name);
     }, 1000);
@@ -61,7 +57,9 @@ export class ActionButtons extends Component {
 
   render() {
     const { disableButton } = this.state;
-    const { id, url, display_name } = this.props;
+    const {
+      id, url, display_name, modalId, closeModal, preview,
+    } = this.props;
     return (
       <React.Fragment>
         <button
@@ -87,10 +85,10 @@ export class ActionButtons extends Component {
           <button type="button" className="btn btn-sm mb-1 actionaButtons">
             Preview concept
             <PreviewCard
-              open={this.state.open}
-              concept={this.props.preview}
+              open={modalId === id}
+              concept={preview}
               addConcept={this.addConcept}
-              closeModal={this.closeModal}
+              closeModal={closeModal}
             />
           </button>
         </div>

--- a/src/components/bulkConcepts/component/ConceptTable.jsx
+++ b/src/components/bulkConcepts/component/ConceptTable.jsx
@@ -8,6 +8,7 @@ import ConceptPagination from './ConceptPagination';
 
 const ConceptTable = ({
   concepts, loading, location, preview, previewConcept, addConcept, conceptLimit, currentPage,
+  modalId, openModal, closeModal,
 }) => {
   if (loading) {
     return (
@@ -55,6 +56,9 @@ const ConceptTable = ({
             Cell: ({ original: concept }) => (
               <ActionButtons
                 preview={preview}
+                modalId={modalId}
+                closeModal={closeModal}
+                openModal={openModal}
                 previewConcept={previewConcept}
                 addConcept={addConcept}
                 params={location}
@@ -83,12 +87,16 @@ ConceptTable.propTypes = {
     display_name: PropTypes.string,
   }).isRequired,
   addConcept: PropTypes.func.isRequired,
+  openModal: PropTypes.func.isRequired,
+  closeModal: PropTypes.func.isRequired,
   previewConcept: PropTypes.func.isRequired,
   conceptLimit: PropTypes.number.isRequired,
   currentPage: PropTypes.number.isRequired,
+  modalId: PropTypes.string,
 };
 ConceptTable.defaultProps = {
   original: {},
+  modalId: '',
 };
 
 export default ConceptTable;

--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -56,12 +56,22 @@ export class BulkConceptsPage extends Component {
       searchInput: '',
       conceptLimit: 10,
       searchingOn: false,
+      modalId: '',
     };
   }
 
   componentDidMount() {
     this.getBulkConcepts();
   }
+
+
+  openModal = (id) => {
+    this.setState({ modalId: id });
+  };
+
+  closeModal = () => {
+    this.setState({ modalId: '' });
+  };
 
   componentDidUpdate(prevProps) {
     const { searchingOn } = this.state;
@@ -176,6 +186,9 @@ export class BulkConceptsPage extends Component {
               concepts={concepts}
               loading={loading}
               location={params}
+              modalId={this.state.modalId}
+              openModal={this.openModal}
+              closeModal={this.closeModal}
               preview={preview}
               previewConcept={previewedConcept}
               addConcept={addedConcept}

--- a/src/tests/bulkConcepts/components/ActionButtons.test.js
+++ b/src/tests/bulkConcepts/components/ActionButtons.test.js
@@ -6,6 +6,9 @@ describe('Test suite for ActionButton in BulkConceptsPage component', () => {
   it('should handle fetchPreview', () => {
     const props = {
       previewConcept: jest.fn(),
+      openModal: jest.fn(),
+      closeModal: jest.fn(),
+      modalId: '',
       id: '',
       display_name: '',
       url: '',
@@ -19,7 +22,6 @@ describe('Test suite for ActionButton in BulkConceptsPage component', () => {
         display_name: '',
       },
       addConcept: jest.fn(),
-      url: '',
     };
 
     const wrapper = shallow(<ActionButtons {...props} />);


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix the issue with the preview concept button](https://issues.openmrs.org/browse/OCLOMRS-448)

# Summary:
Currently, a user needs to double click the preview concept button on the add CIEL page before it works. This should be fixed so that the preview concept button should work on a single click