### PR TITLE
OCLOMRS-509: Edit a concept answer in Q-A concepts without having to remove it

### DIFF
--- a/src/components/dictionaryConcepts/components/AnswerRow.jsx
+++ b/src/components/dictionaryConcepts/components/AnswerRow.jsx
@@ -10,15 +10,43 @@ class AnswerRow extends React.Component {
     const DEFAULT_SOURCE = localStorage.getItem('dictionaryId');
     this.state = {
       source: DEFAULT_SOURCE,
+      isClicked: false,
     };
+  }
+
+  componentDidMount() {
+    this.setState({
+      isEditing: this.props.isEditConcept,
+      isPrePopulated: this.props.prePopulated,
+    });
   }
 
   handleChangeInSource = (event) => {
     const newSource = event.target.value;
+    this.resetInput(event);
     this.setState({
       source: newSource,
     });
   }
+
+  handleClick = () => {
+    if (!this.state.isClicked) {
+      this.setState({
+        isClicked: true,
+        isEditing: false,
+        isPrePopulated: false,
+      });
+    }
+  }
+
+  resetInput = () => {
+    const {
+      answer, removeCurrentAnswer, answerUrl, frontEndUniqueKey,
+    } = this.props;
+    if (answer.prePopulated) {
+      removeCurrentAnswer({ answerUrl, frontEndUniqueKey, answer });
+    }
+  };
 
   render() {
     const {
@@ -31,17 +59,20 @@ class AnswerRow extends React.Component {
       isEditConcept,
       prePopulated,
       answerUrl,
+      removeCurrentAnswer,
+      answer,
     } = this.props;
-    const { source } = this.state;
+    const { source, isEditing, isPrePopulated } = this.state;
     return (
       <tr>
         <td>
           {
-            isEditConcept && prePopulated ? (
+            isEditing && isPrePopulated ? (
               <input
                 type="text"
                 className="form-control"
                 defaultValue={toSourceName}
+                onClick={this.handleClick}
                 required
               />
             ) : (
@@ -65,21 +96,16 @@ class AnswerRow extends React.Component {
         </td>
         <td className="react-async">
           {
-          isEditConcept && prePopulated ? (
-            <input
-              type="text"
-              className="form-control"
-              defaultValue={toConceptName}
-              required
-            />
-          ) : (
             <SelectAnswers
               handleAsyncSelectChange={handleAsyncSelectChange}
               source={source}
               frontEndUniqueKey={frontEndUniqueKey}
               isShown={false}
+              defaultValue={toConceptName}
+              removeCurrentAnswer={removeCurrentAnswer}
+              answer={answer}
+              answerUrl={answerUrl}
             />
-          )
         }
         </td>
         <td>
@@ -117,7 +143,9 @@ AnswerRow.propTypes = {
   toSourceName: PropTypes.string,
   frontEndUniqueKey: PropTypes.string,
   handleAsyncSelectChange: PropTypes.func.isRequired,
+  removeCurrentAnswer: PropTypes.func.isRequired,
   currentDictionaryName: PropTypes.string,
+  answer: PropTypes.object.isRequired,
 };
 
 AnswerRow.defaultProps = {

--- a/src/components/dictionaryConcepts/components/AnswersTable.jsx
+++ b/src/components/dictionaryConcepts/components/AnswersTable.jsx
@@ -11,6 +11,7 @@ const AnswersTable = (props) => {
     removeAnswerRow,
     currentDictionaryName,
     isEditConcept,
+    removeCurrentAnswer,
   } = props;
   return (
     <table className="table table-striped table-bordered concept-form-table">
@@ -38,6 +39,8 @@ const AnswersTable = (props) => {
               currentDictionaryName={currentDictionaryName}
               handleAsyncSelectChange={handleAsyncSelectChange}
               isEditConcept={isEditConcept}
+              answer={ans}
+              removeCurrentAnswer={removeCurrentAnswer}
             />
           );
         })}
@@ -53,6 +56,7 @@ AnswersTable.propTypes = {
   isEditConcept: PropTypes.bool.isRequired,
   removeAnswerRow: PropTypes.func,
   currentDictionaryName: PropTypes.string,
+  removeCurrentAnswer: PropTypes.func.isRequired,
 };
 
 AnswersTable.defaultProps = {

--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -8,12 +8,21 @@ import { classes, MAP_TYPE } from './helperFunction';
 
 const CreateConceptForm = (props) => {
   const {
-    concept, handleAsyncSelectChange,
+    concept,
+    handleAsyncSelectChange,
     selectedAnswers,
     handleAnswerChange,
-    addAnswerRow, removeAnswerRow, currentDictionaryName,
-    mappings, addMappingRow, updateEventListener, updateSourceEventListener,
-    isEditConcept, allSources, removeMappingRow, updateAsyncSelectValue,
+    addAnswerRow,
+    removeAnswerRow,
+    currentDictionaryName,
+    mappings, addMappingRow,
+    updateEventListener,
+    updateSourceEventListener,
+    isEditConcept,
+    allSources,
+    removeMappingRow,
+    updateAsyncSelectValue,
+    removeCurrentAnswer,
   } = props;
 
   const selectedMappings = mappings
@@ -189,6 +198,7 @@ const CreateConceptForm = (props) => {
                 removeAnswerRow={removeAnswerRow}
                 currentDictionaryName={currentDictionaryName}
                 isEditConcept={isEditConcept}
+                removeCurrentAnswer={removeCurrentAnswer}
               />
               <button
                 type="button"
@@ -290,6 +300,7 @@ CreateConceptForm.propTypes = {
   addAnswerRow: PropTypes.func,
   removeAnswerRow: PropTypes.func,
   currentDictionaryName: PropTypes.string,
+  removeCurrentAnswer: PropTypes.func,
 };
 
 CreateConceptForm.defaultProps = {
@@ -309,6 +320,7 @@ CreateConceptForm.defaultProps = {
   addAnswerRow: () => {},
   removeAnswerRow: () => {},
   currentDictionaryName: '',
+  removeCurrentAnswer: () => {},
 };
 
 export default CreateConceptForm;

--- a/src/components/dictionaryConcepts/containers/SelectAnswers.jsx
+++ b/src/components/dictionaryConcepts/containers/SelectAnswers.jsx
@@ -13,21 +13,48 @@ class SelectAnswers extends Component {
     inputValue: '',
     options: [],
     isVisible: false,
+    isClicked: false,
+    hasReset: false,
   }
 
+  componentDidMount() {
+    this.setState({ inputValue: this.props.defaultValue });
+  }
+
+    resetInput = (e) => {
+      const value = String(e.key).length === 1 ? e.key : '';
+      const {
+        answer, removeCurrentAnswer, answerUrl, frontEndUniqueKey,
+      } = this.props;
+      if (answer.prePopulated) {
+        this.setState({ inputValue: value, hasReset: true });
+        removeCurrentAnswer({ answerUrl, frontEndUniqueKey, answer });
+      }
+    };
+
     handleInputChange = (value) => {
-      this.setState({ inputValue: value });
+      const { hasReset } = this.state;
+      if (!hasReset) {
+        this.setState({ inputValue: value });
+      } else {
+        this.setState({ hasReset: false });
+      }
     }
 
     handleKeyDown = async (event, inputValue) => {
-      if ((event.keyCode === KEY_CODE_FOR_ENTER) && inputValue.length >= 3) {
+      const { isClicked } = this.state;
+      if (!isClicked) {
+        this.resetInput(event);
+        this.setState({ isClicked: true });
+      }
+      if (isClicked && (event.keyCode === KEY_CODE_FOR_ENTER) && inputValue.length >= 3) {
         const { source } = this.props;
         const options = await queryAnswers(source, inputValue);
         this.setState({ options, isVisible: true });
-      } else if ((event.keyCode === KEY_CODE_FOR_ENTER) && (inputValue.length < 3)) {
+      } else if (isClicked && (event.keyCode === KEY_CODE_FOR_ENTER) && (inputValue.length < 3)) {
         notify.show(MIN_CHARACTERS_WARNING, 'error', MILLISECONDS_TO_SHOW_WARNING);
         this.setState({ isVisible: false });
-      } else if (event.keyCode === KEY_CODE_FOR_ESCAPE) {
+      } else if (isClicked && event.keyCode === KEY_CODE_FOR_ESCAPE) {
         this.setState({ isVisible: false });
       }
     }
@@ -51,12 +78,11 @@ class SelectAnswers extends Component {
             id="searchInputCiel"
             name="to_concept_name"
             value={inputValue}
-            onChange={e => this.handleInputChange(e.target.value)
-                }
+            onChange={e => this.handleInputChange(e.target.value)}
             onKeyDown={e => this.handleKeyDown(e, inputValue)}
           />
           {(this.state.isVisible || isShown) && <ul className="cielConceptsList">
-            {this.state.options.map(result => <li key={result.display_name}>
+            {this.state.options.map(result => <li key={result.uuid}>
               <button
                 type="button"
                 id="selectConcept"
@@ -75,15 +101,22 @@ class SelectAnswers extends Component {
 SelectAnswers.propTypes = {
   handleAsyncSelectChange: PropTypes.func.isRequired,
   source: PropTypes.string,
+  defaultValue: PropTypes.string,
   frontEndUniqueKey: PropTypes.string.isRequired,
   index: PropTypes.number,
   isShown: PropTypes.bool,
+  answer: PropTypes.object,
+  removeCurrentAnswer: PropTypes.func.isRequired,
+  answerUrl: PropTypes.string,
 };
 
 SelectAnswers.defaultProps = {
   source: '',
+  defaultValue: '',
   index: 0,
   isShown: false,
+  answer: {},
+  answerUrl: '',
 };
 
 export default SelectAnswers;

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -31,6 +31,7 @@ import {
   PRE_POPULATE_ANSWERS,
   UNPOPULATE_PRE_POPULATED_ANSWERS,
   ADD_NEW_ANSWER_ROW,
+  UN_POPULATE_THIS_ANSWER,
 } from '../types';
 import {
   isFetching,
@@ -245,6 +246,17 @@ export const prepopulateAnswers = (answers) => {
   return {
     type: PRE_POPULATE_ANSWERS,
     payload: prepopulatedAnswers,
+  };
+};
+
+export const unPopulateThisAnswer = (answer) => {
+  const newAns = {
+    ...answer,
+    prePopulated: false,
+  };
+  return {
+    type: UN_POPULATE_THIS_ANSWER,
+    payload: newAns,
   };
 };
 

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -147,6 +147,19 @@ export const removeConceptMapping = (data, source) => dispatch => {
     });
 };
 
+export const removeEditedConceptMapping = (data) => dispatch =>
+  api.dictionaries
+    .removeConceptMapping(data)
+    .then(
+      () => {
+        dispatch(removeMapping(data.references[0]));
+      }
+    )
+    .catch((error) => {
+      error.response ? notify.show(error.response.data.detail, 'error', 6000):
+      showNetworkError();
+    });
+
 export const fetchVersions = data => (dispatch) => {
   return api.dictionaries
     .fetchingVersions(data)

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -72,3 +72,4 @@ export const SET_PERVIOUS_PAGE = '[page] prev_page';
 export const SET_NEXT_PAGE = '[page] next_page';
 export const SET_CURRENT_PAGE = '[page] current_page';
 export const IS_LOADING = '[ui] loader_spinning';
+export const UN_POPULATE_THIS_ANSWER = '[concept] unpopulate an answer';

--- a/src/redux/reducers/ConceptReducers.js
+++ b/src/redux/reducers/ConceptReducers.js
@@ -29,10 +29,16 @@ import {
   PRE_POPULATE_ANSWERS,
   UNPOPULATE_PRE_POPULATED_ANSWERS,
   ADD_NEW_ANSWER_ROW,
+  UN_POPULATE_THIS_ANSWER,
 } from '../actions/types';
 import {
-  filterSources, filterClass, filterList, normalizeList, filterNames,
+  filterSources,
+  filterClass,
+  filterList,
+  normalizeList,
+  filterNames,
   filterDescriptions,
+  updatePopulatedAnswers,
 } from './util';
 
 
@@ -278,6 +284,15 @@ export default (state = initialState, action) => {
         selectedAnswers: newAnswers,
       };
     }
+
+    case UN_POPULATE_THIS_ANSWER: {
+      const newAnswers = updatePopulatedAnswers(action.payload, state.selectedAnswers);
+      return {
+        ...state,
+        selectedAnswers: newAnswers,
+      };
+    }
+
     default:
       return state;
   }

--- a/src/redux/reducers/util.js
+++ b/src/redux/reducers/util.js
@@ -71,3 +71,13 @@ export const filterUserPayload = (user, payload) => {
 };
 
 export const filterDescriptions = (item, list) => list.filter(listItem => listItem.uuid !== item);
+
+export const updatePopulatedAnswers = (ans, answers) => {
+  const newAnswers = answers.map((item) => {
+    if (item.frontEndUniqueKey === ans.frontEndUniqueKey) {
+      return ans;
+    }
+    return item;
+  });
+  return newAnswers;
+};

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -471,6 +471,26 @@ describe('Test for successful dictionaries fetch, failure and refresh', () => {
     });
   });
 
+  it('should handle failed a dictionary fetching', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 500,
+        response: {
+          data: 'Error Occurred',
+        },
+      });
+    });
+    const store = mockStore({ payload: {} });
+    return store.dispatch(fetchVersions('/users/chriskala/collections/over/versions/'))
+      .then()
+      .catch((error) => {
+        expect(notify.show).toHaveBeenCalledWith(
+          `${error.response.data[0]}`, 'error', 6000,
+        );
+      });
+  });
+
   it('should handle release head version', () => {
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();

--- a/src/tests/Dashboard/reducer/conceptReducer.test.js
+++ b/src/tests/Dashboard/reducer/conceptReducer.test.js
@@ -9,6 +9,7 @@ import {
   REMOVE_SELECTED_ANSWER,
   PRE_POPULATE_ANSWERS,
   UNPOPULATE_PRE_POPULATED_ANSWERS,
+  UN_POPULATE_THIS_ANSWER,
 } from '../../../redux/actions/types';
 import concepts from '../../__mocks__/concepts';
 
@@ -194,5 +195,37 @@ describe('Test suite for concepts reducer', () => {
     const payload = 'intialKey';
     const newState = reducer(initialState, { type: REMOVE_SELECTED_ANSWER, payload });
     expect(newState.selectedAnswers).toEqual([{ frontEndUniqueKey: 'newIntialKey' }]);
+  });
+
+  it('should handle UN_POPULATE_THIS_ANSWER', () => {
+    const payload = {
+      frontEndUniqueKey: 'initialKey',
+      prePopulated: false,
+    };
+    const state = {
+      ...initialState,
+      selectedAnswers: [
+        {
+          frontEndUniqueKey: 'initialKey',
+          prePopulated: true,
+        },
+        {
+          frontEndUniqueKey: 'initialKey1',
+          prePopulated: true,
+        },
+      ],
+    };
+    const expected = [
+      {
+        frontEndUniqueKey: 'initialKey',
+        prePopulated: false,
+      },
+      {
+        frontEndUniqueKey: 'initialKey1',
+        prePopulated: true,
+      },
+    ];
+    const newState = reducer(state, { type: UN_POPULATE_THIS_ANSWER, payload });
+    expect(newState.selectedAnswers).toEqual(expected);
   });
 });

--- a/src/tests/dictionaryConcepts/components/AnswerRow.test.js
+++ b/src/tests/dictionaryConcepts/components/AnswerRow.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import AnswerRow from
   '../../../components/dictionaryConcepts/components/AnswerRow';
 
@@ -19,7 +19,15 @@ describe('Test select input field', () => {
       handleAsyncSelectChange: jest.fn(),
       currentDictionaryName: 'test dictionary',
       prePopulated: false,
+      removeCurrentAnswer: jest.fn(),
+      answer: {},
+      isClicked: false,
+      answerUrl: '',
     };
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
   });
 
   it('should find an input instead of select if answer was prepopulated', () => {
@@ -50,5 +58,35 @@ describe('Test select input field', () => {
     select.simulate('change', event);
     const instance = wrapper.instance();
     expect(instance.state.source).toEqual('value');
+  });
+
+  it('should change the state to allow the source to be edited when clicked', () => {
+    const newProps = {
+      ...props,
+      isEditConcept: true,
+      prePopulated: true,
+    };
+    wrapper = mount(<AnswerRow {...newProps} />);
+    const instance = wrapper.instance();
+    const spy = jest.spyOn(instance, 'handleClick');
+    instance.handleClick();
+    expect(spy).toHaveBeenCalled();
+    expect(instance.state.isClicked).toBe(true);
+    expect(instance.state.isEditing).toBe(false);
+    expect(instance.state.isPrePopulated).toBe(false);
+  });
+
+  it('should call removeCurrentAnswer to remove the existing answer when resetInput is triggered', () => {
+    const newProps = {
+      ...props,
+      isEditConcept: true,
+      answer: { prePopulated: true },
+    };
+    wrapper = mount(<AnswerRow {...newProps} />);
+    const instance = wrapper.instance();
+    const e = { key: 'a' }
+    instance.resetInput(e);
+    const { answerUrl, frontEndUniqueKey, answer } = newProps;
+    expect(props.removeCurrentAnswer).toHaveBeenCalledWith({ answerUrl, frontEndUniqueKey, answer });
   });
 });

--- a/src/tests/dictionaryConcepts/components/AnswersTable.test.jsx
+++ b/src/tests/dictionaryConcepts/components/AnswersTable.test.jsx
@@ -13,6 +13,7 @@ const defaultProps = {
   queryAnswers: jest.fn(),
   currentDictionaryName: 'test dictionary',
   isEditConcept: false,
+  removeCurrentAnswer: jest.fn(),
 };
 
 describe('Test suite for AnswersTable', () => {

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -76,6 +76,8 @@ describe('Test suite for dictionary concepts components', () => {
     selectConfirm: jest.fn(),
     selectedAnswers: [],
     createNewAnswerRow: jest.fn(),
+    removeEditedConceptMapping: jest.fn(),
+    unPopulateAnswer: jest.fn(),
     ...editConceptProps,
   };
 
@@ -128,11 +130,33 @@ describe('Test suite for dictionary concepts components', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it('should render without breaking', () => {
+  it('should render "Edit a question concept" without breaking', () => {
     const wrapper = mount(<Router>
       <EditConcept {...props} />
     </Router>);
     expect(wrapper.find('h3').text()).toEqual(': Edit a question Concept ');
+    wrapper.unmount();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render other concepts too without breaking', () => {
+    const newProps = {
+      ...props,
+      match: {
+        params: {
+          collectionName: 'dev-col',
+          type: 'users',
+          typeName: 'emmabaye',
+          language: 'en',
+          conceptId: '1',
+          name: '',
+        },
+      },
+    };
+    const wrapper = mount(<Router>
+      <EditConcept {...newProps} />
+    </Router>);
+    expect(wrapper.find('h3').text()).toEqual(': Edit a Concept ');
     wrapper.unmount();
     expect(wrapper).toMatchSnapshot();
   });
@@ -338,6 +362,9 @@ describe('Test suite for mappings on existing concepts', () => {
       frontEndUniqueKey: 'unique', id: 'test ID', map_type: 'Q-AND-A', prePopulated: false,
     }],
     createNewAnswerRow: jest.fn(),
+    removeEditedConceptMappingAction: jest.fn(),
+    unPopulateAnswer: jest.fn(),
+    removeCurrentAnswer: jest.fn(),
     ...editConceptProps,
   };
   const wrapper = mount(<Router>
@@ -624,5 +651,18 @@ describe('Test suite for mappings on existing concepts', () => {
     };
     instance.updateSourceEventListener(event, url);
     expect(instance.state.mappings[1].map_type).toEqual('SAME-AS');
+  });
+
+  it('should call removeEditedConceptMappingAction function to remove mapping', () => {
+    const answerUrl = 'url';
+    const frontEndUniqueKey = 'unique';
+    const answer = {};
+    const info = { answerUrl, frontEndUniqueKey, answer };
+    const instance = wrapper.find('EditConcept').instance();
+    instance.removeCurrentAnswer(info);
+    const submitForm = wrapper.find('#createConceptForm');
+    submitForm.simulate('submit', { preventDefault: jest.fn() });
+    expect(props.removeEditedConceptMappingAction)
+      .toHaveBeenCalledWith({ references: [answerUrl] });
   });
 });

--- a/src/tests/dictionaryConcepts/container/SelectAnswers.test.js
+++ b/src/tests/dictionaryConcepts/container/SelectAnswers.test.js
@@ -16,25 +16,39 @@ describe('<SelectAnswers />', () => {
       queryAnswers: jest.fn(),
       source: 'test source',
       frontEndUniqueKey: 'unique',
+      defaultValue: '',
+      index: 0,
+      isShown: false,
+      answer: {},
+      answerUrl: '',
+      removeCurrentAnswer: jest.fn(),
     };
     wrapper = mount(<SelectAnswers {...props} />);
   });
 
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
   it('should handle key down event when a user presses enter button to search for concept', async () => {
     const spy = jest.spyOn(wrapper.instance(), 'handleKeyDown');
+    wrapper.find('#searchInputCiel').simulate('keyDown');
+    expect(spy).toHaveBeenCalled();
+    expect(wrapper.state().isClicked).toBeTruthy();
     const event = { keyCode: KEY_CODE_FOR_ENTER };
     await wrapper.instance().handleKeyDown(event, 'malaria');
-    expect(spy).toHaveBeenCalled();
     expect(wrapper.state().isVisible).toBeTruthy();
   });
 
   it('should handle key down event when a user presses enter button to search for concept with input less that 3', async () => {
+    wrapper.find('#searchInputCiel').simulate('keyDown');
     const event = { keyCode: KEY_CODE_FOR_ENTER };
     await wrapper.instance().handleKeyDown(event, 'ma');
     expect(wrapper.state().isVisible).toBeFalsy();
   });
 
   it('should handle key down event when a user presses button thats not enter to search for concept', () => {
+    wrapper.find('#searchInputCiel').simulate('keyDown');
     const spy = jest.spyOn(wrapper.instance(), 'handleKeyDown');
     const event = { keyCode: KEY_CODE_FOR_SPACE };
     wrapper.find('#searchInputCiel').simulate('keyDown', event);
@@ -42,6 +56,7 @@ describe('<SelectAnswers />', () => {
   });
 
   it('should handle key down event when a user presses escape button to remove the dropdown', () => {
+    wrapper.find('#searchInputCiel').simulate('keyDown');
     const spy = jest.spyOn(wrapper.instance(), 'handleKeyDown');
     const event = { keyCode: KEY_CODE_FOR_ESCAPE };
     wrapper.find('#searchInputCiel').simulate('keyDown', event);
@@ -71,5 +86,53 @@ describe('<SelectAnswers />', () => {
     const spy = jest.spyOn(wrapper.instance(), 'handleInputChange');
     wrapper.find('#searchInputCiel').simulate('change');
     expect(spy).toHaveBeenCalled();
+  });
+
+  it('should call resetInput  when a user types in a prepopulated answer to edit it', () => {
+    const newProps = {
+      ...props,
+      isShown: true,
+      isClicked: false,
+      answer: {
+        prePopulated: true,
+      },
+    };
+    wrapper = mount(<SelectAnswers {...newProps} />);
+    const spy = jest.spyOn(wrapper.instance(), 'resetInput');
+    wrapper.find('#searchInputCiel').simulate('keyDown');
+    expect(spy).toHaveBeenCalled();
+    expect(wrapper.state().isClicked).toBeTruthy();
+  });
+
+  it('should clear input and update with current value when a user presses any key', () => {
+    const newProps = {
+      ...props,
+      isShown: true,
+      isClicked: false,
+      answer: {
+        prePopulated: true,
+      },
+    };
+    wrapper = mount(<SelectAnswers {...newProps} />);
+    const event = { key: 'a' };
+    wrapper.find('#searchInputCiel').simulate('keyDown', event);
+    expect(wrapper.state().inputValue).toEqual('a');
+    expect(props.removeCurrentAnswer).toHaveBeenCalled();
+  });
+
+  it('should clear input when a user presses any non-character key', () => {
+    const newProps = {
+      ...props,
+      isShown: true,
+      isClicked: false,
+      answer: {
+        prePopulated: true,
+      },
+    };
+    wrapper = mount(<SelectAnswers {...newProps} />);
+    const e = { key: 'backspace' };
+    wrapper.find('#searchInputCiel').simulate('keyDown', e);
+    expect(wrapper.state().inputValue).toEqual('');
+    expect(props.removeCurrentAnswer).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION

# JIRA TICKET NAME:
[ Edit a concept answer in Q-A concepts without having to remove it](https://issues.openmrs.org/browse/OCLOMRS-509)

# Summary:
Currently, if one wishes to change an answer to a concept, they have to remove it and then add a new answer. An ideal situation would be having the ability to edit a concept directly by clicking in the concept field.