### PR TITLE
OCLOMRS-541: Update state persistence to save only user information

### DIFF
--- a/src/redux/reducers/store.js
+++ b/src/redux/reducers/store.js
@@ -4,6 +4,8 @@ import reduxThunk from 'redux-thunk';
 import logger from 'redux-logger';
 import rootReducer from './index';
 
+export const STORE_VERSION = '1';
+
 const saveState = (state) => {
   try {
     localStorage.setItem('state', JSON.stringify(state));
@@ -13,12 +15,19 @@ const saveState = (state) => {
   }
 };
 
-const loadState = () => {
+export const loadState = () => {
   try {
     const state = localStorage.getItem('state');
     if (state === null) {
       return undefined;
     }
+
+    const storeVersion = localStorage.getItem('storeVersion');
+    if (storeVersion !== STORE_VERSION) {
+      localStorage.setItem('storeVersion', STORE_VERSION);
+      return undefined;
+    }
+
     return JSON.parse(state);
   } catch (e) {
     return undefined;

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -1,0 +1,30 @@
+import { loadState, STORE_VERSION } from '../redux/reducers/store';
+
+describe('loadState', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should return undefined when state is null', () => {
+    expect(loadState()).toEqual(undefined);
+  });
+
+  describe('should return undefined when store versions don\'t match', () => {
+    it('should return undefined when store version in local storage is null', () => {
+      localStorage.setItem('state', 'state');
+      expect(loadState()).toEqual(undefined);
+    });
+
+    it('should return undefined when store versions don\'t match', () => {
+      localStorage.setItem('storeVersion', STORE_VERSION - 1);
+      localStorage.setItem('state', 'state');
+      expect(loadState()).toEqual(undefined);
+    });
+  });
+
+  it('should return the right state that was saved', () => {
+    localStorage.setItem('storeVersion', STORE_VERSION);
+    localStorage.setItem('state', JSON.stringify('state'));
+    expect(loadState()).toEqual('state');
+  });
+});


### PR DESCRIPTION
# JIRA TICKET NAME:
[Update state persistence to save only user information](https://issues.openmrs.org/browse/OCLOMRS-541)

# Summary:
#### Related issues;
- Filtering on the Add CIEL concepts not consistent
- Dictionary summary not showing correct counts
- Login loading persisted as true even after fix
- Viewing a previously added dictionary occasionally crashing
- Incorrect sources shown by Q-A concepts