### PR TITLE
OCLOMRS-558: Fix the issue of missing Add answers field when creating a question concept

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -4,7 +4,7 @@ import CreateConceptTable from './CreateConceptTable';
 import DescriptionTable from './DescriptionTable';
 import AnswersTable from './AnswersTable';
 import CreateMapping from './CreateMapping';
-import { classes, MAP_TYPE } from './helperFunction';
+import { classes, MAP_TYPE, CONCEPT_CLASS } from './helperFunction';
 
 const CreateConceptForm = (props) => {
   const {
@@ -187,7 +187,7 @@ const CreateConceptForm = (props) => {
             </div>
           </div>
         </div>
-        {concept.toString().trim() === 'question' ? (
+        {concept.toString().trim() === CONCEPT_CLASS.question ? (
           <div className="form-group answer">
             <div className="row col-12 custom-concept-list">
               <h5 className="text-left section-header">Answers</h5>

--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -59,6 +59,14 @@ export const MAP_TYPE = {
   questionAndAnswer: 'Q-AND-A',
 };
 
+export const CONCEPT_TYPE = {
+  question: 'Question',
+};
+
+export const CONCEPT_CLASS = {
+  question: 'Question',
+};
+
 export const TRADITIONAL_OCL_HOST = urlConfig.TRADITIONAL_OCL_HOST;
 export const CANCEL_WARNING = 'You have unsaved changes. Do you wish to leave without saving these changes?';
 export const LEAVE_PAGE_POPUP_TITLE = 'Are you sure you want to leave this page?';

--- a/src/tests/dictionaryConcepts/components/CreateConceptForm.test.jsx
+++ b/src/tests/dictionaryConcepts/components/CreateConceptForm.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import CreateConceptForm from '../../../components/dictionaryConcepts/components/CreateConceptForm';
 import { mockSource } from '../../__mocks__/concepts';
+import { CONCEPT_CLASS } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 describe('Test suite for CreateConceptForm', () => {
   it('should render CreateConceptForm Component', () => {
@@ -89,7 +90,7 @@ describe('Test suite for CreateConceptForm', () => {
       state: {
         id: '1',
       },
-      concept: 'question',
+      concept: CONCEPT_CLASS.question,
       addDescription: jest.fn(),
       handleNewName: jest.fn(),
       path: '',

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -8,7 +8,7 @@ import {
 import {
   newConcept, mockSource, mockCielSource, mockMapping,
 } from '../../__mocks__/concepts';
-import { INTERNAL_MAPPING_DEFAULT_SOURCE } from '../../../components/dictionaryConcepts/components/helperFunction';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE, CONCEPT_CLASS, CONCEPT_TYPE } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 jest.mock('uuid/v4', () => jest.fn(() => '1234'));
 jest.mock('react-notify-toast');
@@ -17,7 +17,7 @@ describe('Test suite for dictionary concepts components', () => {
   const props = {
     match: {
       params: {
-        conceptType: 'question',
+        conceptType: CONCEPT_TYPE.question,
         collectionName: 'dev-col',
         type: 'users',
         typeName: 'emasys',
@@ -39,7 +39,7 @@ describe('Test suite for dictionary concepts components', () => {
     loading: false,
     newConcept: {
       id: '1',
-      concept_class: 'question',
+      concept_class: CONCEPT_CLASS.question,
       datatype: 'Text',
       names: [],
       descriptions: [],
@@ -136,7 +136,7 @@ describe('Test suite for dictionary concepts components', () => {
   });
 
   it('should render without breaking', () => {
-    expect(wrapper.find('h3').text()).toEqual(': Create a question concept');
+    expect(wrapper.find('h3').text()).toEqual(': Create a Question concept');
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -9,7 +9,7 @@ import {
 import {
   newConcept, existingConcept, mockSource, sampleConcept, newMappings,
 } from '../../__mocks__/concepts';
-import { INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL } from '../../../components/dictionaryConcepts/components/helperFunction';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL, CONCEPT_TYPE } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 jest.mock('uuid/v4', () => jest.fn(() => '1234'));
 jest.mock('react-notify-toast');
@@ -30,7 +30,7 @@ describe('Test suite for dictionary concepts components', () => {
   const props = {
     match: {
       params: {
-        conceptType: 'question',
+        conceptType: CONCEPT_TYPE.question,
         collectionName: 'dev-col',
         type: 'users',
         typeName: 'emmabaye',
@@ -134,7 +134,7 @@ describe('Test suite for dictionary concepts components', () => {
     const wrapper = mount(<Router>
       <EditConcept {...props} />
     </Router>);
-    expect(wrapper.find('h3').text()).toEqual(': Edit a question Concept ');
+    expect(wrapper.find('h3').text()).toEqual(': Edit a Question Concept ');
     wrapper.unmount();
     expect(wrapper).toMatchSnapshot();
   });
@@ -312,7 +312,7 @@ describe('Test suite for mappings on existing concepts', () => {
   const props = {
     match: {
       params: {
-        conceptType: 'question',
+        conceptType: CONCEPT_TYPE.question,
         collectionName: 'dev-col',
         type: 'users',
         typeName: 'emmabaye',


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix the issue of missing Add answers field when creating a question concept](https://issues.openmrs.org/browse/OCLOMRS-558)

# Summary:
Fix the issue of missing Add answers field when creating a question concept