### PR TITLE
OCLOMRS-494: Refreshing the Edit Page causes two versions of the same Concept to be created

### DIFF
--- a/src/redux/reducers/store.js
+++ b/src/redux/reducers/store.js
@@ -38,9 +38,7 @@ const store = createStore(
 );
 
 store.subscribe(() => {
-  saveState({
-    users: { loggedIn: store.getState().users.loggedIn },
-  });
+  saveState(store.getState());
 });
 
 export default store;


### PR DESCRIPTION
# JIRA TICKET NAME:
[Refreshing the Edit Page causes two versions of the same Concept to be created](https://issues.openmrs.org/browse/OCLOMRS-494)

# Summary:
After Editing a Concept, its reference to the Dictionary is supposed to be deleted and then recreated. However, this reference cannot be deleted when the page is refreshed because the version_url is lost. This is solved by preserving the State.