### PR TITLE
OCLOMRS-515: Remove the quick search option from the Add Bulk Concepts Page

### DIFF
--- a/src/components/bulkConcepts/addBulkConcepts.jsx
+++ b/src/components/bulkConcepts/addBulkConcepts.jsx
@@ -2,16 +2,13 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import Downshift from 'downshift';
 import {
   Form,
   FormGroup,
   Input,
 } from 'reactstrap';
-import Loader from '../Loader';
 import fetchSourceConcepts, { addExistingBulkConcepts, isConceptValid, fetchConceptSources } from '../../redux/actions/bulkConcepts';
 import Header from './container/Header';
-import { KEY_CODE_FOR_ENTER } from '../dictionaryConcepts/components/helperFunction';
 import ResultModal from './component/addBulkConceptResultModal';
 
 export class AddBulkConcepts extends Component {
@@ -40,7 +37,6 @@ export class AddBulkConcepts extends Component {
     this.state = {
       conceptIds: '',
       openResultModal: false,
-      value: '',
     };
     this.invalidConceptIds = [];
     this.sourceUrl = 'orgs/CIEL/sources/CIEL/';
@@ -103,15 +99,6 @@ export class AddBulkConcepts extends Component {
     this.setState({ openResultModal: false });
   }
 
-  onKeyDown = (event, onKeyDown, onChange) => {
-    this.setState({ value: event.target.value });
-    if (event.keyCode === KEY_CODE_FOR_ENTER) {
-      event.preventDefault();
-      onChange(event);
-      onKeyDown(event);
-    }
-  }
-
   render() {
     const dictionaryName = localStorage.getItem('dictionaryName');
     const { conceptIds, openResultModal } = this.state;
@@ -121,8 +108,6 @@ export class AddBulkConcepts extends Component {
           type, typeName, collectionName, language,
         },
       },
-      sourceConcepts,
-      isLoading,
     } = this.props;
     const disableButton = (conceptIds.length < 1);
     return (
@@ -164,88 +149,6 @@ export class AddBulkConcepts extends Component {
           <div className="row">
             <div className="col-md-6">
               <h3>Concept IDs to add</h3>
-            </div>
-            <div className="col-md-6 pull-right">
-              <Downshift
-                id="searchInput"
-                onChange={selected => this.handleSelected(selected)}
-                itemToString={item => item && item.display_name}
-              >
-                {({
-                  getInputProps,
-                  getItemProps,
-                  getMenuProps,
-                  highlightedIndex,
-                  isOpen,
-                  inputValue,
-                }) => (
-                  <div>
-                    <div id="other-search">
-                      <div className="form-check vertical-center">
-                        <span className="mr-2">Quick search</span>
-                        <form className="form-inline search-bar">
-                          <i className="fas fa-search" />
-                          <input
-                            {
-                              ...getInputProps()
-                              }
-                            className="form-control search"
-                            id="search"
-                            placeholder="search"
-                            value={this.state.value}
-                            aria-label="Search"
-                            onChange={e => this.onKeyDown(
-                              e,
-                              getInputProps().onKeyDown,
-                              getInputProps().onChange,
-                            )}
-                            onKeyDown={
-                              e => this.onKeyDown(
-                                e,
-                                getInputProps().onKeyDown,
-                                getInputProps().onChange,
-                              )}
-                            {...getInputProps().rest}
-                          />
-                          {isLoading
-                              && <div className="ml-auto text-right">
-                                <Loader smaller />
-                              </div>
-                            }
-                        </form>
-                      </div>
-                    </div>
-                    <div className="search-ul">
-                      {isOpen ? (
-                        <ul {...getMenuProps()} className="search-ul-li">
-                          {
-                              sourceConcepts.filter(item => !inputValue.trim()
-                                || item.display_name.toLowerCase()
-                                  .includes(inputValue.toLowerCase()))
-                                .slice(1, 10).map((item, index) => (
-                                  <li
-                                    {...getItemProps({
-                                      key: item.id,
-                                      index,
-                                      item,
-                                      style: {
-                                        backgroundColor:
-                                          highlightedIndex === index ? 'lightgray' : 'white',
-                                        padding: '5px 10px 1px',
-                                      },
-                                    })}
-                                  >
-                                    {item.display_name}
-                                  </li>
-                                ))
-                            }
-                        </ul>
-                      )
-                        : null}
-                    </div>
-                  </div>
-                )}
-              </Downshift>
             </div>
           </div>
           <div className="preferred-concepts">

--- a/src/tests/bulkConcepts/addBulkConcepts.test.jsx
+++ b/src/tests/bulkConcepts/addBulkConcepts.test.jsx
@@ -8,7 +8,6 @@ import Authenticated from '../__mocks__/fakeStore';
 import { AddBulkConcepts, mapStateToProps } from '../../components/bulkConcepts/addBulkConcepts';
 import { mockConcepts } from '../__mocks__/concepts';
 import configInstance from '../../config/axiosConfig';
-import { KEY_CODE_FOR_ENTER } from '../../components/dictionaryConcepts/components/helperFunction';
 
 const store = createMockStore(Authenticated);
 const match = {
@@ -63,57 +62,6 @@ describe('Add Bulk Concepts', () => {
     bulkWrapper.forceUpdate();
     wrapper.find('#ciel').at(0).simulate('click');
     expect(spy).toHaveBeenCalled();
-  });
-
-  it('should render a loader while fetching Source Concepts', () => {
-    const wrapper = mount(<MemoryRouter>
-      <Provider store={store}>
-        <AddBulkConcepts {...props} />
-      </Provider>
-    </MemoryRouter>);
-    expect(wrapper.find('Loader')).toHaveLength(1);
-  });
-
-  it('shows suggestions when typing', () => {
-    const hasMenu = wrapper => wrapper.find('.search-ul').at(0).length === 1;
-
-    const wrapper = mount(<MemoryRouter>
-      <Provider store={store}>
-        <AddBulkConcepts {...props} />
-      </Provider>
-    </MemoryRouter>);
-    wrapper.find('#search').simulate('keydown', { key: 'ArrowDown' });
-    expect(hasMenu(wrapper)).toBe(true);
-  });
-
-  it('can search for and select "Bronze ..." in concepts', () => {
-    const wrapper = mount(<MemoryRouter>
-      <Provider store={store}>
-        <AddBulkConcepts {...props} />
-      </Provider>
-    </MemoryRouter>);
-    const input = wrapper.find('#search');
-    input.simulate('change', { target: { value: 'Bronze Diabetes' } });
-    input.simulate('keydown', { key: 'ArrowDown' });
-    input.simulate('keydown', { keyCode: KEY_CODE_FOR_ENTER });
-    expect(input.instance().value).toEqual('Bronze Diabetes');
-    const txtInput = wrapper.find('#idsText').at(0);
-    expect(txtInput.instance().props.value).toEqual('');
-  });
-
-
-  it('can search for concept that does not exist', () => {
-    const wrapper = mount(<MemoryRouter>
-      <Provider store={store}>
-        <AddBulkConcepts {...props} />
-      </Provider>
-    </MemoryRouter>);
-    const input = wrapper.find('#search');
-    input.simulate('change', { target: { value: 'non existent' } });
-    input.simulate('keydown', { key: 'ArrowDown' });
-    input.simulate('keydown', { keyCode: KEY_CODE_FOR_ENTER });
-    const txtInput = wrapper.find('#idsText').at(0);
-    expect(txtInput.instance().props.value).toEqual('');
   });
 
   it('adding ides to already existing conceptIds should prepend commer', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Remove the quick search option from the Add Bulk Concepts Page](https://issues.openmrs.org/browse/OCLOMRS-515)

# Summary:
Remove the quick search option from the Add Bulk Concepts Page. The search functionality is irrelevant since users can easily add multiple concept IDs in the available text area.
