### PR TITLE
OCLOMRS-516: When creating a dictionary the default cursor position should be set in the dictionary name field

### DIFF
--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -230,6 +230,7 @@ export class DictionaryModal extends React.Component {
                       placeholder="e.g Community Health Dictionary"
                       value={data.name}
                       required
+                      autofocus="autofocus"
                     />
                   </FormGroup>
                   <FormGroup style={{ marginTop: '12px' }}>


### PR DESCRIPTION
# JIRA TICKET NAME:
[When creating a dictionary the default cursor position should be set in the dictionary name field.](https://issues.openmrs.org/browse/OCLOMRS-516)

# Summary:
When creating a dictionary the default cursor position should be set in the dictionary name field.
