### PR TITLE
OCLOMRS-464: Fix inability to save the correct relationship for each Mapping

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateMapping.jsx
+++ b/src/components/dictionaryConcepts/components/CreateMapping.jsx
@@ -45,6 +45,7 @@ class CreateMapping extends Component {
         <td>
           {<MapType
             updateEventListener={updateEventListener}
+            url={url}
             index={index}
             map_type={map_type}
             source={source}

--- a/src/components/dictionaryConcepts/components/MapType.jsx
+++ b/src/components/dictionaryConcepts/components/MapType.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const mapType = (props) => {
   const {
-    index, map_type, map_types, updateEventListener,
+    index, map_type, map_types, updateEventListener, url,
   } = props;
   return (
     <select
@@ -13,7 +13,8 @@ const mapType = (props) => {
       placeholder="map type"
       type="text"
       name="map_type"
-      onChange={updateEventListener}
+      id="mapping-relationship"
+      onChange={(event) => { updateEventListener(event, url); }}
     >
       {
       map_types.map(_ => <option key={_}>
@@ -31,9 +32,11 @@ mapType.propTypes = {
   index: PropTypes.number,
   updateEventListener: PropTypes.func,
   map_types: PropTypes.array,
+  url: PropTypes.string,
 };
 
 mapType.defaultProps = {
+  url: '',
   map_type: '',
   index: 0,
   updateEventListener: () => {},

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -534,3 +534,15 @@ export const mockCielSource = {
   owner_type: 'Organization',
   owner_url: '/orgs/CIEL/',
 };
+
+export const mockMapping = {
+  id: 1,
+  isNew: true,
+  map_type: 'SAME-AS',
+  retired: false,
+  source: null,
+  to_concept_code: null,
+  to_concept_name: null,
+  to_source_url: null,
+  url: '1234',
+};

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -5,7 +5,9 @@ import {
   CreateConcept,
   mapStateToProps,
 } from '../../../components/dictionaryConcepts/containers/CreateConcept';
-import { newConcept, mockSource, mockCielSource } from '../../__mocks__/concepts';
+import {
+  newConcept, mockSource, mockCielSource, mockMapping,
+} from '../../__mocks__/concepts';
 import { INTERNAL_MAPPING_DEFAULT_SOURCE } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 jest.mock('uuid/v4', () => jest.fn(() => '1234'));
@@ -260,5 +262,15 @@ describe('Test suite for dictionary concepts components', () => {
     };
     instance.handleAnswerChange(event, 'test ID');
     expect(wrapper.state().answers[0].map_type).toEqual('Same as');
+  });
+
+  it('should pass the Relationship provided to CreateConceptForm', () => {
+    wrapper.setState({ mappings: [mockMapping] }, () => {
+      const inputValue = 'BROADER-THAN';
+      const relationshipDropdown = wrapper.find('select#mapping-relationship');
+      const event = { target: { name: 'map_type', value: inputValue } };
+      relationshipDropdown.simulate('change', event);
+      expect(wrapper.find('CreateConceptForm').props().mappings[0].map_type).toEqual(inputValue);
+    });
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix inability to save the correct relationship for each Mapping](https://issues.openmrs.org/browse/OCLOMRS-464)

# Summary:
While creating or editing concepts, any relationship that is not the default "SAME-AS" relationship is not saved. The concept and the mappings are saved but with wrong relationships.