### PR TITLE
OCLOMRS-461: The source of the Mapping does not display while editing a Concept

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateMapping.jsx
+++ b/src/components/dictionaryConcepts/components/CreateMapping.jsx
@@ -31,7 +31,7 @@ class CreateMapping extends Component {
             className="form-control"
             name="source"
             onChange={(event) => { updateEventListener(event, url); }}
-            defaultValue={isNew ? '' : source}
+            value={source || undefined}
           >
             <option value="" hidden>Select a source</option>
             {allSources.map(src => <option


### PR DESCRIPTION
# JIRA TICKET NAME:
[The source of the Mapping does not display while editing a Concept](https://issues.openmrs.org/browse/OCLOMRS-461)

# Summary:
When a concept is created with its mappings and then the user clicks to edit the concept, the mappings display without their sources.