### PR TITLE
OCLOMRS-465: Fix error when a concept doesn't have mapping

### DIFF
--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -102,7 +102,7 @@ export class EditConcept extends Component {
   componentWillReceiveProps(newProps) {
     const { existingConcept } = newProps;
     const { mappings } = this.state;
-    if (existingConcept.mappings !== undefined
+    if (existingConcept && existingConcept.mappings
       && existingConcept.mappings.length > mappings.length) {
       this.organizeMappings(existingConcept.mappings);
     }


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix error when a concept doesn't have mapping](https://issues.openmrs.org/browse/OCLOMRS-465)

# Summary:
Create a custom concept without adding mapping. When you select that concept by clicking on the edit button on dictionary concept page it throws an error.