### PR TITLE
OCLOMRS-495: Fix the occurrence of the message returned below the search fields on the All dictionaries and Add CIEL concepts pages

### DIFF
--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { NotificationContainer, NotificationManager } from 'react-notifications';
+import { notify } from 'react-notify-toast';
 import SideNav from '../component/Sidenav';
 import SearchBar from '../component/SearchBar';
 import ConceptTable from '../component/ConceptTable';
@@ -122,7 +122,7 @@ export class BulkConceptsPage extends Component {
       const query = `q=${searchInput.trim()}*`; // The asterisk permits partial search
       const { currentPage, fetchFilteredConcepts: fetchedFilteredConcepts } = this.props;
       fetchedFilteredConcepts(INTERNAL_MAPPING_DEFAULT_SOURCE, query, currentPage);
-    } else NotificationManager.warning(MIN_CHARACTERS_WARNING, '', MILLISECONDS_TO_SHOW_WARNING);
+    } else notify.show(MIN_CHARACTERS_WARNING, 'error', MILLISECONDS_TO_SHOW_WARNING);
   }
 
   handleSearch = async (event) => {
@@ -181,7 +181,6 @@ export class BulkConceptsPage extends Component {
               handleChange={this.handleChange}
               searchInput={searchInput}
             />
-            <NotificationContainer />
             <ConceptTable
               concepts={concepts}
               loading={loading}

--- a/src/components/dashboard/container/DictionariesDisplay.jsx
+++ b/src/components/dashboard/container/DictionariesDisplay.jsx
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from 'react';
 import autoBind from 'react-autobind';
 import propTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { NotificationContainer, NotificationManager } from 'react-notifications';
+import { notify } from 'react-notify-toast';
 import {
   fetchDictionaries,
   searchDictionaries,
@@ -48,7 +48,7 @@ export class DictionaryDisplay extends Component {
     const { searchInput } = this.state;
     if (searchInput && searchInput.trim().length > 2) {
       this.props.searchDictionaries(`${searchInput}*`); // asterisk added to allow partial search
-    } else NotificationManager.warning(MIN_CHARACTERS_WARNING, '', MILLISECONDS_TO_SHOW_WARNING);
+    } else notify.show(MIN_CHARACTERS_WARNING, 'error', MILLISECONDS_TO_SHOW_WARNING);
   }
 
   onSearch(event) {
@@ -96,7 +96,6 @@ export class DictionaryDisplay extends Component {
               searchValue={searchInput}
               fetching={isFetching}
             />
-            <NotificationContainer />
           </div>
         </div>
         <Paginations

--- a/src/tests/Dashboard/container/DictionaryDisplay.test.jsx
+++ b/src/tests/Dashboard/container/DictionaryDisplay.test.jsx
@@ -13,6 +13,8 @@ import {
 import ListDictionaries from '../../../components/dashboard/components/dictionary/ListDictionaries';
 import DictionaryCard from '../../../components/dashboard/components/dictionary/DictionaryCard';
 
+jest.mock('react-notify-toast');
+
 describe('DictionaryDisplay', () => {
   it('should render without any dictionary data', () => {
     const props = {


### PR DESCRIPTION


# JIRA TICKET NAME:
[Fix the occurrence of the message returned below the search fields on the "All dictionaries" and "Add CIEL concepts " pages](https://issues.openmrs.org/browse/OCLOMRS-495)

# Summary:
On the "All dictionaries" and "Add CIEL concepts " pages, when a user searches for anything less than three characters and the search button clicked multiple times, the 'Search query must contain at least 3 characters' message uncharacteristically appears multiple times.
