### PR TITLE
OCLOMRS-501: Refreshing the Create Concept page should not render new rows for Names and Descriptions

### DIFF
--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -95,8 +95,13 @@ export class CreateConcept extends Component {
     } = this.props;
     unpopulateSelectedAnswers();
     const concept = conceptType || '';
-    this.props.createNewName();
-    this.props.addNewDescription();
+    const { newName, description } = this.props;
+    if (newName.length === 0) {
+      this.props.createNewName();
+    }
+    if (description.length === 0) {
+      this.props.addNewDescription();
+    }
     this.setState({ concept_class: concept });
     fetchAllConceptSources();
   }

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -134,6 +134,28 @@ describe('Test suite for dictionary concepts components', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should not call the createNewName function if new names are already available', () => {
+    const propsWithNames = { ...props, newName: ['a'] };
+    wrapper = mount(<Router><CreateConcept {...propsWithNames} /></Router>);
+    expect(propsWithNames.createNewName).not.toHaveBeenCalled();
+  });
+  it('should call the createNewName function if there are no new names', () => {
+    const propsWithoutNames = { ...props, newName: [] };
+    wrapper = mount(<Router><CreateConcept {...propsWithoutNames} /></Router>);
+    expect(propsWithoutNames.createNewName).toHaveBeenCalled();
+  });
+
+  it('should not call the addNewDescription function if new descriptions are already available', () => {
+    const propsWithDescriptions = { ...props, description: ['b'] };
+    wrapper = mount(<Router><CreateConcept {...propsWithDescriptions} /></Router>);
+    expect(propsWithDescriptions.addNewDescription).not.toHaveBeenCalled();
+  });
+  it('should call the addNewDescription function if there are no new descriptions', () => {
+    const propsWithoutDescriptions = { ...props, description: [] };
+    wrapper = mount(<Router><CreateConcept {...propsWithoutDescriptions} /></Router>);
+    expect(propsWithoutDescriptions.addNewDescription).toHaveBeenCalled();
+  });
+
   it('it should render with a null conceptType', () => {
     const newProps = {
       ...props,


### PR DESCRIPTION
# JIRA TICKET NAME:
[Refreshing the Create Concept page should not render new rows for Names and Descriptions](https://issues.openmrs.org/browse/OCLOMRS-501)

# Summary:
When the Create Concept page is refreshed, new rows for Names and Descriptions are created.