### PR TITLE
OCLOMRS-528: The concept ID should be visible on the Dictionary Concepts page

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -61,9 +61,9 @@ const ConceptTable = ({
           Cell: cell => showCellContents(cell),
         },
         {
-          Header: 'Source',
+          Header: 'Source - ID',
           id: 'sourceCol',
-          accessor: concept => [concept.source, concept.retired],
+          accessor: concept => [`${concept.source} - ${concept.id}`, concept.retired],
           Cell: cell => showCellContents(cell),
         },
         {


### PR DESCRIPTION
# JIRA TICKET NAME:
[The concept ID should be visible on the Dictionary Concepts page](https://issues.openmrs.org/browse/OCLOMRS-528)

# Summary:
The concept ID should be visible on the Dictionary Concepts page
