### PR TITLE
OCLOMRS-541: Update state persistence to introduce state versioning

### DIFF
--- a/src/redux/reducers/store.js
+++ b/src/redux/reducers/store.js
@@ -4,21 +4,31 @@ import reduxThunk from 'redux-thunk';
 import logger from 'redux-logger';
 import rootReducer from './index';
 
+export const STORE_VERSION = '1';
+export const CURRENT_STORE_VERSION_KEY = 'currentStoreVersion';
+
 const saveState = (state) => {
   try {
     localStorage.setItem('state', JSON.stringify(state));
+    localStorage.setItem(CURRENT_STORE_VERSION_KEY, STORE_VERSION);
     return undefined;
   } catch (e) {
     return undefined;
   }
 };
 
-const loadState = () => {
+export const loadState = () => {
   try {
     const state = localStorage.getItem('state');
     if (state === null) {
       return undefined;
     }
+
+    const currentStoreVersion = localStorage.getItem(CURRENT_STORE_VERSION_KEY);
+    if (currentStoreVersion !== STORE_VERSION) {
+      return undefined;
+    }
+
     return JSON.parse(state);
   } catch (e) {
     return undefined;

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -1,0 +1,42 @@
+import { loadState, STORE_VERSION, CURRENT_STORE_VERSION_KEY } from '../redux/reducers/store';
+
+describe('loadState', () => {
+  const expectedState = {
+    concepts: [1, 2],
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should return undefined when state is null', () => {
+    expect(loadState()).toEqual(undefined);
+  });
+
+  describe('should return undefined when store versions don\'t match', () => {
+    it('should return undefined when store version in local storage is null', () => {
+      localStorage.setItem('state', JSON.stringify(expectedState));
+      expect(loadState()).toEqual(undefined);
+    });
+
+    it('should return undefined when store versions don\'t match', () => {
+      localStorage.setItem(CURRENT_STORE_VERSION_KEY, STORE_VERSION - 1);
+      localStorage.setItem('state', JSON.stringify(expectedState));
+      const loadedState = loadState();
+      expect(loadedState).not.toEqual(expectedState);
+      expect(loadedState).toEqual(undefined);
+    });
+  });
+
+  it('should return the state that was saved when store versions match', () => {
+    localStorage.setItem(CURRENT_STORE_VERSION_KEY, STORE_VERSION);
+    localStorage.setItem('state', JSON.stringify(expectedState));
+    expect(loadState()).toEqual(expectedState);
+  });
+
+  it('should not return the saved state when store versions don\'t match', () => {
+    localStorage.setItem(CURRENT_STORE_VERSION_KEY, STORE_VERSION - 1);
+    localStorage.setItem('state', JSON.stringify(expectedState));
+    expect(loadState()).not.toEqual(expectedState);
+  });
+});


### PR DESCRIPTION
# JIRA TICKET NAME:
[Update state persistence to introduce state versioning](https://issues.openmrs.org/browse/OCLOMRS-541)

# Summary:
Given that we are persisting state, we have situation where when an individual updates the structure of state, it conflicts with the currently stored state, causing a crash

 

This ticket introduces versioning to solve this issue.