### PR TITLE
OCLOMRS-514: raise test coverage

### DIFF
--- a/src/redux/actions/concepts/specificConceptAction.js
+++ b/src/redux/actions/concepts/specificConceptAction.js
@@ -24,7 +24,7 @@ const fetchConceptsActionTypes = (
     if (error.response) {
       dispatch(isErrored(error.response.data));
       dispatch(isFetching(false));
-    } else if (error.request) {
+    } else {
       dispatch(isErrored("Request can't be made"));
       dispatch(isFetching(false));
     }

--- a/src/tests/Dashboard/action/specificConceptAction.test.js
+++ b/src/tests/Dashboard/action/specificConceptAction.test.js
@@ -86,4 +86,24 @@ describe('Test suite for specific concepts actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
+
+  it('should return an error message if request fails', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({});
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: IS_FETCHING, payload: false },
+      { type: FETCH_CONCEPTS, payload: 'Request can\'t be made' },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    const store = mockStore({ payload: {} });
+
+    return store.dispatch(fetchConceptsActionTypes('malaria', 10, 1)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-514](https://issues.openmrs.org/browse/OCLOMRS-514)

# Summary:
- Add test to cover condition where a request fails when making an api call for concept types.