### PR TITLE
OCLOMRS-521: addConcept action incorrectly calls with 'already added'

### DIFF
--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -80,8 +80,9 @@ export const addConcept = (params, data, conceptName) => async (dispatch) => {
   dispatch(isSuccess(payload.data, ADD_EXISTING_CONCEPTS));
   if (payload.data[0].added === true) {
     notify.show(`Just Added - ${conceptName}`, 'success', 3000);
+  } else {
+    notify.show(`${conceptName} already added`, 'error', 3000);
   }
-  notify.show(`${conceptName} already added`, 'error', 3000);
 };
 
 export const setCurrentPage = currentPage => async (dispatch) => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[addConcept action incorrectly calls with 'already added'](https://issues.openmrs.org/browse/OCLOMRS-521)

# Summary:
- Notify was called on outside the `if-else` block. Should be called within the else
- Add test for this