### PR TITLE
OCLOMRS-526: On the Dictionary Concepts Page, the names should be fully displayed

### DIFF
--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -141,6 +141,10 @@ body {
     flex: none;
 }
 
+.ReactTable .rt-td {
+  white-space: normal;
+}
+
 .search-container .concept-search-wrapper .fa-search {
   font-size: .8rem;
   padding-right: .7rem;


### PR DESCRIPTION
# JIRA TICKET NAME:
[On the Dictionary Concepts Page, the names should be fully displayed](https://issues.openmrs.org/browse/OCLOMRS-526)

# Summary:
On the Dictionary Concepts Page, the names should be fully displayed. Remove the ellipsis
