### PR TITLE
OCLOMRS-482: Fix Mapping relationship in Edit and Create to allow cha…

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateMapping.jsx
+++ b/src/components/dictionaryConcepts/components/CreateMapping.jsx
@@ -2,17 +2,42 @@ import React, { Component } from 'react';
 import AsyncSelect from 'react-select/lib/Async';
 import PropTypes from 'prop-types';
 import { fetchSourceConcepts } from '../../../redux/actions/concepts/dictionaryConcepts';
-import { INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL } from './helperFunction';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL, MAP_TYPES_DEFAULTS } from './helperFunction';
 import MapType from './MapType';
 
 class CreateMapping extends Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      type: '',
+      editMapType: '',
+    };
   }
 
   handleInputChange = (value) => {
     this.setState({ inputValue: value });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      type: nextProps.map_type,
+    });
+  }
+
+  componentWillMount() {
+    const editMapType = this.props.source;
+    this.setState({
+      editMapType,
+    });
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.source !== this.props.source) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({
+        type: '',
+      });
+    }
   }
 
   render() {
@@ -22,6 +47,9 @@ class CreateMapping extends Component {
       updateEventListener, removeMappingRow, updateAsyncSelectValue,
       isNew, allSources, url,
     } = this.props;
+    const nullEditMapType = (source !== INTERNAL_MAPPING_DEFAULT_SOURCE ? this.state.type
+      || MAP_TYPES_DEFAULTS[1] : this.state.type || MAP_TYPES_DEFAULTS[0]);
+
     return (
       <tr>
         <td>
@@ -43,13 +71,16 @@ class CreateMapping extends Component {
           </select>}
         </td>
         <td>
-          {<MapType
-            updateEventListener={updateEventListener}
-            url={url}
-            index={index}
-            map_type={map_type}
-            source={source}
-          />}
+
+          {
+            <MapType
+              updateEventListener={updateEventListener}
+              url={url}
+              index={index}
+              map_type={this.state.editMapType === null ? nullEditMapType : map_type}
+            />
+          }
+
         </td>
 
         <td className="react-async">

--- a/src/components/dictionaryConcepts/components/MapType.jsx
+++ b/src/components/dictionaryConcepts/components/MapType.jsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { INTERNAL_MAPPING_DEFAULT_SOURCE, MAP_TYPES_DEFAULTS } from './helperFunction';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE } from './helperFunction';
 
 const mapType = (props) => {
   const {
-    index, map_type, map_types, updateEventListener, url, source,
+    index, map_type, map_types, updateEventListener, url,
   } = props;
+
   return (
     <select
       tabIndex={index}
-      value={source !== INTERNAL_MAPPING_DEFAULT_SOURCE ? MAP_TYPES_DEFAULTS[1] : map_type}
+      value={map_type}
       className="form-control"
       placeholder="map type"
       type="text"

--- a/src/tests/dictionaryConcepts/components/CreateMapping.test.js
+++ b/src/tests/dictionaryConcepts/components/CreateMapping.test.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { MemoryRouter as Router } from 'react-router';
 import CreateMapping from '../../../components/dictionaryConcepts/components/CreateMapping';
 import { INTERNAL_MAPPING_DEFAULT_SOURCE } from '../../../components/dictionaryConcepts/components/helperFunction';
 import { mockSource } from '../../__mocks__/concepts';
+import { wrap } from 'module';
 
 describe('Test suite for dictionary concepts components', () => {
   const props = {
@@ -73,5 +74,16 @@ describe('Test suite for dictionary concepts components', () => {
     </Router>);
     const inputs = wrapper.find('select');
     expect(inputs).toHaveLength(2);
+  });
+  it('should set the default relationship when source changes.'
+  + 'Selecting a new relationship updates the state and map_type props with the new relationship details.', () => {
+    wrapper = mount(<CreateMapping {...props} />);
+    const nextProps = {
+      ...props,
+      source: 'MapTypes',
+      map_type: 'Associated With',
+    };
+    wrapper.setProps(nextProps);
+    expect(wrapper.instance().props.map_type).toEqual('Associated With');
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix Mapping relationship in Edit and Create to allow changing to other relationship types.](https://issues.openmrs.org/browse/OCLOMRS-482)

# Summary:

- When creating or editing a new mapping, if a user changed the source from CIEL to anything else, the user could not edit the relationship field from the default value: Narrower-than. 

- Currently, when a user changes the value for the source from CIEL to anything else, he should be able to change the value for the relationship to any field.