### PR TITLE
OCLOMRS-490: Fix and add remove button on dictionary concepts page with class Concept Class

### DIFF
--- a/src/components/dictionaryConcepts/components/ActionButtons.jsx
+++ b/src/components/dictionaryConcepts/components/ActionButtons.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { CUSTOM_SOURCE } from './helperFunction';
+import { CUSTOM_SOURCE, CONCEPT_CLASS } from './helperFunction';
 
 const ActionButtons = ({
   actionButtons,
@@ -14,13 +14,14 @@ const ActionButtons = ({
   retireConcept,
 }) => {
   const dictionaryPathName = localStorage.getItem('dictionaryPathName');
+  const showButton = source !== CUSTOM_SOURCE || concept_class === CONCEPT_CLASS;
   let showExtra;
   if (actionButtons === true) {
     showExtra = true;
   }
   return (
     <React.Fragment>
-      {source !== CUSTOM_SOURCE && (
+      {showButton && (
         <button
           type="button"
           className="btn btn-sm mb-1 actionButtons action-btn-style"

--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -63,3 +63,5 @@ export const TRADITIONAL_OCL_HOST = urlConfig.TRADITIONAL_OCL_HOST;
 
 export const CUSTOM_SOURCE = 'Custom';
 export const ATTRIBUTE_NAME_SOURCE = 'source';
+export const KEY_CODE_FOR_ENTER = 13;
+export const CONCEPT_CLASS = 'Concept Class';


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-490](https://issues.openmrs.org/browse/OCLOMRS-490)

# Summary:
While viewing Concepts of a specific Dictionary, the "Remove" button/action is also be available for Concepts with the class, "Concept Class"