### PR TITLE
OCLOMRS-489: Raise Test Coverage

### DIFF
--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -399,8 +399,10 @@ export const unretireMapping = url => async (dispatch) => {
     const response = await instance.put(url, { retired: false });
     dispatch(isSuccess(response.data, UPDATE_CONCEPT));
     notify.show('Mapping Un-retired', 'success', 5000);
+    return response.data;
   } catch (error) {
     notify.show('Could not un-retire mapping', 'error', 3000);
     dispatch(isFetching(false));
+    return null;
   }
 };

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -62,6 +62,7 @@ import {
   removeSelectedAnswer,
   unpopulatePrepopulatedAnswers,
   prepopulateAnswers,
+  unretireMapping,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import {
   removeDictionaryConcept,
@@ -666,6 +667,40 @@ describe('Testing Edit concept actions ', () => {
     const conceptUrl = '/orgs/EthiopiaNHDD/sources/HMIS-Indicators/concepts/C1.1.1.1/';
     return store.dispatch(updateConcept(conceptUrl, existingConcept, history)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should unretire a Mapping when the unretireMapping action is triggered', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({ status: 200, response: existingConcept });
+    });
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: UPDATE_CONCEPT, payload: existingConcept },
+    ];
+    const store = mockStore(mockConceptStore);
+    const conceptUrl = '/orgs/EthiopiaNHDD/sources/HMIS-Indicators/concepts/C1.1.1.1/';
+    return store.dispatch(unretireMapping(conceptUrl)).then((result) => {
+      expect(store.getActions()).toEqual(expectedActions);
+      expect(result.retired).toEqual(false);
+    });
+  });
+
+  it('should handle exceptions for unretire a Mapping', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({ status: 400 });
+    });
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: IS_FETCHING, payload: false },
+    ];
+    const store = mockStore(mockConceptStore);
+    const conceptUrl = '/orgs/EthiopiaNHDD/sources/HMIS-Indicators/concepts/C1.1.1.1/';
+    return store.dispatch(unretireMapping(conceptUrl)).then((result) => {
+      expect(store.getActions()).toEqual(expectedActions);
+      expect(result).toEqual(null);
     });
   });
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[Raise Test Coverage](https://issues.openmrs.org/browse/OCLOMRS-489)

# Summary:
Fix the drop in test coverage in the "dictionaryConcepts.js" file. This was discovered in this [PR](https://github.com/openmrs/openmrs-ocl-client/pull/378) and was due to an untested Action called *unretireMapping*