### PR TITLE
OCLOMRS-463: Passing OCL URL environment variables to run at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ package-lock.json
 **/__snapshots__/**
 src/components/dashboard/container/ListContainer.jsx
 .env
+/public/env-config.js
+env-config.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,16 @@ COPY --from=build-deps /usr/src/app/docker/default.conf /etc/nginx/conf.d/
 # Make port 80 available to the world outside the container
 EXPOSE 80
 
-# Run the nginx server
-CMD ["nginx", "-g", "daemon off;"]
+# Copy .env file and shell script to container
+WORKDIR /usr/share/nginx/html
+COPY ./init.sh .
+COPY .env .
+
+# Add bash
+RUN apk add --no-cache bash
+
+# Make our shell script executable
+RUN chmod +x init.sh
+
+# Start Nginx server
+CMD ["/bin/bash", "-c", "/usr/share/nginx/html/init.sh && nginx -g \"daemon off;\""]

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
     # git clone [the url of the repository] For example; 
     # git clone https://github.com/yourusername/openmrs-ocl-client.git
     # Create a .env file in the root directory with the variables API URL and Traditional OCL URL as shown below to access app in dev mode;
-      REACT_APP_OCL_API_HOST=https://api.qa.openconceptlab.org/
-      REACT_APP_TRADITIONAL_OCL_HOST=https://qa.openconceptlab.org
+      OCL_API_HOST=https://api.qa.openconceptlab.org/
+      TRADITIONAL_OCL_HOST=https://qa.openconceptlab.org
       
 - In the root directory of the project install all the dependencies using the command below 
     $ npm install

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Recreate config file
+rm -rf ./env-config.js
+touch ./env-config.js
+
+# Add assignment 
+echo "window.env = {" >> ./env-config.js
+
+# Read each line in .env file
+# Each line represents key=value pairs
+while read -r line || [[ -n "$line" ]];
+do
+  # Split env variables by character `=`
+  if printf '%s\n' "$line" | grep -q -e '='; then
+    varname=$(printf '%s\n' "$line" | sed -e 's/=.*//')
+    varvalue=$(printf '%s\n' "$line" | sed -e 's/^[^=]*=//')
+  fi
+
+  # Read value of current variable if exists as Environment variable
+  value=$(printf '%s\n' "${!varname}")
+  # Otherwise use value from .env file
+  [[ -z $value ]] && value=${varvalue}
+  
+  # Append configuration property to JS file
+  echo "  $varname: '$value'," >> ./env-config.js
+done < .env
+
+echo "};" >> ./env-config.js

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "uuid": "^3.3.2"
   },
   "scripts": {
-    "start": "npm run build:css && react-scripts start",
+    "start": "chmod +x ./init.sh && ./init.sh && cp env-config.js ./public/ && npm run build:css && react-scripts start",
     "build": "npm run build:css && react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="msapplication-config" content="%PUBLIC_URL%/images/favicons/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
+    <script src="./env-config.js"></script>
     <title>OpenMRS OCL client</title>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.11/css/all.css" integrity="sha384-p2jx59pefphTFIpeqCcISO9MdVfIm4pNnsL08A6v5vaQc4owkQqxMV8kg4Yvhaw/" crossorigin="anonymous">
   </head>

--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -13,7 +13,8 @@ class ConceptNameRows extends Component {
     removeRow: PropTypes.func.isRequired,
     removeDataFromRow: PropTypes.func.isRequired,
     pathName: PropTypes.object.isRequired,
-    existingConcept: PropTypes.object.isRequired,
+    // eslint-disable-next-line react/require-default-props
+    existingConcept: PropTypes.object,
     rowId: PropTypes.string,
   };
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,4 +1,4 @@
 export default {
-  OCL_API_HOST: process.env.REACT_APP_OCL_HOST || 'https://api.qa.openconceptlab.org/',
-  TRADITIONAL_OCL: process.env.REACT_APP_TRADITIONAL_OCL_HOST || 'https://qa.openconceptlab.org',
+  OCL_API_HOST: (window.env && window.env.OCL_API_HOST) || 'https://api.qa.openconceptlab.org/',
+  TRADITIONAL_OCL: (window.env && window.env.TRADITIONAL_OCL_HOST) || 'https://qa.openconceptlab.org',
 };

--- a/src/tests/dictionaryConcepts/components/ConceptNameRows.test.jsx
+++ b/src/tests/dictionaryConcepts/components/ConceptNameRows.test.jsx
@@ -9,7 +9,6 @@ const props = {
   addDataFromRow: jest.fn(),
   removeRow: jest.fn(),
   removeDataFromRow: jest.fn(),
-  existingConcept: {},
   newRow: {
     uuid: '123',
   },


### PR DESCRIPTION
# JIRA TICKET NAME:
[Passing OCL URL environment variables to run at runtime](https://issues.openmrs.org/browse/OCLOMRS-463)

# Summary:
- Create a bash script that creates an env-config.js file with key-value pairs of the environment variables.
- Load env-config.js  with the script tag in index.html
- Update the start script in package.json to run the bash script when running the app during development.
- Update the Dockerfile to copy the .env file, the bash script and also run the bash script before the build(at runtime). Then remove env-config.js from the public folder if any and add the newly created one by the bash script. 
 

**Testing.**

**In development**

- Create a .env file in the root directory and pass it;

    
`OCL_API_HOST=https://api.qa.openconceptlab.org/`
`TRADITIONAL_OCL_HOST=https://qa.openconceptlab.org`

- Then run `npm start

**In docker**

- ** Create a .env file in the root directory and pass it;

`OCL_API_HOST=https://api.qa.openconceptlab.org/`
`TRADITIONAL_OCL_HOST=https://qa.openconceptlab.org`

- Then run `docker build -t openmrs/ocl-client:local .`
- Wait for the build to finish, then run `docker-compose -f docker/docker-compose.yml up ` to run the Docker container
- Wait for the container to run, then access the app at `http://localhost:8081/`