### PR TITLE
OCLOMRS-466: Show ellipses for long names and descriptions in Create and Edit Concept views

### DIFF
--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -103,7 +103,6 @@ class DescriptionRow extends Component {
       <tr>
         <td>
           <textarea
-            type="text"
             rows="3"
             className="form-control concept-description"
             onChange={this.handleChange}

--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -407,3 +407,7 @@ input:-webkit-autofill:active {
 .concept-code {
   margin-top: 5px;
 }
+
+input[type=text] {
+  text-overflow: ellipsis;
+}

--- a/src/styles/login.scss
+++ b/src/styles/login.scss
@@ -33,11 +33,6 @@ h4 {
   box-shadow: 0px 4px 20px #00000014;
 }
 
-.form-wrapper .form-control {
-  height: 3rem;
-  line-height: 3rem;
-}
-
 .form-wrapper .btn {
   box-shadow: none;
   height: auto;


### PR DESCRIPTION
# JIRA TICKET NAME:
[Show ellipses for long names and descriptions in Create and Edit Concept views](https://issues.openmrs.org/browse/OCLOMRS-466)

# Summary:
On the Create and Edit Concept screens, show an ellipsis (three dots) for all names and descriptions that are too long. (Those whose text is being truncated)