### PR TITLE
OCLOMRS-478: When adding a CIEL mapping or Bulk Concepts, execute a search only when ENTER is pressed

### DIFF
--- a/src/components/bulkConcepts/addBulkConcepts.jsx
+++ b/src/components/bulkConcepts/addBulkConcepts.jsx
@@ -11,6 +11,7 @@ import {
 import Loader from '../Loader';
 import fetchSourceConcepts, { addExistingBulkConcepts, isConceptValid, fetchConceptSources } from '../../redux/actions/bulkConcepts';
 import Header from './container/Header';
+import { KEY_CODE_FOR_ENTER } from '../dictionaryConcepts/components/helperFunction';
 import ResultModal from './component/addBulkConceptResultModal';
 
 export class AddBulkConcepts extends Component {
@@ -40,6 +41,7 @@ export class AddBulkConcepts extends Component {
       conceptIds: '',
       openResultModal: false,
       otherSelected: false,
+      value: '',
     };
     this.invalidConceptIds = [];
     this.sourceUrl = 'orgs/CIEL/sources/CIEL/';
@@ -112,6 +114,15 @@ export class AddBulkConcepts extends Component {
   closeResultModal = () => {
     this.invalidConceptIds = [];
     this.setState({ openResultModal: false });
+  }
+
+  onKeyDown = (event, onKeyDown, onChange) => {
+    this.setState({ value: event.target.value });
+    if (event.keyCode === KEY_CODE_FOR_ENTER) {
+      event.preventDefault();
+      onChange(event);
+      onKeyDown(event);
+    }
   }
 
   render() {
@@ -221,7 +232,7 @@ export class AddBulkConcepts extends Component {
                                   .map((item, index) => (
                                     <li
                                       {...getItemProps({
-                                        key: item.id,
+                                        key: item.name,
                                         index,
                                         item,
                                         style: {
@@ -280,7 +291,20 @@ export class AddBulkConcepts extends Component {
                             className="form-control search"
                             id="search"
                             placeholder="search"
+                            value={this.state.value}
                             aria-label="Search"
+                            onChange={e => this.onKeyDown(
+                              e,
+                              getInputProps().onKeyDown,
+                              getInputProps().onChange,
+                            )}
+                            onKeyDown={
+                              e => this.onKeyDown(
+                                e,
+                                getInputProps().onKeyDown,
+                                getInputProps().onChange,
+                              )}
+                            {...getInputProps().rest}
                           />
                           {isLoading
                               && <div className="ml-auto text-right">

--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -231,6 +231,7 @@ const CreateConceptForm = (props) => {
                       isEditConcept={isEditConcept}
                       isNew={mapping.isNew}
                       allSources={allSources}
+                      isShown={false}
                     />
                   ))}
                 </tbody>

--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -63,3 +63,4 @@ export const TRADITIONAL_OCL_HOST = urlConfig.TRADITIONAL_OCL_HOST;
 
 export const CUSTOM_SOURCE = 'Custom';
 export const ATTRIBUTE_NAME_SOURCE = 'source';
+export const KEY_CODE_FOR_ENTER = 13;

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -268,14 +268,18 @@ export const addConceptToDictionary = (id, dataUrl) => async (dispatch) => {
 };
 
 export const fetchSourceConcepts = async (source, query, index) => {
-  const url = `/orgs/${source}/sources/${source}/concepts/?q=${query}*&limit=0&verbose=true`;
-  const response = await instance.get(url);
-  const options = response.data.map(concept => ({
-    value: concept.url,
-    label: `ID(${concept.id}) - ${concept.display_name}`,
-    index,
-  }));
-  return options;
+  try {
+    const url = `/orgs/${source}/sources/${source}/concepts/?q=${query}*&limit=0&verbose=true`;
+    const response = await instance.get(url);
+    const options = response.data.map(concept => ({
+      value: concept.url,
+      label: `ID(${concept.id}) - ${concept.display_name}`,
+      index,
+    }));
+    return options;
+  } catch (error) {
+    return [];
+  }
 };
 
 export const CreateMapping = (data, from_concept_url, source) => {

--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -411,3 +411,31 @@ input:-webkit-autofill:active {
 input[type=text] {
   text-overflow: ellipsis;
 }
+
+.conceptDetails {
+  max-height: 80px;
+}
+.cielConceptsList {
+  border: 1px solid #bbb;
+  border-radius: 3px;
+  padding: 5px;
+  background: #F4f4f4;
+  z-index: 10;
+
+  li {
+    display: block;
+    margin: 1px;
+    padding: 5px;
+  }
+  li:hover {
+    background: #cccccc;
+  }
+  button {
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    text-align: left;
+  }
+}

--- a/src/tests/bulkConcepts/addBulkConcepts.test.jsx
+++ b/src/tests/bulkConcepts/addBulkConcepts.test.jsx
@@ -8,6 +8,7 @@ import Authenticated from '../__mocks__/fakeStore';
 import { AddBulkConcepts, mapStateToProps } from '../../components/bulkConcepts/addBulkConcepts';
 import { mockConcepts } from '../__mocks__/concepts';
 import configInstance from '../../config/axiosConfig';
+import { KEY_CODE_FOR_ENTER } from '../../components/dictionaryConcepts/components/helperFunction';
 
 const store = createMockStore(Authenticated);
 const match = {
@@ -113,13 +114,14 @@ describe('Add Bulk Concepts', () => {
       </Provider>
     </MemoryRouter>);
     const input = wrapper.find('#search');
-    input.simulate('change', { target: { value: '' } });
+    input.simulate('change', { target: { value: 'Bronze Diabetes' } });
     input.simulate('keydown', { key: 'ArrowDown' });
-    input.simulate('keydown', { key: 'Enter' });
+    input.simulate('keydown', { keyCode: KEY_CODE_FOR_ENTER });
     expect(input.instance().value).toEqual('Bronze Diabetes');
     const txtInput = wrapper.find('#idsText').at(0);
-    expect(txtInput.instance().props.value).toEqual('1');
+    expect(txtInput.instance().props.value).toEqual('');
   });
+
 
   it('can search for concept that does not exist', () => {
     const wrapper = mount(<MemoryRouter>
@@ -130,7 +132,7 @@ describe('Add Bulk Concepts', () => {
     const input = wrapper.find('#search');
     input.simulate('change', { target: { value: 'non existent' } });
     input.simulate('keydown', { key: 'ArrowDown' });
-    input.simulate('keydown', { key: 'Enter' });
+    input.simulate('keydown', { keyCode: KEY_CODE_FOR_ENTER });
     const txtInput = wrapper.find('#idsText').at(0);
     expect(txtInput.instance().props.value).toEqual('');
   });
@@ -214,7 +216,7 @@ describe('Add Bulk Concepts', () => {
     const other = wrapper.find('#otherSourcesOption');
     other.simulate('click');
     const input = wrapper.find('#sourceSearch');
-    input.simulate('change', { target: { value: '' } });
+    input.simulate('change', { target: { value: 'testSource' } });
     input.simulate('keydown', { key: 'ArrowDown' });
     input.simulate('keydown', { key: 'Enter' });
     expect(input.instance().value).toEqual('testSource');

--- a/src/tests/dictionaryConcepts/components/CreateMapping.test.js
+++ b/src/tests/dictionaryConcepts/components/CreateMapping.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { MemoryRouter as Router } from 'react-router';
 import CreateMapping from '../../../components/dictionaryConcepts/components/CreateMapping';
-import { INTERNAL_MAPPING_DEFAULT_SOURCE } from '../../../components/dictionaryConcepts/components/helperFunction';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE, KEY_CODE_FOR_ENTER } from '../../../components/dictionaryConcepts/components/helperFunction';
 import { mockSource } from '../../__mocks__/concepts';
-import { wrap } from 'module';
+
 
 describe('Test suite for dictionary concepts components', () => {
   const props = {
@@ -39,7 +39,7 @@ describe('Test suite for dictionary concepts components', () => {
     </Router>);
 
     const inputField = wrapper.find('CreateMapping');
-    inputField.find('#to_concept_code').simulate('change');
+    inputField.find('#searchInputNotCiel').simulate('change');
     expect(props.updateEventListener).toHaveBeenCalled();
   });
 
@@ -75,15 +75,183 @@ describe('Test suite for dictionary concepts components', () => {
     const inputs = wrapper.find('select');
     expect(inputs).toHaveLength(2);
   });
-  it('should set the default relationship when source changes.'
-  + 'Selecting a new relationship updates the state and map_type props with the new relationship details.', () => {
-    wrapper = mount(<CreateMapping {...props} />);
-    const nextProps = {
+
+  it('should handle update of new mappings row source data when isNew is true', () => {
+    const newProps = {
       ...props,
-      source: 'MapTypes',
-      map_type: 'Associated With',
+      isNew: true,
     };
-    wrapper.setProps(nextProps);
-    expect(wrapper.instance().props.map_type).toEqual('Associated With');
+
+    wrapper = mount(<Router>
+      <table><tbody><CreateMapping {...newProps} /></tbody></table>
+    </Router>);
+    const inputField = wrapper.find('CreateMapping');
+    inputField.find('#source').simulate('change');
+    expect(props.updateEventListener).toHaveBeenCalled();
+  });
+
+  it('should handel update of new mappings row data for non Ciel concepts when isNew is true', () => {
+    const newProps = {
+      ...props,
+      isNew: true,
+      source: 'Classes',
+    };
+
+    wrapper = mount(<Router>
+      <table><tbody><CreateMapping {...newProps} /></tbody></table>
+    </Router>);
+    const inputField = wrapper.find('CreateMapping');
+    inputField.find('#to_concept_code').simulate('change');
+    expect(props.updateEventListener).toHaveBeenCalled();
+  });
+
+  it('should handle update of new mappings row concept name for Ciel concepts when isNew is true', () => {
+    const newProps = {
+      ...props,
+      isNew: true,
+      source: 'maptypes',
+    };
+
+    wrapper = mount(<Router>
+      <table><tbody><CreateMapping {...newProps} /></tbody></table>
+    </Router>);
+    const inputField = wrapper.find('CreateMapping');
+    inputField.find('#ConceptName').simulate('change');
+    expect(props.updateEventListener).toHaveBeenCalled();
+  });
+
+  it('should handle change when a user inputs concept name mappings data for for existing concepts', () => {
+    const newProps = {
+      ...props,
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+    };
+
+    wrapper = mount(<Router>
+      <table><tbody><CreateMapping {...newProps} /></tbody></table>
+    </Router>);
+
+    const inputField = wrapper.find('CreateMapping');
+    const spy = jest.spyOn(inputField.instance(), 'handleInputChange');
+    inputField.find('#searchInputCiel').simulate('change');
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should handle change when a user inputs concept name mappings data for new rows when isNew is true', () => {
+    const newProps = {
+      ...props,
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      isNew: true,
+    };
+
+    wrapper = mount(<Router>
+      <table><tbody><CreateMapping {...newProps} /></tbody></table>
+    </Router>);
+
+    const inputField = wrapper.find('CreateMapping');
+    const spy = jest.spyOn(inputField.instance(), 'handleInputChange');
+    inputField.find('#searchInputCielIsnew').simulate('change');
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('Should handle key down event when a user presses the enter button to search mappings for existing rows', () => {
+    const newProps = {
+      ...props,
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+    };
+
+    wrapper = mount(<Router>
+      <table><tbody><CreateMapping {...newProps} /></tbody></table>
+    </Router>);
+
+    const inputField = wrapper.find('CreateMapping');
+    const spy = jest.spyOn(inputField.instance(), 'handleKeyPress');
+    const event = { key: 'Space' };
+    inputField.find('#searchInputCiel').simulate('keyDown', event);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('Should handle click event when a user click to select a prefered concept name for existing rows', () => {
+    const newProps = {
+      ...props,
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      isNew: false,
+      isShown: true,
+    };
+
+    wrapper = mount(<table><tbody><CreateMapping {...newProps} /></tbody></table>);
+
+    const inputField = wrapper.find('CreateMapping');
+    inputField.setState({
+      options: [{
+        index: '1',
+        label: 'mala',
+        value: '/orgs/CIEL/sources/CIEL/concepts/32/',
+      }],
+    }, () => {
+      const spy = jest.spyOn(inputField.instance(), 'handleSelect');
+      wrapper.find('#selectMappingnotNew').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  it('should handle click when a user click to select a prefered concept mapping name for new rows', () => {
+    const newProps = {
+      ...props,
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      isNew: true,
+      isShown: true,
+    };
+
+    wrapper = mount(<table><tbody><CreateMapping {...newProps} /></tbody></table>);
+
+    const inputField = wrapper.find('CreateMapping');
+    inputField.setState({
+      options: [{
+        index: '1',
+        label: 'mala',
+        value: '/orgs/CIEL/sources/CIEL/concepts/32/',
+      }],
+    }, () => {
+      const spy = jest.spyOn(inputField.instance(), 'handleSelect');
+      wrapper.find('#selectMappingNew').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  it('should handle key down event when a user presses the enter button to search mappings for existing rows', () => {
+    const newProps = {
+      ...props,
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+    };
+
+    wrapper = mount(<Router>
+      <table><tbody><CreateMapping {...newProps} /></tbody></table>
+    </Router>);
+
+    const inputField = wrapper.find('CreateMapping');
+    const spy = jest.spyOn(inputField.instance(), 'handleKeyPress');
+    const event = { keyCode: KEY_CODE_FOR_ENTER };
+    inputField.find('#searchInputCiel').simulate('keyDown', event);
+    expect(spy).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it('should handle key down event when a user presses the enter button to search mappings for new rows (isNew is true)', () => {
+    const newProps = {
+      ...props,
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      isNew: true,
+    };
+
+    wrapper = mount(<Router>
+      <table><tbody><CreateMapping {...newProps} /></tbody></table>
+    </Router>);
+
+    const inputField = wrapper.find('CreateMapping');
+    const spy = jest.spyOn(inputField.instance(), 'handleKeyPress');
+    const event = { keyCode: KEY_CODE_FOR_ENTER };
+    inputField.find('#searchInputCielIsnew').simulate('keyDown', event);
+    expect(spy).toHaveBeenCalled();
+    wrapper.unmount();
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[When adding a CIEL mapping or Bulk Concepts, execute a search only when ENTER is pressed](https://issues.openmrs.org/browse/OCLOMRS-478)

# Summary:
When adding a CIEL mapping, execute a search only when ENTER is pressed in order to be consistent with other searches, and to avoid multiple calls to the backend at every keystroke. Repeat the same behaviour for the Add Bulk Concepts search fields.