### PR TITLE
OCLOMRS-513: Previewing a concept does not display a concept's mappings, answers and sets

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,11 @@
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ]
-  }
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
 }

--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -14,7 +14,7 @@ import {
 } from '../../types';
 
 export const fetchBulkConcepts = (currentPage, source = 'CIEL') => async (dispatch) => {
-  const url = `orgs/${source}/sources/${source}/concepts/?limit=10&page=${currentPage}&&verbose=true`;
+  const url = `orgs/${source}/sources/${source}/concepts/?limit=10&page=${currentPage}&verbose=true&includeMappings=1`;
   dispatch(isFetching(true));
   try {
     const response = await instance.get(url);
@@ -34,16 +34,14 @@ export const fetchFilteredConcepts = (source = 'CIEL', query = '', currentPage) 
   const {
     bulkConcepts: { datatypeList, classList },
   } = getState();
-  let url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=10&page=${currentPage}&verbose=true`;
+  let url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=10&page=${currentPage}&verbose=true&includeMappings=1`;
 
-  if (datatypeList.length > 0 && classList.length > 0) {
-    url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=10&page=${currentPage}&verbose=true&datatype=${datatypeList.join(',')}&conceptClass=${classList.join(',')}`;
+  if (datatypeList.length > 0) {
+    url = `${url}&datatype=${datatypeList.join(',')}`;
   }
-  if (datatypeList.length > 0 && classList.length === 0) {
-    url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=10&page=${currentPage}&verbose=true&datatype=${datatypeList.join(',')}`;
-  }
-  if (datatypeList.length === 0 && classList.length > 0) {
-    url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=10&page=${currentPage}&verbose=true&conceptClass=${classList.join(',')}`;
+
+  if (classList.length > 0) {
+    url = `${url}&conceptClass=${classList.join(',')}`;
   }
 
   try {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Concepts missing mappings, answers and sets on preview](https://issues.openmrs.org/browse/OCLOMRS-513)

# Summary:
When a user clicks 'preview concept', one of the items they expect to view are mappings, answers and sets.
Currently, mappings, answers and sets are not displayed