### PR TITLE
OCLOMRS-504: Raise Test Coverage

### DIFF
--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -97,7 +97,11 @@ describe('Test suite for dictionary concept actions', () => {
       const request = moxios.requests.mostRecent();
       request.respondWith({ status: 200, response: expectedPosts });
     });
-    await fetchSourceConcepts('source', 'query');
+    try {
+      await fetchSourceConcepts('source', 'query');
+    } catch (error) {
+      expect(error).toEqual([]);
+    }
   });
 
   it('should query possible answer concepts', async () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Raise Test Coverage](https://issues.openmrs.org/browse/OCLOMRS-504)

# Summary:
Fix the drop in test coverage in the "DictionaryConcepts.js" file. This was discovered in this [PR](https://github.com/openmrs/openmrs-ocl-client/pull/392). It was due to the catch clause in the "fetchSourceConcepts" action having no test.
