### PR TITLE
OCLOMRS-525: Change the spelling of "sources" on the Dictionary concepts page

### DIFF
--- a/src/components/dictionaryConcepts/components/Sidenav.jsx
+++ b/src/components/dictionaryConcepts/components/Sidenav.jsx
@@ -8,7 +8,7 @@ const Sidenav = ({
   <div className="col-12 col-md-2 custom-full-width">
     <div className="sidenav-container">
       <div className="row">
-        <h6 className="sidenav-header">Sources</h6>
+        <h6 className="sidenav-header">Source</h6>
       </div>
       {filteredSources.map(source => (
         <SideNavItem


### PR DESCRIPTION


# JIRA TICKET NAME:
[Change the spelling of "sources" on the Dictionary concepts page](https://issues.openmrs.org/browse/OCLOMRS-525)

# Summary:
Change the spelling of "sources" on the Dictionary concepts page to 'Source'