### PR TITLE
OCLOMRS-535: When creating a concept, removing a name should really remove it, not just hide it in the UI

### DIFF
--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -233,7 +233,8 @@ export class CreateConcept extends Component {
     }
   }
 
-  removeDataFromRow(id, arrayName) {
+  removeDataFromRow(data, arrayName) {
+    const id = data.uuid;
     const currentData = this.state[arrayName].filter(name => name.id !== id);
     if (currentData.length) {
       const newItems = this.state[arrayName].filter(name => name.id !== id);


### PR DESCRIPTION
# JIRA TICKET NAME:
[When creating a concept, removing a name should really remove it, not just hide it in the UI](https://issues.openmrs.org/browse/OCLOMRS-535)

# Summary:
Steps to reproduce the bug:

- Create a new concept(e.g Symptom/Finding)
- Name: Any name in any language(e.g “Itchy Nose” in English), preferred in language = true
- Click add another name
- Choose the language e.g French(or any other) for the other name
- Click Remove on the second name without entering anything
- Enter description
- Save Concept

Bug:

When the concepts page is refreshed, an empty row appears i.e. an extra concept is created without a name