### PR TITLE
OCLOMRS-510: A user should be redirected to the login page after a network error occurs

### DIFF
--- a/src/redux/actions/auth/authActions.js
+++ b/src/redux/actions/auth/authActions.js
@@ -22,7 +22,8 @@ const loginAction = ({ username, password }) => (dispatch) => {
     return dispatch(login(response));
   }).catch((error) => {
     if (error.response === undefined) {
-      return showNetworkError();
+      showNetworkError();
+      return dispatch(loginFailed());
     }
     let errorMessage = error.response.data.detail;
     if (errorMessage === 'Not found.') {

--- a/src/tests/Login/actions/login.test.js
+++ b/src/tests/Login/actions/login.test.js
@@ -125,6 +125,11 @@ describe('Test suite for login action', () => {
       {
         type: AUTHENTICATION_IN_PROGRESS,
         loading: true,
+      },
+      {
+        type: AUTHENTICATION_FAILED,
+        loading: false,
+        payload: { errorMessage: undefined },
       }];
 
     const store = mockStore();


### PR DESCRIPTION
# JIRA TICKET NAME:
[A user should be redirected to the login page after a network error occurs](https://issues.openmrs.org/browse/OCLOMRS-510)

# Summary:
When a network error occurs or connection is lost while a user is trying to log in, a user should be redirected to the login page.
Currently, this is not possible at the moment.
