### PR TITLE
OCLOMRS-467: Fix Retired count in the table of Concepts as well as the Dictionary Overview page

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -59,7 +59,7 @@ export class DictionaryOverview extends Component {
     this.props.fetchDictionary(url);
     this.props.fetchVersions(versionUrl);
 
-    const conceptsUrl = `/${ownerType}/${owner}/collections/${name}/concepts/?q=&limit=0&page=1&verbose=true`;
+    const conceptsUrl = `/${ownerType}/${owner}/collections/${name}/concepts/?includeRetired=true&q=&limit=0&page=1&verbose=true`;
     this.props.fetchDictionaryConcepts(conceptsUrl);
   }
 

--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -20,7 +20,6 @@ const DictionaryDetailCard = (props) => {
       short_code,
       default_locale,
       url,
-      active_concepts,
     },
     versions,
     showEditModal,
@@ -145,12 +144,6 @@ Dictionary
               {Number(customConcepts) + Number(cielConcepts)}
             </p>
             <p className="points">
-              <b>Active Concepts</b>
-:
-              {' '}
-              {active_concepts}
-            </p>
-            <p className="points">
               <b>Custom Concepts</b>
 :
               {' '}
@@ -272,9 +265,6 @@ Browse in traditional OCL
     </div>
   );
 };
-DictionaryDetailCard.defaultProps = {
-  active_concepts: 0,
-};
 
 DictionaryDetailCard.propTypes = {
   dictionary: PropTypes.object.isRequired,
@@ -299,7 +289,6 @@ DictionaryDetailCard.propTypes = {
   versionDescription: PropTypes.string.isRequired,
   versionId: PropTypes.string.isRequired,
   disableButton: PropTypes.bool.isRequired,
-  active_concepts: PropTypes.number,
 };
 
 export default DictionaryDetailCard;

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -454,6 +454,52 @@ describe('DictionaryOverview', () => {
     done();
   });
 
+  it('should handle release confirmation without error', async (done) => {
+    const props = {
+      dictionary,
+      versions: [{ released: true, ...versions, customVersion }],
+      dictionaryConcepts: [dictionary],
+      isReleased: true,
+      hideVersionModal: jest.fn(),
+      showVersionModal: jest.fn(),
+      error: ['null'],
+      inputLength: 4,
+      match: {
+        params: {
+          ownerType: 'users',
+          owner: 'nesh',
+          type: 'collection',
+          name: 'test',
+        },
+      },
+      fetchDictionary: jest.fn(),
+      fetchVersions: jest.fn(),
+      fetchDictionaryConcepts: jest.fn(),
+      releaseHead: jest.fn(),
+      createVersion: jest.fn().mockImplementation(() => Promise.resolve()),
+      loader: false,
+    };
+    const event = {
+      preventDefault: jest.fn(),
+      target: {
+        value: 'v2.0',
+        name: 'versionId',
+      },
+    };
+    localStorage.setItem('username', dictionary.owner);
+    const wrapper = mount(<Provider store={store}>
+      <MemoryRouter><DictionaryOverview {...props} /></MemoryRouter>
+    </Provider>);
+    const spy = jest.spyOn(wrapper.find('DictionaryOverview').instance(), 'confirmRelease');
+    wrapper.find('#releaseVersion').simulate('click');
+    wrapper.find('Input #versionId').simulate('change', event);
+    wrapper.find('Button #saveReleaseVersion').simulate('click');
+    wrapper.find('Button #generalConfirmButton').simulate('click');
+    expect(spy).toHaveBeenCalledTimes(1);
+    await expect(props.createVersion).toHaveBeenCalled();
+    done();
+  });
+
   it('should handle a new version release with error', () => {
     const props = {
       dictionary,


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix Retired count in the table of Concepts as well as the Dictionary Overview page](https://issues.openmrs.org/browse/OCLOMRS-467)

# Summary:
- Ensure that the number of retired concepts shown in on the Dictionary overview page.
- Matches the number of retired concepts shown in the table and ensure they add up.