### PR TITLE
OCLOMRS-486: Get rid of the “Remove” button for custom concepts

### DIFF
--- a/src/components/dictionaryConcepts/components/ActionButtons.jsx
+++ b/src/components/dictionaryConcepts/components/ActionButtons.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import { CUSTOM_SOURCE } from './helperFunction';
 
 const ActionButtons = ({
   actionButtons,
+  source,
   id,
   concept_class,
   showDeleteModal,
@@ -15,7 +17,6 @@ const ActionButtons = ({
   if (actionButtons === true) {
     showExtra = true;
   }
-
   return (
     !retired && <React.Fragment>
       {showExtra && (
@@ -28,14 +29,18 @@ const ActionButtons = ({
           </Link>
         </React.Fragment>
       )}
-      <button
-        type="button"
-        className="btn btn-sm mb-1 actionButtons action-btn-style"
-        id="retireConcept"
-        onClick={() => { showDeleteModal(version_url); }}
-      >
-      Remove
-      </button>
+      {source !== CUSTOM_SOURCE && (
+        <button
+          type="button"
+          className="btn btn-sm mb-1 actionButtons action-btn-style"
+          id="retireConcept"
+          onClick={() => {
+            showDeleteModal(version_url);
+          }}
+        >
+          Remove
+        </button>
+      )}
     </React.Fragment>
   );
 };

--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -60,3 +60,5 @@ export const MAP_TYPE = {
 };
 
 export const TRADITIONAL_OCL_HOST = urlConfig.TRADITIONAL_OCL_HOST;
+
+export const CUSTOM_SOURCE = 'Custom';


### PR DESCRIPTION
# JIRA TICKET NAME:
[Get rid of the “Remove” button for custom concepts](https://issues.openmrs.org/browse/OCLOMRS-486)

# Summary:
Before this, when viewing a dictionary, the "Remove" button was being shown on all the concepts. This PR eliminates this button on custom concepts.