### PR TITLE
OCLOMRS-557: On concept preview for a question or set concepts, the answers or set members should have a space between the title and ID

### DIFF
--- a/src/components/bulkConcepts/component/PreviewCard.jsx
+++ b/src/components/bulkConcepts/component/PreviewCard.jsx
@@ -13,13 +13,13 @@ import {
 const getSetMembers = mappings => (
   mappings.filter(mapping => mapping.map_type === MAP_TYPE.conceptSet))
   .map(
-    mapping => `<div>${mapping.to_concept_name}(${mapping.to_concept_code})</div>`,
+    mapping => `<div>${mapping.to_concept_name} (${mapping.to_concept_code})</div>`,
   );
 
 const getAnswers = mappings => (
   mappings.filter(mapping => mapping.map_type === MAP_TYPE.questionAndAnswer))
   .map(
-    mapping => `<div>${mapping.to_concept_name}(${mapping.to_concept_code})</div>`,
+    mapping => `<div>${mapping.to_concept_name} (${mapping.to_concept_code})</div>`,
   );
 
 const getOtherMappings = mappings => (


### PR DESCRIPTION
# JIRA TICKET NAME:
[On concept preview for a question or set concepts, the answers or set members should have a space between the title and ID](https://issues.openmrs.org/browse/OCLOMRS-557)

# Summary:
On concept preview for a question or set concepts, the answers or set members should have a space between the title and ID