### PR TITLE
OCLOMRS-503: The default mapping relationship for external mappings is saved as SAME-AS instead of NARROWER-THAN

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -12,8 +12,8 @@ const CreateConceptForm = (props) => {
     selectedAnswers,
     handleAnswerChange,
     addAnswerRow, removeAnswerRow, currentDictionaryName,
-    mappings, addMappingRow, updateEventListener, removeMappingRow, updateAsyncSelectValue,
-    isEditConcept, allSources,
+    mappings, addMappingRow, updateEventListener, updateSourceEventListener,
+    isEditConcept, allSources, removeMappingRow, updateAsyncSelectValue,
   } = props;
 
   const selectedMappings = mappings
@@ -222,6 +222,7 @@ const CreateConceptForm = (props) => {
                       to_concept_code={mapping.to_concept_code}
                       to_concept_name={mapping.to_concept_name}
                       updateEventListener={updateEventListener}
+                      updateSourceEventListener={updateSourceEventListener}
                       removeMappingRow={removeMappingRow}
                       updateAsyncSelectValue={updateAsyncSelectValue}
                       key={mapping.id}
@@ -281,6 +282,7 @@ CreateConceptForm.propTypes = {
   mappings: PropTypes.array,
   addMappingRow: PropTypes.func,
   updateEventListener: PropTypes.func,
+  updateSourceEventListener: PropTypes.func,
   showModal: PropTypes.func,
   removeMappingRow: PropTypes.func,
   updateAsyncSelectValue: PropTypes.func,
@@ -301,6 +303,7 @@ CreateConceptForm.defaultProps = {
   mappings: [],
   addMappingRow: null,
   updateEventListener: null,
+  updateSourceEventListener: null,
   removeMappingRow: null,
   updateAsyncSelectValue: null,
   addAnswerRow: () => {},

--- a/src/components/dictionaryConcepts/components/CreateMapping.jsx
+++ b/src/components/dictionaryConcepts/components/CreateMapping.jsx
@@ -67,7 +67,7 @@ class CreateMapping extends Component {
     const { inputValue } = this.state;
     const {
       map_type, source, to_concept_code, to_concept_name, index,
-      updateEventListener, removeMappingRow,
+      updateEventListener, updateSourceEventListener, removeMappingRow,
       isNew, allSources, url, isShown,
     } = this.props;
     const nullEditMapType = (source !== INTERNAL_MAPPING_DEFAULT_SOURCE ? this.state.type
@@ -81,7 +81,7 @@ class CreateMapping extends Component {
             tabIndex={index}
             className="form-control"
             name="source"
-            onChange={(event) => { updateEventListener(event, url); }}
+            onChange={(event) => { updateSourceEventListener(event, url); }}
             value={source || undefined}
           >
             <option value="" hidden>Select a source</option>
@@ -228,6 +228,7 @@ CreateMapping.propTypes = {
   url: PropTypes.string,
   index: PropTypes.number,
   updateEventListener: PropTypes.func,
+  updateSourceEventListener: PropTypes.func,
   removeMappingRow: PropTypes.func,
   updateAsyncSelectValue: PropTypes.func,
   isNew: PropTypes.bool,
@@ -244,6 +245,7 @@ CreateMapping.defaultProps = {
   isNew: false,
   url: '',
   updateEventListener: () => {},
+  updateSourceEventListener: () => {},
   removeMappingRow: () => {},
   updateAsyncSelectValue: () => {},
   isShown: false,

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -20,6 +20,7 @@ import {
 import { fetchConceptSources } from '../../../redux/actions/bulkConcepts';
 import {
   MAP_TYPE, CANCEL_WARNING, LEAVE_PAGE, STAY_ON_PAGE, LEAVE_PAGE_POPUP_TITLE,
+  INTERNAL_MAPPING_DEFAULT_SOURCE, MAP_TYPES_DEFAULTS,
 } from '../components/helperFunction';
 import GeneralModel from '../../dashboard/components/dictionary/common/GeneralModal';
 
@@ -274,6 +275,26 @@ export class CreateConcept extends Component {
     this.setState({ mappings });
   }
 
+  updateSourceEventListener = (event, url) => {
+    const { value, name } = event.target;
+    const defaultRelationship = MAP_TYPES_DEFAULTS[1];
+    const relationship = MAP_TYPES_DEFAULTS[0];
+    const { mappings } = this.state;
+    const newMappings = mappings.map((map) => {
+      const modifyMap = map;
+      if (modifyMap.url === url) {
+        modifyMap[name] = value;
+      }
+      if (modifyMap.source !== INTERNAL_MAPPING_DEFAULT_SOURCE) {
+        modifyMap.map_type = defaultRelationship;
+      } else {
+        modifyMap.map_type = relationship;
+      }
+      return modifyMap;
+    });
+    this.setState({ mappings: newMappings });
+  }
+
   updateEventListener = (event, url) => {
     const { value, name } = event.target;
     const { mappings } = this.state;
@@ -386,6 +407,7 @@ Concept
                 mappings={mappings}
                 addMappingRow={this.addMappingRow}
                 updateEventListener={this.updateEventListener}
+                updateSourceEventListener={this.updateSourceEventListener}
                 removeMappingRow={this.removeMappingRow}
                 updateAsyncSelectValue={this.updateAsyncSelectValue}
                 allSources={this.props.allSources}

--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -27,6 +27,7 @@ import {
 import {
   INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL, MAP_TYPE, ATTRIBUTE_NAME_SOURCE,
   CANCEL_WARNING, LEAVE_PAGE, STAY_ON_PAGE, LEAVE_PAGE_POPUP_TITLE,
+  MAP_TYPES_DEFAULTS,
 } from '../components/helperFunction';
 import { fetchConceptSources } from '../../../redux/actions/bulkConcepts';
 import { removeDictionaryConcept, removeConceptMapping } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
@@ -295,6 +296,26 @@ export class EditConcept extends Component {
     this.setState({ mappings });
   }
 
+  updateSourceEventListener = (event, url) => {
+    const { value, name } = event.target;
+    const defaultRelationship = MAP_TYPES_DEFAULTS[1];
+    const relationship = MAP_TYPES_DEFAULTS[0];
+    const { mappings } = this.state;
+    const newMappings = mappings.map((map) => {
+      const modifyMap = map;
+      if (modifyMap.url === url) {
+        modifyMap[name] = value;
+      }
+      if (modifyMap.source !== INTERNAL_MAPPING_DEFAULT_SOURCE) {
+        modifyMap.map_type = defaultRelationship;
+      } else {
+        modifyMap.map_type = relationship;
+      }
+      return modifyMap;
+    });
+    this.setState({ mappings: newMappings });
+  }
+
   updateEventListener = (event, url) => {
     const { value, name } = event.target;
     const { mappings } = this.state;
@@ -520,6 +541,7 @@ Concept
                 mappings={mappings}
                 addMappingRow={this.addMappingRow}
                 updateEventListener={this.updateEventListener}
+                updateSourceEventListener={this.updateSourceEventListener}
                 removeMappingRow={this.removeMappingRow}
                 updateAsyncSelectValue={this.updateAsyncSelectValue}
                 allSources={this.props.allSources}

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -663,3 +663,14 @@ export const sampleRetiredConcept = {
   ...sampleConcept,
   retired: true,
 };
+
+export const newMappings = [{
+  id: 1,
+  map_type: 'Same-as',
+  source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+  to_concept_code: 'dce20834-a9d7-41c6-be70-587f5246d41a',
+  to_concept_name: 'MALARIA SMEAR, QUALITATIVE',
+  to_source_url: '/orgs/CIEL/sources/CIEL/concepts/1366/',
+  isNew: false,
+  url: '1435',
+}];

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -314,4 +314,38 @@ describe('Test suite for dictionary concepts components', () => {
     wrapper.find('.cancelButton').simulate('click');
     expect(createConceptInstance.state.show).toEqual(false);
   });
+  it('should set `NARROWER-THAN` as the default relationship when the source is changed to `MapTypes`'
+  + 'while creating a new concept', () => {
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'source',
+        value: '',
+      },
+    };
+    const url = '1234';
+    const instance = wrapper.find('CreateConcept').instance();
+    instance.state.mappings[1] = {
+      source: 'MapTypes',
+    };
+    instance.updateSourceEventListener(event, url);
+    expect(instance.state.mappings[1].map_type).toEqual('NARROWER-THAN');
+  });
+  it('should set `SAME-AS` as the default relationship when the source is changed to `CIEL`'
+  + 'while creating a new concept', () => {
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'source',
+        value: '',
+      },
+    };
+    const url = '1234';
+    const instance = wrapper.find('CreateConcept').instance();
+    instance.state.mappings[1] = {
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+    };
+    instance.updateSourceEventListener(event, url);
+    expect(instance.state.mappings[1].map_type).toEqual('SAME-AS');
+  });
 });

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -7,7 +7,7 @@ import {
   mapStateToProps,
 } from '../../../components/dictionaryConcepts/containers/EditConcept';
 import {
-  newConcept, existingConcept, mockSource, sampleConcept,
+  newConcept, existingConcept, mockSource, sampleConcept, newMappings,
 } from '../../__mocks__/concepts';
 import { INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL } from '../../../components/dictionaryConcepts/components/helperFunction';
 
@@ -588,5 +588,41 @@ describe('Test suite for mappings on existing concepts', () => {
   it('should call removeAnswer and remove the anwser row when a user clicks the remove button while creating a Q-A concept', () => {
     wrapper.find('button#removeAnswer').simulate('click');
     expect(props.removeAnswer).toHaveBeenCalledWith(props.selectedAnswers[0].frontEndUniqueKey);
+  });
+  it('should set `NARROWER-THAN` as the default relationship when the source is changed to `Datatype`'
+  + 'while editing a concept', () => {
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'source',
+        value: '',
+      },
+    };
+    const url = '1435';
+    const instance = wrapper.find('EditConcept').instance();
+    instance.state.mappings = newMappings;
+    instance.state.mappings[0] = {
+      source: 'Datatype',
+      url: '1435',
+    };
+    instance.updateSourceEventListener(event, url);
+    expect(instance.state.mappings[0].map_type).toEqual('NARROWER-THAN');
+  });
+  it('should set `SAME-AS` as the default relationship when the source is changed to `CIEL`'
+  + 'while editing a concept', () => {
+    const event = {
+      target: {
+        tabIndex: 0,
+        name: 'source',
+        value: 'a234',
+      },
+    };
+    const url = '1234';
+    const instance = wrapper.find('EditConcept').instance();
+    instance.state.mappings[1] = {
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+    };
+    instance.updateSourceEventListener(event, url);
+    expect(instance.state.mappings[1].map_type).toEqual('SAME-AS');
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[The default mapping relationship for external mappings is saved as SAME-AS instead of NARROWER-THAN](https://issues.openmrs.org/browse/OCLOMRS-503)

# Summary:
When creating a new external mapping (i.e. a mapping with a source that is not CIEL) the default relationship is saved as SAME-AS instead of NARROWER-THAN.