### PR TITLE
OCLOMRS-483: On the Q-AND-A page show CIEL instead of INTERNAL_MAPPING_DEFAULT_SOURCE on the source drop down under answers

### DIFF
--- a/src/components/dictionaryConcepts/components/AnswerRow.jsx
+++ b/src/components/dictionaryConcepts/components/AnswerRow.jsx
@@ -52,7 +52,7 @@ class AnswerRow extends React.Component {
               >
                 <option value={localStorage.getItem('dictionaryId')}>{currentDictionaryName}</option>
                 <option value={INTERNAL_MAPPING_DEFAULT_SOURCE}>
-                INTERNAL_MAPPING_DEFAULT_SOURCE
+                  {INTERNAL_MAPPING_DEFAULT_SOURCE}
                 </option>
               </select>
             )


### PR DESCRIPTION
# JIRA TICKET NAME:
[On the Q-AND-A page show CIEL instead of INTERNAL_MAPPING_DEFAULT_SOURCE on the source drop down under answers](https://issues.openmrs.org/browse/OCLOMRS-483)

# Summary:
The answer source drop down shows INTERNAL_MAPPING_DEFAULT_SOURCE, a constant used in the code, instead of CIEL. This ticket fixes that.
