### PR TITLE
OCLOMRS-522: When logout is clicked, the flash message is missing a space

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -26,7 +26,7 @@ export class Navbar extends Component {
     event.preventDefault();
     this.props.logoutAction();
     this.props.history.push('/');
-    notify.show('You Loggedout successfully', 'success', 3000);
+    notify.show('You Logged out successfully', 'success', 3000);
   };
 
   toggle = () => {

--- a/src/tests/Navbar.test.js
+++ b/src/tests/Navbar.test.js
@@ -76,7 +76,7 @@ describe('Navbar Component', () => {
       preventDefault: () => {},
     };
     wrapper.find('#logout-user').at(0).simulate('click', event);
-    expect(notify.show).toHaveBeenCalledWith('You Loggedout successfully', 'success', 3000);
+    expect(notify.show).toHaveBeenCalledWith('You Logged out successfully', 'success', 3000);
   });
 
   it('should toggle state isOpen value on button click', () => {


### PR DESCRIPTION


# JIRA TICKET NAME:
[When logout is clicked, the flash message is missing a space](https://issues.openmrs.org/browse/OCLOMRS-522)

# Summary:
When logout is clicked, the flash message is missing a space