### PR TITLE
OCLOMRS-462: When a concept mapping from a specific source is removed  a user should be able to re-add it

### DIFF
--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -18,6 +18,7 @@ import {
   clearPreviousConcept,
   createNewNameForEditConcept,
   removeNameForEditConcept,
+  unretireMapping,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import { INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL } from '../components/helperFunction';
 import { fetchConceptSources } from '../../../redux/actions/bulkConcepts';
@@ -55,6 +56,7 @@ export class EditConcept extends Component {
     fetchAllConceptSources: PropTypes.func.isRequired,
     allSources: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     removeConceptMappingAction: PropTypes.func.isRequired,
+    unretireMapping: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -158,6 +160,14 @@ export class EditConcept extends Component {
 
   handleSubmit(event) {
     event.preventDefault();
+    const { mappings } = this.state;
+    const retired = mappings.filter(mapping => mapping.retired);
+    const freshMappings = mappings.filter(mapping => mapping.isNew);
+    freshMappings.forEach((mapping) => {
+      const toBeUnRetired = retired.find(m => m.to_concept_name === mapping.to_concept_name);
+      if (toBeUnRetired) this.props.unretireMapping(toBeUnRetired.url);
+    });
+
     const regx = /^[a-zA-Z\d-_]+$/;
     if (regx.test(this.state.id) && this.state.datatype && this.state.concept_class) {
       this.props.updateConcept(this.conceptUrl, this.state, this.props.history);
@@ -434,6 +444,7 @@ export default connect(
     clearPreviousConcept,
     createNewNameForEditConcept,
     removeNameForEditConcept,
+    unretireMapping,
     fetchAllConceptSources: fetchConceptSources,
     removeConceptMappingAction: removeConceptMapping,
   },

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -369,3 +369,15 @@ export const updateConcept = (conceptUrl, data, history) => async (dispatch) => 
 export const clearPreviousConcept = () => (dispatch) => {
   dispatch({ type: CLEAR_PREVIOUS_CONCEPT });
 };
+
+export const unretireMapping = url => async (dispatch) => {
+  dispatch(isFetching(true));
+  try {
+    const response = await instance.put(url, { retired: false });
+    dispatch(isSuccess(response.data, UPDATE_CONCEPT));
+    notify.show('Mapping Un-retired', 'success', 5000);
+  } catch (error) {
+    notify.show('Could not un-retire mapping', 'error', 3000);
+    dispatch(isFetching(false));
+  }
+};


### PR DESCRIPTION
# JIRA TICKET NAME:
[When a concept mapping from a specific source is removed  a user should be able to add it back ](https://issues.openmrs.org/browse/OCLOMRS-462)

# Summary:
When editing a concept, a user should be able to remove a concept mapping and re-add it. When one removes an already existing mapping then selects the same concept mapping and clicks update, the concept mapping is not added.