### PR TITLE
OCLOMRS-470: Make “Narrower-Than” the default relationship for external mappings, and “SAME-AS” the default for CIEL (when adding a mapping)

### DIFF
--- a/src/components/dictionaryConcepts/components/MapType.jsx
+++ b/src/components/dictionaryConcepts/components/MapType.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE, MAP_TYPES_DEFAULTS } from './helperFunction';
 
 const mapType = (props) => {
   const {
-    index, map_type, map_types, updateEventListener, url,
+    index, map_type, map_types, updateEventListener, url, source,
   } = props;
   return (
     <select
       tabIndex={index}
-      defaultValue={map_type}
+      value={source !== INTERNAL_MAPPING_DEFAULT_SOURCE ? MAP_TYPES_DEFAULTS[1] : map_type}
       className="form-control"
       placeholder="map type"
       type="text"
@@ -33,12 +34,14 @@ mapType.propTypes = {
   updateEventListener: PropTypes.func,
   map_types: PropTypes.array,
   url: PropTypes.string,
+  source: PropTypes.string,
 };
 
 mapType.defaultProps = {
   url: '',
   map_type: '',
   index: 0,
+  source: INTERNAL_MAPPING_DEFAULT_SOURCE,
   updateEventListener: () => {},
   map_types: ['SAME-AS', 'NARROWER-THAN', 'BROADER-THAN', 'Associated finding', 'Associated morphology',
     'Associated procedure', 'Associated with', 'Causative agent', 'Finding site', 'Has specimen', 'Laterality', 'Severity', 'Access', 'After',

--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -49,6 +49,8 @@ export const DATA_TYPES = [
   'Text',
 ];
 
+export const MAP_TYPES_DEFAULTS = ['SAME-AS', 'NARROWER-THAN'];
+
 export const INTERNAL_MAPPING_DEFAULT_SOURCE = 'CIEL';
 export const CIEL_SOURCE_URL = '/orgs/CIEL/sources/CIEL/';
 

--- a/src/tests/Signup/index.test.jsx
+++ b/src/tests/Signup/index.test.jsx
@@ -28,4 +28,60 @@ describe('Sign up Component', () => {
     wrapper.find('#firstName').simulate('change', event);
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('should handle text lastname input', () => {
+    const event = {
+      preventDefault: jest.fn(),
+      target: {
+        value: 'user',
+        name: 'lastname',
+      },
+    };
+    const spy = jest.spyOn(wrapper.find('Signup').instance(), 'handleInput');
+    wrapper.instance().forceUpdate();
+    wrapper.find('#lastname').simulate('change', event);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle text email input', () => {
+    const event = {
+      preventDefault: jest.fn(),
+      target: {
+        value: 'user@gmail.com',
+        name: 'email',
+      },
+    };
+    const spy = jest.spyOn(wrapper.find('Signup').instance(), 'handleInput');
+    wrapper.instance().forceUpdate();
+    wrapper.find('#email').simulate('change', event);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle text userName input', () => {
+    const event = {
+      preventDefault: jest.fn(),
+      target: {
+        value: 'user',
+        name: 'username',
+      },
+    };
+    const spy = jest.spyOn(wrapper.find('Signup').instance(), 'handleInput');
+    wrapper.instance().forceUpdate();
+    wrapper.find('#userName').simulate('change', event);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle text password input', () => {
+    const event = {
+      preventDefault: jest.fn(),
+      target: {
+        value: 'user',
+        name: 'password',
+      },
+    };
+    const spy = jest.spyOn(wrapper.find('Signup').instance(), 'handleInput');
+    wrapper.instance().forceUpdate();
+    wrapper.find('#password').simulate('change', event);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Make “Narrower-Than” the default relationship for external mappings, and “SAME-AS” the default for CIEL (when adding a mapping)](https://issues.openmrs.org/browse/OCLOMRS-470)

# Summary:
Make “Narrower-Than” the default relationship for external mappings (all mappings except CIEL) when adding or editing a concept mapping.