### PR TITLE
OCLOMRS-506: Tests are failing to run on the OpenMRS yokobue agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react-render-html": "^0.6.0",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.2.2",
-    "react-scripts": "1.1.4",
+    "react-scripts": "^2.1.8",
     "react-select": "^2.4.2",
     "react-table": "^6.8.6",
     "react-tooltip": "^3.6.0",
@@ -41,7 +41,6 @@
     "watch:css": "node-sass-chokidar ./src/styles/all.scss ./src/styles/all.css --include-path ./node_modules src/styles -o src/styles --watch --recursive"
   },
   "devDependencies": {
-    "babel-eslint": "^10.0.1",
     "coveralls": "^3.0.2",
     "deep-freeze": "0.0.1",
     "enzyme": "^3.7.0",

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -850,7 +850,7 @@ describe('Add answer mappings to concept', () => {
     moxios.uninstall();
   });
 
-  it('should add all chosen answer mappings', async () => {
+  it('should add all chosen answer mappings', () => {
     const mappingData = [
       {
         url: 'some/test.url',
@@ -940,6 +940,6 @@ describe('Add answer mappings to concept', () => {
       const request = moxios.requests.mostRecent();
       request.respondWith({ status: 201, response: expected });
     });
-    await addAnswerMappingToConcept('/url/test/', '2434435454545', mappingData);
+    addAnswerMappingToConcept('/url/test/', '2434435454545', mappingData);
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Tests are failing to run on the OpenMRS yokobue agent](https://issues.openmrs.org/browse/OCLOMRS-506)

# Summary:
Tests are failing to run on the OpenMRS yokobue agent due to having deprecated version of react-scripts. This PR fixes the bug.
