### PR TITLE
OCLOMRS-556: When creating a set or symptom-finding concept, a user should be able to select from the different class options

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -71,7 +71,7 @@ const CreateConceptForm = (props) => {
           <div className="form-group col-md-5">
             <label htmlFor="class"><h5>Class</h5></label>
             <div>
-              { (props.concept.toString().trim() === 'symptom-finding')
+              { (props.concept.toString().trim() === 'Symptom-Finding')
               && (
               <React.Fragment>
                 <select
@@ -91,7 +91,7 @@ const CreateConceptForm = (props) => {
               )
               }
 
-              { (props.concept.toString().trim() === 'set')
+              { (props.concept.toString().trim() === 'Set')
               && (
               <React.Fragment>
                 <select
@@ -112,8 +112,8 @@ const CreateConceptForm = (props) => {
               }
 
               {(
-                props.concept.toString().trim() !== 'symptom-finding'
-                && props.concept.toString().trim() !== 'set') && (
+                props.concept.toString().trim() !== 'Symptom-Finding'
+                && props.concept.toString().trim() !== Set) && (
                 <span className="btn btn-sm btn-light normal-cursor col-12 text-capitalize pt-3">
                   {props.concept}
                 </span>

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -361,7 +361,7 @@ export class CreateConcept extends Component {
     const { mappings } = this.state;
     const concept = conceptType ? `${conceptType}` : '';
     const path = localStorage.getItem('dictionaryPathName');
-    const append = concept === 'set' ? ' of concepts' : ' concept';
+    const append = concept === 'Set' ? ' of concepts' : ' concept';
 
     return (
       <div className="container create-custom-concept">

--- a/src/tests/dictionaryConcepts/components/CreateConceptForm.test.jsx
+++ b/src/tests/dictionaryConcepts/components/CreateConceptForm.test.jsx
@@ -39,7 +39,7 @@ describe('Test suite for CreateConceptForm', () => {
       state: {
         id: '1',
       },
-      concept: 'set',
+      concept: 'Set',
       addDescription: jest.fn(),
       handleNewName: jest.fn(),
       path: '',
@@ -64,7 +64,7 @@ describe('Test suite for CreateConceptForm', () => {
       state: {
         id: '1',
       },
-      concept: 'symptom-finding',
+      concept: 'Symptom-Finding',
       addDescription: jest.fn(),
       handleNewName: jest.fn(),
       path: '',

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -147,14 +147,14 @@ describe('Test suite for dictionary concepts components', () => {
         ...props.match,
         params: {
           ...props.match.params,
-          conceptType: 'set',
+          conceptType: 'Set',
         },
       },
     };
     wrapper = mount(<Router>
       <CreateConcept {...newProps} />
     </Router>);
-    expect(wrapper.find('h3').text()).toEqual(': Create a set of concepts');
+    expect(wrapper.find('h3').text()).toEqual(': Create a Set of concepts');
     expect(wrapper).toMatchSnapshot();
   });
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[When creating a set or symptom-finding concept, a user should be able to select from the different class options](https://issues.openmrs.org/browse/OCLOMRS-556)

# Summary:
When creating a set or symptom-finding concept, a user should be able to select the different class options.