### PR TITLE
OCLOMRS-505: When adding or editing a mapping make the results drop down menu scrollable when searching for CIEL concepts

### DIFF
--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -421,6 +421,8 @@ input[type=text] {
   padding: 5px;
   background: #F4f4f4;
   z-index: 10;
+  max-height:210px;
+  overflow:auto;
 
   li {
     display: block;


### PR DESCRIPTION
# JIRA TICKET NAME:
[When adding or editing a mapping make the results drop down menu scrollable when searching for CIEL concepts](https://issues.openmrs.org/browse/OCLOMRS-505)

# Summary:
When adding or editing a mapping, searching for CIEL concepts might return a drop down of results in hundreds or thousands. This could make the display uncharacteristically inconveniencing and bad for the users. The results drop down should be made scrollable to improve user experience.
