### PR TITLE
OCLOMRS-475: While editing a mapping when the source changes clear all the other fields in the row

### DIFF
--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -62,3 +62,4 @@ export const MAP_TYPE = {
 export const TRADITIONAL_OCL_HOST = urlConfig.TRADITIONAL_OCL_HOST;
 
 export const CUSTOM_SOURCE = 'Custom';
+export const ATTRIBUTE_NAME_SOURCE = 'source';

--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -23,7 +23,9 @@ import {
   removeSelectedAnswer,
   addNewAnswerRow,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
-import { INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL, MAP_TYPE } from '../components/helperFunction';
+import {
+  INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL, MAP_TYPE, ATTRIBUTE_NAME_SOURCE,
+} from '../components/helperFunction';
 import { fetchConceptSources } from '../../../redux/actions/bulkConcepts';
 import { removeConceptMapping } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import GeneralModel from '../../dashboard/components/dictionary/common/GeneralModal';
@@ -251,6 +253,10 @@ export class EditConcept extends Component {
       const modifyMap = map;
       if (modifyMap.url === url) {
         modifyMap[name] = value;
+      }
+      if (name === ATTRIBUTE_NAME_SOURCE) {
+        modifyMap.to_concept_code = '';
+        modifyMap.to_concept_name = '';
       }
       return modifyMap;
     });

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -408,6 +408,25 @@ describe('Test suite for mappings on existing concepts', () => {
     expect(instance.state.mappings[0].to_concept_code).not.toEqual(null);
   });
 
+  it('should call updateEventListener function on source change', () => {
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'source',
+        value: '',
+      },
+    };
+    const url = '1234';
+    const { value } = event.target;
+    const instance = wrapper.find('EditConcept').instance();
+    const spy = jest.spyOn(instance, 'updateEventListener');
+    instance.updateEventListener({ target: { tabIndex: 0, name: INTERNAL_MAPPING_DEFAULT_SOURCE, value: '' } });
+    instance.updateEventListener(event, url);
+    wrapper.find('.form-control').at(0).simulate('select');
+    expect(spy).toHaveBeenCalled();
+    expect(instance.state.mappings[0].to_concept_code).toEqual(value);
+  });
+
   it('should call updateEventListener function with internal mapping', () => {
     const event = {
       target: {


### PR DESCRIPTION
# JIRA TICKET NAME:
[While editing a mapping when the source changes clear all the other fields in the row.](https://issues.openmrs.org/browse/OCLOMRS-475)

# Summary:
When editing a mapping, clear all editable fields when the mappings' source is changed.
