### PR TITLE
OCLOMRS-485: Mulago (Dictionary) - show the words in parenthesis and CIEL (Source) - show the words in parenthesis	

### DIFF
--- a/src/components/dictionaryConcepts/components/AnswerRow.jsx
+++ b/src/components/dictionaryConcepts/components/AnswerRow.jsx
@@ -50,9 +50,13 @@ class AnswerRow extends React.Component {
                 onChange={event => this.handleChangeInSource(event)}
                 required
               >
-                <option value={localStorage.getItem('dictionaryId')}>{currentDictionaryName}</option>
+                <option value={localStorage.getItem('dictionaryId')}>
+                  {currentDictionaryName}
+                  &nbsp;(Dictionary)
+                </option>
                 <option value={INTERNAL_MAPPING_DEFAULT_SOURCE}>
-                INTERNAL_MAPPING_DEFAULT_SOURCE
+                  {INTERNAL_MAPPING_DEFAULT_SOURCE}
+                  &nbsp;(Source)
                 </option>
               </select>
             )


### PR DESCRIPTION
# JIRA TICKET NAME:
[Mulago (Dictionary) - show the words in parenthesis and CIEL (Source) - show the words in parenthesis](https://issues.openmrs.org/browse/OCLOMRS-485)

# Summary:

- On the Create a question concept page, Under Answers section, the concept and the dictionary are not clearly differentiated. 