### PR TITLE
OCLOMRS-529: On the Add CIEL concepts page, do not show any concepts

### DIFF
--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -7,7 +7,6 @@ import SearchBar from '../component/SearchBar';
 import ConceptTable from '../component/ConceptTable';
 import Header from './Header';
 import {
-  fetchBulkConcepts,
   addToFilterList,
   previewConcept,
   addConcept,
@@ -23,7 +22,6 @@ export class BulkConceptsPage extends Component {
     setCurrentPage: PropTypes.func.isRequired,
     currentPage: PropTypes.number.isRequired,
     fetchFilteredConcepts: PropTypes.func.isRequired,
-    fetchBulkConcepts: PropTypes.func.isRequired,
     concepts: PropTypes.arrayOf(PropTypes.shape(conceptsProps)).isRequired,
     loading: PropTypes.bool.isRequired,
     preview: PropTypes.shape({
@@ -60,11 +58,6 @@ export class BulkConceptsPage extends Component {
     };
   }
 
-  componentDidMount() {
-    this.getBulkConcepts();
-  }
-
-
   openModal = (id) => {
     this.setState({ modalId: id });
   };
@@ -76,12 +69,11 @@ export class BulkConceptsPage extends Component {
   componentDidUpdate(prevProps) {
     const { searchingOn } = this.state;
     const { currentPage } = this.props;
-    if (currentPage !== prevProps.currentPage) {
-      if (searchingOn) {
-        return this.searchOption();
-      }
-      return this.getBulkConcepts();
+    if (currentPage !== prevProps.currentPage && searchingOn) {
+      console.log('hey');
+      return this.searchOption();
     }
+    console.log('hey2');
     return null;
   }
 
@@ -100,19 +92,10 @@ export class BulkConceptsPage extends Component {
     }
   };
 
-  getBulkConcepts = () => {
-    const { currentPage, fetchBulkConcepts: bulkConceptsFetched } = this.props;
-    bulkConceptsFetched(currentPage);
-  }
-
   handleChange = (event) => {
     const {
       target: { value },
     } = event;
-    if (!value) {
-      const { fetchBulkConcepts: bulkConceptsFetched } = this.props;
-      bulkConceptsFetched(1);
-    }
     this.setState(() => ({ searchInput: value }));
   };
 
@@ -141,7 +124,7 @@ export class BulkConceptsPage extends Component {
     if (searchingOn) {
       return this.searchOption();
     }
-    return this.getBulkConcepts();
+    return null;
   };
 
   render() {
@@ -211,7 +194,6 @@ export const mapStateToProps = ({ bulkConcepts, concepts }) => ({
 export default connect(
   mapStateToProps,
   {
-    fetchBulkConcepts,
     addToFilterList,
     previewConcept,
     addConcept,

--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -2,7 +2,6 @@ import { notify } from 'react-notify-toast';
 import instance from '../../../../config/axiosConfig';
 import { isFetching, isSuccess } from '../../globalActionCreators';
 import {
-  FETCH_BULK_CONCEPTS,
   ADD_TO_DATATYPE_LIST,
   ADD_TO_CLASS_LIST,
   FETCH_FILTERED_CONCEPTS,
@@ -12,19 +11,6 @@ import {
   SET_NEXT_PAGE,
   SET_CURRENT_PAGE,
 } from '../../types';
-
-export const fetchBulkConcepts = (currentPage, source = 'CIEL') => async (dispatch) => {
-  const url = `orgs/${source}/sources/${source}/concepts/?limit=10&page=${currentPage}&&verbose=true`;
-  dispatch(isFetching(true));
-  try {
-    const response = await instance.get(url);
-    dispatch(isSuccess(response.data, FETCH_BULK_CONCEPTS));
-    dispatch(isFetching(false));
-  } catch (error) {
-    dispatch(isFetching(false));
-    notify.show('An error occurred with your internet connection, please fix it and try reloading the page.', 'error', 3000);
-  }
-};
 
 export const fetchFilteredConcepts = (source = 'CIEL', query = '', currentPage) => async (
   dispatch,

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -53,7 +53,6 @@ export const FETCH_USER_ORGANIZATION = '[user] fetch_user_organization';
 export const FETCH_SOURCE_CONCEPTS = '[concepts] fetch_source_concepts';
 export const FETCH_CONCEPT_SOURCES = '[concepts] fetch_concept_sources';
 export const CLEAR_SOURCE_CONCEPTS = '[concepts] clear source_concept_sources';
-export const FETCH_BULK_CONCEPTS = '[concept] fetch_bulk_concepts';
 export const ADD_EXISTING_BULK_CONCEPTS = '[concept] add_existing_bulk_concepts';
 export const ADD_TO_DATATYPE_LIST = '[concept] add_to_datatype_list';
 export const ADD_TO_CLASS_LIST = '[concept] add_to_class_list';

--- a/src/redux/reducers/bulkConceptReducer.js
+++ b/src/redux/reducers/bulkConceptReducer.js
@@ -1,5 +1,4 @@
 import {
-  FETCH_BULK_CONCEPTS,
   ADD_TO_DATATYPE_LIST,
   ADD_TO_CLASS_LIST,
   FETCH_FILTERED_CONCEPTS,
@@ -21,13 +20,6 @@ const userInitialState = {
 };
 const bulkConcepts = (state = userInitialState, action) => {
   switch (action.type) {
-    case FETCH_BULK_CONCEPTS:
-      return {
-        ...state,
-        bulkConcepts: action.payload,
-        datatypes: dataTypesList,
-        classes: classList,
-      };
     case FETCH_FILTERED_CONCEPTS:
       return {
         ...state,

--- a/src/tests/bulkConcepts/actions/bulkConcept.test.js
+++ b/src/tests/bulkConcepts/actions/bulkConcept.test.js
@@ -6,7 +6,6 @@ import { notify } from 'react-notify-toast';
 import instance from '../../../config/axiosConfig';
 import {
   IS_FETCHING,
-  FETCH_BULK_CONCEPTS,
   ADD_TO_DATATYPE_LIST,
   ADD_TO_CLASS_LIST,
   FETCH_FILTERED_CONCEPTS,
@@ -17,7 +16,6 @@ import {
   SET_PERVIOUS_PAGE,
 } from '../../../redux/actions/types';
 import {
-  fetchBulkConcepts,
   addToFilterList,
   fetchFilteredConcepts,
   previewConcept,
@@ -38,48 +36,6 @@ describe('Test suite for addBulkConcepts async actions', () => {
 
   afterEach(() => {
     moxios.uninstall(instance);
-  });
-
-  it('should handle FETCH_BULK_CONCEPTS', () => {
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent();
-      request.respondWith({
-        status: 200,
-        response: [concepts],
-      });
-    });
-
-    const expectedActions = [
-      { type: IS_FETCHING, payload: true },
-      { type: FETCH_BULK_CONCEPTS, payload: [concepts] },
-      { type: IS_FETCHING, payload: false },
-    ];
-
-    const store = mockStore({});
-
-    return store.dispatch(fetchBulkConcepts()).then(() => {
-      expect(store.getActions()).toEqual(expectedActions);
-    });
-  });
-  it('should handle error in FETCH_BULK_CONCEPTS', () => {
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent();
-      request.respondWith({
-        status: 400,
-        response: 'bad request',
-      });
-    });
-
-    const expectedActions = [
-      { type: IS_FETCHING, payload: true },
-      { type: IS_FETCHING, payload: false },
-    ];
-
-    const store = mockStore({});
-
-    return store.dispatch(fetchBulkConcepts()).then(() => {
-      expect(store.getActions()).toEqual(expectedActions);
-    });
   });
   it('should add concept on ADD_EXISTING_CONCEPTS action dispatch', () => {
     const notifyMock = jest.fn();

--- a/src/tests/bulkConcepts/components/ConceptPagination.test.js
+++ b/src/tests/bulkConcepts/components/ConceptPagination.test.js
@@ -12,7 +12,6 @@ describe('Test suite for ConceptPagination component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       data: [concepts],
       loading: false,
@@ -82,7 +81,6 @@ describe('Test suite for ConceptPagination component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       data: [{ id: '1' }, { id: '2' },
         { id: '3' }, { id: '4' },
@@ -118,7 +116,6 @@ describe('Test suite for ConceptPagination component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       data: [concepts],
       loading: false,
@@ -150,7 +147,6 @@ describe('Test suite for ConceptPagination component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       data: [concepts],
       loading: false,

--- a/src/tests/bulkConcepts/components/Pagination.test.js
+++ b/src/tests/bulkConcepts/components/Pagination.test.js
@@ -24,7 +24,6 @@ describe('Test suite for Paginations component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [concepts],
       loading: false,
@@ -64,7 +63,6 @@ describe('Test suite for Paginations component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [concepts],
       loading: false,

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -24,7 +24,6 @@ describe('Test suite for BulkConceptsPage component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [],
       loading: true,
@@ -56,7 +55,6 @@ describe('Test suite for BulkConceptsPage component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [],
       loading: false,
@@ -87,7 +85,6 @@ describe('Test suite for BulkConceptsPage component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [],
       loading: true,
@@ -121,7 +118,6 @@ describe('Test suite for BulkConceptsPage component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [],
       loading: true,
@@ -157,7 +153,6 @@ describe('Test suite for BulkConceptsPage component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [],
       loading: true,
@@ -195,7 +190,6 @@ describe('Test suite for BulkConceptsPage component', () => {
       setCurrentPage: jest.fn(),
       currentPage: 1,
       searchingOn: true,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [],
       loading: true,
@@ -237,75 +231,10 @@ describe('Test suite for BulkConceptsPage component', () => {
     expect(showState).toEqual(true);
   });
 
-  it('it should call the handle componentDidUpdate function', () => {
-    const props = {
-      setCurrentPage: jest.fn(),
-      currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
-      filterConcept: jest.fn(),
-      concepts: [],
-      loading: true,
-      datatypes: [],
-      classes: [],
-      conceptLimit: 10,
-      match: {
-        params: {
-          type: 'users',
-          typeName: 'emasys',
-          collectionName: 'dev-org',
-          language: 'en',
-          dictionaryName: 'CIEL',
-        },
-      },
-      addToFilterList: jest.fn(),
-      fetchFilteredConcepts: jest.fn(),
-      addConcept: jest.fn(),
-      previewConcept: jest.fn(),
-      handleNextPage: jest.fn(),
-      componentDidUpdate: jest.fn(),
-    };
-    const wrapper = shallow(<BulkConceptsPage {...props} />);
-    const instance = wrapper.instance();
-    expect(instance.componentDidUpdate(2)).toEqual(undefined);
-  });
-
-  it('it should call the handle componentDidMount function', () => {
-    const props = {
-      setCurrentPage: jest.fn(),
-      currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
-      filterConcept: jest.fn(),
-      concepts: [],
-      loading: true,
-      datatypes: [],
-      classes: [],
-      conceptLimit: 10,
-      match: {
-        params: {
-          type: 'users',
-          typeName: 'emasys',
-          collectionName: 'dev-org',
-          language: 'en',
-          dictionaryName: 'CIEL',
-        },
-      },
-      addToFilterList: jest.fn(),
-      fetchFilteredConcepts: jest.fn(),
-      addConcept: jest.fn(),
-      previewConcept: jest.fn(),
-      handleNextPage: jest.fn(),
-      componentDidMount: jest.fn(),
-    };
-    const wrapper = shallow(<BulkConceptsPage {...props} />);
-    const instance = wrapper.instance();
-    expect(instance.componentDidMount()).toEqual(undefined);
-  });
-
   it('it should call the handle componentDidUpdate function while searching', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [],
       loading: true,
@@ -333,53 +262,10 @@ describe('Test suite for BulkConceptsPage component', () => {
     expect(instance.componentDidUpdate(2)).toEqual(undefined);
   });
 
-  it('should refresh page when search input is empty', () => {
-    const props = {
-      setCurrentPage: jest.fn(),
-      currentPage: 1,
-      searchingOn: true,
-      fetchBulkConcepts: jest.fn(),
-      getBulkConcepts: jest.fn(),
-      bulkConceptsFetched: jest.fn(),
-      concepts: [],
-      loading: true,
-      datatypes: [],
-      classes: [],
-      conceptLimit: 10,
-      match: {
-        params: {
-          type: 'users',
-          typeName: 'emasys',
-          collectionName: 'dev-org',
-          language: 'en',
-          dictionaryName: 'CIEL',
-        },
-      },
-      addToFilterList: jest.fn(),
-      fetchFilteredConcepts: jest.fn(),
-      addConcept: jest.fn(),
-      previewConcept: jest.fn(),
-      handleNextPage: jest.fn(),
-    };
-    const wrapper = mount(<Router>
-      <Provider store={store}>
-        <BulkConceptsPage {...props} />
-      </Provider>
-    </Router>);
-    const Wrapper = wrapper.find('BulkConceptsPage').instance();
-    const spy = jest.spyOn(Wrapper.props, 'fetchBulkConcepts');
-    Wrapper.forceUpdate();
-    wrapper.update();
-    const event = { target: { name: 'searchInput', value: '' } };
-    wrapper.find('#search-concept').simulate('change', event);
-    expect(spy).toHaveBeenCalled();
-  });
-
   it('should search for concepts', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       fetchFilteredConcepts: jest.fn(),
       filterConcept: jest.fn(),
       handleSearch: jest.fn(),
@@ -431,7 +317,6 @@ describe('Test suite for BulkConceptsPage component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [concepts],
       loading: false,
@@ -466,7 +351,6 @@ describe('Test suite for BulkConceptsPage component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       filterConcept: jest.fn(),
       concepts: [concepts],
       loading: false,
@@ -502,7 +386,6 @@ describe('Test suite for BulkConceptsPage component', () => {
     const props = {
       setCurrentPage: jest.fn(),
       currentPage: 1,
-      fetchBulkConcepts: jest.fn(),
       concepts: [concepts],
       loading: false,
       datatypes: ['text'],

--- a/src/tests/bulkConcepts/reducer/index.test.js
+++ b/src/tests/bulkConcepts/reducer/index.test.js
@@ -1,7 +1,6 @@
 import deepFreeze from 'deep-freeze';
 import reducer from '../../../redux/reducers/bulkConceptReducer';
 import {
-  FETCH_BULK_CONCEPTS,
   ADD_TO_DATATYPE_LIST,
   ADD_TO_CLASS_LIST,
   FETCH_FILTERED_CONCEPTS,
@@ -33,22 +32,6 @@ describe('Test suite for bulkConcepts reducer', () => {
     expect(reducer(state, action)).toBe(state);
   });
 
-  it('should handle FETCH_BULK_CONCEPTS', () => {
-    action = {
-      type: FETCH_BULK_CONCEPTS,
-      payload: [concepts, concept2],
-    };
-
-    deepFreeze(state);
-    deepFreeze(action);
-
-    expect(reducer(state, action)).toEqual({
-      ...state,
-      classes: classList,
-      datatypes: dataTypesList,
-      bulkConcepts: action.payload,
-    });
-  });
   it('should handle SET_NEXT_PAGE', () => {
     action = {
       type: SET_NEXT_PAGE,


### PR DESCRIPTION

# JIRA TICKET NAME:
[On the Add CIEL concepts page, do not show any concepts
](https://issues.openmrs.org/browse/OCLOMRS-529)

# Summary:
As Andy mentioned on the call today, when you first open this, do not trigger an empty search, and do not show any concepts. (There are 60000 concepts, so showing one page is not helpful.)