### PR TITLE
OCLOMRS-465: Fix error when a concept doesn't have mapping

### DIFF
--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -71,6 +71,7 @@ export class EditConcept extends Component {
       openGeneralModal: false,
       url: '',
       mapp: '',
+      source: '',
     };
     this.conceptUrl = '';
 
@@ -102,9 +103,10 @@ export class EditConcept extends Component {
   componentWillReceiveProps(newProps) {
     const { existingConcept } = newProps;
     const { mappings } = this.state;
-    if (existingConcept.mappings !== undefined
-      && existingConcept.mappings.length > mappings.length) {
-      this.organizeMappings(existingConcept.mappings);
+    if (existingConcept !== undefined && existingConcept.mappings) {
+      if (existingConcept.mappings.length > mappings.length) {
+        this.organizeMappings(existingConcept.mappings);
+      }
     }
   }
 

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -214,6 +214,7 @@ describe('Test suite for mappings on existing concepts', () => {
       push: jest.fn(),
     },
     createNewName: jest.fn(),
+    organizeMappings: jest.fn(),
     addNewDescription: jest.fn(),
     clearSelections: jest.fn(),
     fetchExistingConcept: jest.fn(),
@@ -412,6 +413,18 @@ describe('Test suite for mappings on existing concepts', () => {
     const spy = jest.spyOn(instance, 'updateEventListener');
     instance.updateEventListener(event);
     expect(spy).toHaveBeenCalled();
+  });
+
+  it('should test componentWillReceiveProps with ', () => {
+    const newProps = {
+      existingConcept: {
+        mappings: null,
+      },
+    };
+    const instance = wrapper.find('EditConcept').instance();
+    instance.componentWillReceiveProps({ existingConcept: { mappings: undefined } });
+    instance.componentWillReceiveProps(newProps);
+    expect(instance.state.source).toEqual('');
   });
 
   it('should test componentWillReceiveProps', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix error when a concept doesn't have mapping](https://issues.openmrs.org/browse/OCLOMRS-465)

# Summary:
When a custom concept is created without adding mapping. when you select that concept by clicking on the edit button on dictionary concept page it throws an error.