### PR TITLE
OCLOMRS-500: Raise Test Coverage

### DIFF
--- a/src/components/dictionaryConcepts/components/AnswerRow.jsx
+++ b/src/components/dictionaryConcepts/components/AnswerRow.jsx
@@ -91,6 +91,7 @@ class AnswerRow extends React.Component {
               toConceptName,
               prePopulated,
             )}
+            id="removeAnswer"
           >
                 remove
           </button>

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -558,4 +558,8 @@ describe('Test suite for mappings on existing concepts', () => {
     instance.removeAnswerRow('uniqueKey', true, 'url', 'name', 'code', true);
     expect(spy).toHaveBeenCalled();
   });
+  it('should call removeAnswer and remove the anwser row when a user clicks the remove button while creating a Q-A concept', () => {
+    wrapper.find('button#removeAnswer').simulate('click');
+    expect(props.removeAnswer).toHaveBeenCalledWith(props.selectedAnswers[0].frontEndUniqueKey);
+  });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Raise Test Coverage](https://issues.openmrs.org/browse/OCLOMRS-500)

# Summary:
Fix the drop in test coverage in the "EditConcepts.jsx" file. This was discovered in this [PR](https://github.com/openmrs/openmrs-ocl-client/pull/389) and was due to an if else statement found in the removeAnswerRow function not being fully tested

