### PR TITLE
OCLOMRS-468: Preview a CIEL concept - Add space between the last word and id inside parenthesis

### DIFF
--- a/src/components/bulkConcepts/component/PreviewCard.jsx
+++ b/src/components/bulkConcepts/component/PreviewCard.jsx
@@ -90,7 +90,7 @@ const PreviewCard = ({
       <Modal isOpen={open} className="modal-lg">
         <ModalBody className="preview-modal">
           <h6>
-            {`${display_name}(${id})`}
+            {`${display_name}  (${id})`}
             <div className="card-version">
               <small>
                 <a href={`${TRADITIONAL_OCL_BASE_URL}${url}`} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
# JIRA TICKET NAME:
[Preview a CIEL concept - Add space between the last word and id inside parenthesis](https://issues.openmrs.org/browse/OCLOMRS-468)

# Summary:
On the preview CIEL concept modal (popup), add a space between the last word in the title and the ID.