### PR TITLE
OCLOMRS-497: The warning should not appear if no changes were made on the Edit and Create concept pages when Cancel is clicked

### DIFF
--- a/src/components/dashboard/components/dictionary/common/GeneralModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/GeneralModal.jsx
@@ -26,19 +26,19 @@ const GeneralModal = (props) => {
 
         <ModalFooter>
           <Button
-            className="btn btn-primary mr-1"
-            id="generalConfirmButton"
-            onClick={select_confirm}
-          >
-            {confirm_button}
-          </Button>
-
-          <Button
-            className="btn btn-danger"
+            className="btn btn-primary stayButton primaryButton"
             id="sub-cancel"
             onClick={hide}
           >
             {cancel_button}
+          </Button>
+
+          <Button
+            className="btn btn-danger mr-1 leaveButton"
+            id="generalConfirmButton"
+            onClick={select_confirm}
+          >
+            {confirm_button}
           </Button>
         </ModalFooter>
       </Modal>

--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -250,7 +250,7 @@ const CreateConceptForm = (props) => {
           <button className="btn btn-primary mr-1" type="submit" disabled={props.disableButton}>
             {props.isEditConcept ? 'Update' : 'Create' }
           </button>
-          <button id="remove" className="btn btn-danger" type="button" onClick={props.showModal}>
+          <button id="remove" className="btn btn-danger cancelButton" type="button" onClick={props.showModal}>
             Cancel
           </button>
         </div>

--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -60,7 +60,11 @@ export const MAP_TYPE = {
 };
 
 export const TRADITIONAL_OCL_HOST = urlConfig.TRADITIONAL_OCL_HOST;
-
+export const CANCEL_WARNING = 'You have unsaved changes. Do you wish to leave without saving these changes?';
+export const LEAVE_PAGE_POPUP_TITLE = 'Are you sure you want to leave this page?';
+export const LEAVE_PAGE = 'Leave';
+export const STAY_ON_PAGE = 'Stay';
+export const INTERNET_ERROR = 'An error occurred with your internet connection, please fix it and try reloading the page.';
 export const CUSTOM_SOURCE = 'Custom';
 export const ATTRIBUTE_NAME_SOURCE = 'source';
 export const KEY_CODE_FOR_ENTER = 13;

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -18,7 +18,10 @@ import {
   addNewAnswerRow,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import { fetchConceptSources } from '../../../redux/actions/bulkConcepts';
-import { MAP_TYPE } from '../components/helperFunction';
+import {
+  MAP_TYPE, CANCEL_WARNING, LEAVE_PAGE, STAY_ON_PAGE, LEAVE_PAGE_POPUP_TITLE,
+} from '../components/helperFunction';
+import GeneralModel from '../../dashboard/components/dictionary/common/GeneralModal';
 
 export class CreateConcept extends Component {
   static propTypes = {
@@ -80,8 +83,9 @@ export class CreateConcept extends Component {
         retired: false,
         url: uuid(),
       }],
+      show: false,
     };
-
+    this.oldState = {};
     autoBind(this);
   }
 
@@ -95,14 +99,9 @@ export class CreateConcept extends Component {
     } = this.props;
     unpopulateSelectedAnswers();
     const concept = conceptType || '';
-    const { newName, description } = this.props;
-    if (newName.length === 0) {
-      this.props.createNewName();
-    }
-    if (description.length === 0) {
-      this.props.addNewDescription();
-    }
-    this.setState({ concept_class: concept });
+    this.initializeConcept(concept).then(() => {
+      this.oldState = this.state;
+    });
     fetchAllConceptSources();
   }
 
@@ -127,6 +126,17 @@ export class CreateConcept extends Component {
 
   componentWillUnmount() {
     this.props.clearSelections();
+  }
+
+  initializeConcept = async (concept) => {
+    const { newName, description } = this.props;
+    if (newName.length === 0) {
+      this.props.createNewName();
+    }
+    if (description.length === 0) {
+      this.props.addNewDescription();
+    }
+    this.setState({ concept_class: concept });
   }
 
   handleAsyncSelectChange = (answers, uniqueKey) => {
@@ -302,6 +312,20 @@ export class CreateConcept extends Component {
     this.setState({ mappings: selectedMappings });
   }
 
+  selectConfirm = () => {
+    this.props.history.push(localStorage.getItem('dictionaryPathName'));
+  }
+
+  hideModal = () => this.setState({ show: false });
+
+  showModal = () => {
+    if (this.oldState === this.state) {
+      this.selectConfirm();
+    } else {
+      this.setState({ show: true });
+    }
+  }
+
   render() {
     const {
       match: {
@@ -365,6 +389,17 @@ Concept
                 removeMappingRow={this.removeMappingRow}
                 updateAsyncSelectValue={this.updateAsyncSelectValue}
                 allSources={this.props.allSources}
+                showModal={this.showModal}
+              />
+              <GeneralModel
+                title={LEAVE_PAGE_POPUP_TITLE}
+                content={CANCEL_WARNING}
+                show={this.state.show}
+                confirm_button={LEAVE_PAGE}
+                cancel_button={STAY_ON_PAGE}
+                hide={this.hideModal}
+                select_confirm={this.selectConfirm}
+                showModal={this.showModal}
               />
             </div>
           </div>

--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -26,6 +26,7 @@ import {
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import {
   INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL, MAP_TYPE, ATTRIBUTE_NAME_SOURCE,
+  CANCEL_WARNING, LEAVE_PAGE, STAY_ON_PAGE, LEAVE_PAGE_POPUP_TITLE,
 } from '../components/helperFunction';
 import { fetchConceptSources } from '../../../redux/actions/bulkConcepts';
 import { removeDictionaryConcept, removeConceptMapping } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
@@ -90,7 +91,7 @@ export class EditConcept extends Component {
     };
     this.conceptUrl = '';
     this.createUrl = '';
-
+    this.oldState = {};
     autoBind(this);
   }
 
@@ -109,7 +110,9 @@ export class EditConcept extends Component {
     } = this.props;
     this.conceptUrl = `/${type}/${typeName}/sources/${collectionName}/concepts/${conceptId}/?includeMappings=true&verbose=true`;
     this.createUrl = `/${type}/${typeName}/sources/${collectionName}/concepts/`;
-    this.props.fetchExistingConcept(this.conceptUrl);
+    this.props.fetchExistingConcept(this.conceptUrl).then(() => {
+      this.oldState = this.state;
+    });
     fetchAllConceptSources();
   }
 
@@ -366,9 +369,13 @@ export class EditConcept extends Component {
   hideModal = () => this.setState({ show: false });
 
   showModal = () => {
-    this.setState(
-      { show: true },
-    );
+    if (this.oldState === this.state) {
+      this.selectConfirm();
+    } else {
+      this.setState(
+        { show: true },
+      );
+    }
   }
 
   removeMappingRow = (url, name, code) => {
@@ -538,11 +545,11 @@ Concept
                 select_confirm={this.confirmRemoveMappingRow}
               />
               <GeneralModel
-                title=""
-                content="Are you sure you want to cancel without saving?"
+                title={LEAVE_PAGE_POPUP_TITLE}
+                content={CANCEL_WARNING}
                 show={this.state.show}
-                confirm_button="Yes"
-                cancel_button="No"
+                confirm_button={LEAVE_PAGE}
+                cancel_button={STAY_ON_PAGE}
                 hide={this.hideModal}
                 select_confirm={this.selectConfirm}
                 showModal={this.showModal}

--- a/src/styles/dictionary_modal.scss
+++ b/src/styles/dictionary_modal.scss
@@ -151,7 +151,7 @@ legend {
       color: #cc0000;
   }
 
-#addDictionary, #generalConfirmButton, #saveReleaseVersion{
+#addDictionary, .primaryButton, #saveReleaseVersion{
     color: #fff;
     background-color: #007bff;
     border-color: #007bff;

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -58,12 +58,14 @@ describe('Test suite for dictionary concepts components', () => {
   };
 
   let wrapper;
+  let createConceptComponent;
 
   beforeEach(() => {
     localStorage.setItem('dictionaryPathName', '/dictionary/url');
     wrapper = mount(<Router>
       <CreateConcept {...props} />
     </Router>);
+    createConceptComponent = wrapper.find('CreateConcept');
   });
 
   it('should call addMappingRow function', () => {
@@ -274,5 +276,42 @@ describe('Test suite for dictionary concepts components', () => {
       relationshipDropdown.simulate('change', event);
       expect(wrapper.find('CreateConceptForm').props().mappings[0].map_type).toEqual(inputValue);
     });
+  });
+
+  it('should follow the provided path when the Leave button is clicked', () => {
+    const mockPath = localStorage.getItem('dictionaryPathName');
+    const spy = jest.spyOn(createConceptComponent.instance(), 'selectConfirm');
+    createConceptComponent.setState({ show: true }, () => {
+      wrapper.find('.leaveButton').at(1).simulate('click');
+      expect(spy).toHaveBeenCalled();
+      expect(props.history.push).toHaveBeenCalledWith(mockPath);
+    });
+  });
+
+  it('should hide the modal when the Stay button is clicked', () => {
+    const spy = jest.spyOn(createConceptComponent.instance(), 'hideModal');
+    createConceptComponent.setState({ show: true });
+    wrapper.find('.stayButton').at(1).simulate('click');
+    expect(spy).toHaveBeenCalled();
+    expect(createConceptComponent.instance().state.show).toEqual(false);
+  });
+
+  it('should show the modal when Cancel is clicked with unsaved changes', () => {
+    const event = {
+      target: {
+        name: 'datatype',
+        value: 'Complex',
+      },
+    };
+    wrapper.find('select#datatype').simulate('change', event);
+    wrapper.find('.cancelButton').simulate('click');
+    expect(createConceptComponent.instance().state.show).toEqual(true);
+  });
+
+  it('should not show the modal when cancel is clicked without unsaved changes', () => {
+    const createConceptInstance = createConceptComponent.instance();
+    createConceptInstance.oldState = createConceptInstance.state;
+    wrapper.find('.cancelButton').simulate('click');
+    expect(createConceptInstance.state.show).toEqual(false);
   });
 });

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -45,7 +45,7 @@ describe('Test suite for dictionary concepts components', () => {
     createNewName: jest.fn(),
     addNewDescription: jest.fn(),
     clearSelections: jest.fn(),
-    fetchExistingConcept: jest.fn(),
+    fetchExistingConcept: async () => jest.fn(),
     clearPreviousConcept: jest.fn(),
     createNewNameForEditConcept: jest.fn(),
     removeDescriptionForEditConcept: jest.fn(),
@@ -78,6 +78,14 @@ describe('Test suite for dictionary concepts components', () => {
     createNewAnswerRow: jest.fn(),
     ...editConceptProps,
   };
+
+  let editConceptWrapper;
+  let editConceptComponent;
+
+  beforeEach(() => {
+    editConceptWrapper = mount(<Router><EditConcept {...props} /></Router>);
+    editConceptComponent = editConceptWrapper.find('EditConcept');
+  });
 
   it('should redirect on confirm cancel', () => {
     localStorage.setItem('dictionaryPathName', '/concepts/users/admin/CCL/CASE CLINIC/en');
@@ -255,6 +263,25 @@ describe('Test suite for dictionary concepts components', () => {
     expect(mapStateToProps(initialState).newName).toEqual(['1']);
     expect(mapStateToProps(initialState).existingConcept).toEqual(existingConcept);
   });
+
+  it('should show the modal when cancel is clicked with unsaved changes', () => {
+    const event = {
+      target: {
+        name: 'datatype',
+        value: 'Complex',
+      },
+    };
+    editConceptWrapper.find('select#datatype').simulate('change', event);
+    editConceptWrapper.find('.cancelButton').simulate('click');
+    expect(editConceptComponent.instance().state.show).toEqual(true);
+  });
+
+  it('should not show the modal when cancel is clicked without unsaved changes', () => {
+    const editConceptInstance = editConceptComponent.instance();
+    editConceptInstance.oldState = editConceptInstance.state;
+    editConceptWrapper.find('.cancelButton').simulate('click');
+    expect(editConceptInstance.state.show).toEqual(false);
+  });
 });
 
 describe('Test suite for mappings on existing concepts', () => {
@@ -276,7 +303,7 @@ describe('Test suite for mappings on existing concepts', () => {
     createNewName: jest.fn(),
     addNewDescription: jest.fn(),
     clearSelections: jest.fn(),
-    fetchExistingConcept: jest.fn(),
+    fetchExistingConcept: async () => jest.fn(),
     clearPreviousConcept: jest.fn(),
     createNewNameForEditConcept: jest.fn(),
     removeDescriptionForEditConcept: jest.fn(),


### PR DESCRIPTION
# JIRA TICKET NAME:
[The warning should not appear if no changes were made on the Edit and Create concept pages when Cancel is clicked](https://issues.openmrs.org/browse/OCLOMRS-497)

# Summary:
On the Edit and Create concept pages, do not show the warning message/popup if no changes were made.