### PR TITLE
OCLOMRS-542: Create and edit a concept without a description (which should be optional)

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -27,7 +27,7 @@ const CreateConceptForm = (props) => {
 
   const selectedMappings = mappings
     .filter(map => map.retired === false && map.map_type !== MAP_TYPE.questionAndAnswer);
-
+  const descriptions = props.existingConcept.descriptions || props.description;
   return (
     <form className="form-wrapper" onSubmit={props.handleSubmit} id="createConceptForm">
       <div className="concept-form-body">
@@ -182,7 +182,7 @@ const CreateConceptForm = (props) => {
                 onClick={props.addDescription}
                 className="btn btn-outline-secondary btn-sm "
               >
-                Add another description...
+                {descriptions.length > 0 ? 'Add another description...' : 'Add a description'}
               </button>
             </div>
           </div>
@@ -301,6 +301,7 @@ CreateConceptForm.propTypes = {
   removeAnswerRow: PropTypes.func,
   currentDictionaryName: PropTypes.string,
   removeCurrentAnswer: PropTypes.func,
+  description: PropTypes.array,
 };
 
 CreateConceptForm.defaultProps = {
@@ -321,6 +322,7 @@ CreateConceptForm.defaultProps = {
   removeAnswerRow: () => {},
   currentDictionaryName: '',
   removeCurrentAnswer: () => {},
+  description: [],
 };
 
 export default CreateConceptForm;

--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -8,7 +8,6 @@ class DescriptionRow extends Component {
   static propTypes = {
     rowId: PropTypes.string,
     newRow: PropTypes.object,
-    newRowUuid: PropTypes.string,
     addDataFromDescription: PropTypes.func.isRequired,
     removeDescription: PropTypes.func.isRequired,
     removeDataFromRow: PropTypes.func.isRequired,
@@ -27,7 +26,6 @@ class DescriptionRow extends Component {
       locale_preferred: true,
       name_type: '',
     },
-    newRowUuid: '',
     rowId: '',
   };
 
@@ -128,9 +126,7 @@ class DescriptionRow extends Component {
             className=" btn btn-danger concept-form-table-link"
             id="remove-description"
             type="button"
-            onClick={event => ((this.props.newRowUuid === '')
-              ? this.handleRemove(event, this.props.newRow)
-              : this.handleRemove(event, this.props.newRowUuid))}
+            onClick={event => this.handleRemove(event, this.props.newRow)}
           >
             remove
           </button>

--- a/src/components/dictionaryConcepts/components/DescriptionTable.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionTable.jsx
@@ -1,37 +1,29 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import DescriptionRow from './DescriptionRow';
 
-const DescriptionTable = props => (
-  <table className="table table-striped table-bordered concept-form-table">
-    <thead className="header text-white">
-      <tr>
-        <th scope="col">Description</th>
-        <th scope="col">Language</th>
-        <th scope="col">Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      {props.existingConcept && props.existingConcept.descriptions
-        ? props.existingConcept.descriptions.map(newRow => (
-          <DescriptionRow
-            newRow={newRow}
-            rowId={newRow.uuid}
-            key={newRow.uuid}
-            {...props}
-          />
-        ))
-        : props.description.map(newRow => (
-          <DescriptionRow
-            newRowUuid={newRow}
-            rowId={newRow}
-            key={newRow}
-            {...props}
-          />))
-      }
-    </tbody>
-  </table>
-);
+class DescriptionTable extends PureComponent {
+  render() {
+    const { existingConcept, description } = this.props;
+    const descriptions = existingConcept.descriptions || description;
+    return (
+      <table className="table table-striped table-bordered concept-form-table">
+        <thead className="header text-white">
+          <tr>
+            <th scope="col">Description</th>
+            <th scope="col">Language</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {descriptions.map(newRow => (
+            <DescriptionRow newRow={newRow} rowId={newRow.uuid} key={newRow.uuid} {...this.props} />
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+}
 
 DescriptionTable.propTypes = {
   description: PropTypes.array.isRequired,

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -235,13 +235,10 @@ export class CreateConcept extends Component {
 
   removeDataFromRow(data, arrayName) {
     const id = data.uuid;
-    const currentData = this.state[arrayName].filter(name => name.id !== id);
-    if (currentData.length) {
-      const newItems = this.state[arrayName].filter(name => name.id !== id);
-      this.setState(() => ({
-        [arrayName]: newItems,
-      }));
-    }
+    const newItems = this.state[arrayName].filter(name => name.id !== id);
+    this.setState(() => ({
+      [arrayName]: newItems,
+    }));
   }
 
   addDataFromDescription(data) {

--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -108,7 +108,6 @@ export class EditConcept extends Component {
   componentDidMount() {
     this.props.clearPreviousConcept();
     this.props.createNewName();
-    this.props.addNewDescription();
     this.updateState();
     const {
       match: {

--- a/src/redux/reducers/ConceptReducers.js
+++ b/src/redux/reducers/ConceptReducers.js
@@ -37,10 +37,10 @@ import {
   filterList,
   normalizeList,
   filterNames,
-  filterDescriptions,
+  removeItem,
   updatePopulatedAnswers,
+  addDescription,
 } from './util';
-
 
 const initialState = {
   concepts: [],
@@ -68,7 +68,6 @@ const initialState = {
     frontEndUniqueKey: 'intialKey',
   }],
 };
-
 
 export default (state = initialState, action) => {
   const calculatePayload = () => {
@@ -152,7 +151,7 @@ export default (state = initialState, action) => {
     case ADD_NEW_DESCRIPTION:
       return {
         ...state,
-        description: [...state.description, action.payload],
+        description: addDescription(action.payload, state.description),
       };
     case REMOVE_ONE_DESCRIPTION:
       return {
@@ -201,10 +200,7 @@ export default (state = initialState, action) => {
         ...state,
         existingConcept: {
           ...state.existingConcept,
-          descriptions: [
-            ...state.existingConcept.descriptions,
-            { uuid: action.payload },
-          ],
+          descriptions: addDescription(action.payload, state.existingConcept.descriptions),
         },
       };
     case EDIT_CONCEPT_CREATE_NEW_NAMES:
@@ -223,7 +219,7 @@ export default (state = initialState, action) => {
         ...state,
         existingConcept: {
           ...state.existingConcept,
-          descriptions: filterDescriptions(action.payload, state.existingConcept.descriptions),
+          descriptions: removeItem(action.payload, state.existingConcept.descriptions),
         },
       };
     case EDIT_CONCEPT_REMOVE_ONE_NAME:
@@ -231,7 +227,7 @@ export default (state = initialState, action) => {
         ...state,
         existingConcept: {
           ...state.existingConcept,
-          names: filterDescriptions(action.payload, state.existingConcept.names),
+          names: removeItem(action.payload, state.existingConcept.names),
         },
       };
     case FETCH_EXISTING_CONCEPT_ERROR:

--- a/src/redux/reducers/util.js
+++ b/src/redux/reducers/util.js
@@ -70,7 +70,10 @@ export const filterUserPayload = (user, payload) => {
   return filteredDictionaries;
 };
 
-export const filterDescriptions = (item, list) => list.filter(listItem => listItem.uuid !== item);
+export const removeItem = (item, list) => {
+  const newList = list ? list.filter(listItem => listItem.uuid !== item) : [];
+  return newList;
+};
 
 export const updatePopulatedAnswers = (ans, answers) => {
   const newAnswers = answers.map((item) => {
@@ -80,4 +83,9 @@ export const updatePopulatedAnswers = (ans, answers) => {
     return item;
   });
   return newAnswers;
+};
+
+export const addDescription = (uuid, list) => {
+  const newList = list ? [...list, { uuid }] : [{ uuid }];
+  return newList;
 };

--- a/src/tests/dictionaryConcepts/components/DescriptionTable.test.jsx
+++ b/src/tests/dictionaryConcepts/components/DescriptionTable.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import DescriptionTable from
   '../../../components/dictionaryConcepts/components/DescriptionTable';
 
@@ -28,6 +28,22 @@ describe('Test suite for DescriptionTable', () => {
   it('should render CreateConceptTable Component for undefined existingConcepts', () => {
     props.existingConcept = {};
     const wrapper = shallow(<DescriptionTable {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('should render DescriptionTable Component for new concepts', () => {
+    const newProps = {
+      ...props,
+      existingConcept: {},
+      description: [{
+        uuid: 'newUUID',
+      }, {
+        uuid: 'a.n.other',
+      }],
+    };
+    const wrapper = mount(<DescriptionTable {...newProps} />);
+    expect(wrapper.find('DescriptionRow').length).toEqual(newProps.description.length);
+    expect(wrapper.find('DescriptionRow').at(0).instance().props.newRow)
+      .toEqual(newProps.description[0]);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -35,7 +35,7 @@ describe('Test suite for dictionary concepts components', () => {
     removeDescription: jest.fn(),
     createNewConcept: jest.fn(),
     newName: ['1'],
-    description: ['1'],
+    description: [{ uuid: '1' }],
     loading: false,
     newConcept: {
       id: '1',

--- a/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
@@ -44,7 +44,7 @@ beforeEach(() => {
     sourceList: [],
     classList: [],
     newName: ['456'],
-    description: ['456'],
+    description: [{ uuid: '456' }],
     answer: ['123y'],
     newConcept: {},
     addConceptToDictionary: [],
@@ -168,7 +168,7 @@ describe('Test suite for single dictionary concepts', () => {
 
     expect(reducer(state, action)).toEqual({
       ...state,
-      description: ['456', '123'],
+      description: [{ uuid: '456' }, { uuid: '123' }],
     });
   });
 
@@ -183,7 +183,7 @@ describe('Test suite for single dictionary concepts', () => {
 
     expect(reducer(state, action)).toEqual({
       ...state,
-      description: ['456'],
+      description: [{ uuid: '456' }],
     });
   });
   it('should handle CLEAR_FORM_SELECTIONS', () => {


### PR DESCRIPTION


# JIRA TICKET NAME:
[Create and edit a concept without a description (which should be optional)](https://issues.openmrs.org/browse/OCLOMRS-542)

# Summary:
Creating a concept without a description (which should be optional) fails silently. The concept is not created but doesn't notify the user.

Relatedly, creating a concept with a description then editing it to remove the description works. However, on a subsequent edit, trying to remove the empty description added by default causes the app to crash. 
