### PR TITLE
OCLOMRS-553: When you edit a concept, a new version of that concept should be created and its reference refreshed in the collection

### DIFF
--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -22,7 +22,6 @@ import {
   addSelectedAnswersToState,
   removeSelectedAnswer,
   addNewAnswerRow,
-  createNewConcept,
   unPopulateThisAnswer,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import {
@@ -32,9 +31,8 @@ import {
 } from '../components/helperFunction';
 import { fetchConceptSources } from '../../../redux/actions/bulkConcepts';
 import {
-  removeDictionaryConcept,
   removeConceptMapping,
-  removeEditedConceptMapping,
+  removeEditedConceptMapping, addReferenceToCollectionAction, deleteReferenceFromCollectionAction,
 } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import GeneralModel from '../../dashboard/components/dictionary/common/GeneralModal';
 
@@ -74,10 +72,10 @@ export class EditConcept extends Component {
     selectedAnswers: PropTypes.array.isRequired,
     removeAnswer: PropTypes.func.isRequired,
     createNewAnswerRow: PropTypes.func.isRequired,
-    deleteConcept: PropTypes.func.isRequired,
-    recreateConcept: PropTypes.func.isRequired,
     unPopulateAnswer: PropTypes.func.isRequired,
     dictionaryConcepts: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+    addReferenceToCollection: PropTypes.func.isRequired,
+    deleteReferenceFromCollection: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -187,47 +185,35 @@ export class EditConcept extends Component {
     this.setState({ [name]: value });
   }
 
-  recreateMappings = mappings => mappings.map((mapping) => {
-    const isInternal = Boolean(
-      mapping.to_source_url
-      && (mapping.to_source_url.trim().toLowerCase() === CIEL_SOURCE_URL.trim().toLowerCase()),
-    );
-    const freshMapping = {
-      ...mapping,
-      isNew: true,
-      url: String(uuid()),
-      source: isInternal ? INTERNAL_MAPPING_DEFAULT_SOURCE : mapping.source,
-      to_source_url: isInternal
-        ? `${mapping.to_source_url}concepts/${mapping.to_concept_code}/`
-        : mapping.to_source_url,
-    };
-    return freshMapping;
-  });
-
-  deleteConceptReference = (version_url) => {
-    const { deleteConcept, match: { params: { type, typeName, collectionName } } } = this.props;
-    deleteConcept({ references: [version_url] }, type, typeName, collectionName);
-  }
-
-  updateConceptReference = async (concept, mappings) => {
-    const { answers } = this.state;
-    const { recreateConcept, dictionaryConcepts } = this.props;
+  updateConceptReference = async (concept) => {
+    const {
+      dictionaryConcepts,
+      match: { params: { type, typeName, collectionName } },
+      deleteReferenceFromCollection,
+      addReferenceToCollection,
+    } = this.props;
     const conceptRef = dictionaryConcepts.find(c => c.id === concept.id);
-    const newMappings = mappings && this.recreateMappings(mappings);
-    const freshConcept = {
-      ...concept,
-      id: String(uuid()),
-      answers,
-      mappings: newMappings,
-    };
-    recreateConcept(freshConcept, this.createUrl)
-      .then(() => this.deleteConceptReference(conceptRef.version_url));
-  }
+
+    let response = await deleteReferenceFromCollection(type, typeName, collectionName, [
+      conceptRef.version_url,
+    ]);
+    if (!response) return false;
+
+    response = await addReferenceToCollection(type, typeName, collectionName, [conceptRef.url]);
+    if (!response) return false;
+
+    return true;
+  };
 
   handleSubmit = (event) => {
     event.preventDefault();
     const { mappings } = this.state;
-    const { removeEditedConceptMappingAction, history } = this.props;
+    const {
+      removeEditedConceptMappingAction,
+      history,
+      match: { params: { collectionName } },
+      existingConcept: concept,
+    } = this.props;
     const retired = mappings.filter(mapping => mapping.retired);
     const freshMappings = mappings.filter(mapping => mapping.isNew);
     const editedAns = this.editedAnswers;
@@ -246,9 +232,9 @@ export class EditConcept extends Component {
     const regx = /^[a-zA-Z\d-_]+$/;
     if (regx.test(this.state.id) && this.state.datatype && this.state.concept_class) {
       const unRetiredMappings = mappings.filter(m => m.retired === false);
-      this.props.updateConcept(this.conceptUrl, this.state, history)
-        .then(editedConcept => this.updateConceptReference(editedConcept, unRetiredMappings)
-          .then(() => setTimeout(() => history.goBack(), 2000)));
+      this.props.updateConcept(this.conceptUrl, this.state, history, collectionName, concept)
+        .then(result => result && this.updateConceptReference(result, unRetiredMappings)
+          .then(() => history.goBack()));
     } else {
       if (!regx.test(this.state.id)) {
         notify.show('enter a valid uuid', 'error', 3000);
@@ -373,15 +359,21 @@ export class EditConcept extends Component {
     });
   }
 
-  removeUnsavedMappingRow = (url) => {
+  removeUnsavedMappingRow = (url, wasRetired = true) => {
     const { mappings } = this.state;
-    const selectedMappings = mappings.map((map) => {
-      const updatedMap = map;
-      if (updatedMap.url === url) {
-        updatedMap.retired = true;
-      }
-      return updatedMap;
-    });
+    let selectedMappings;
+    if (wasRetired) {
+      selectedMappings = mappings.map((map) => {
+        const updatedMap = map;
+        if (updatedMap.url === url) {
+          updatedMap.retired = true;
+        }
+        return updatedMap;
+      });
+    } else {
+      selectedMappings = mappings.filter(mapping => mapping.url !== url);
+    }
+
     this.setState({ mappings: selectedMappings });
   }
 
@@ -424,7 +416,7 @@ export class EditConcept extends Component {
     this.setState({ mapp });
     const filterMappings = mappings.filter(map => map.url === url);
     if (filterMappings[0].isNew) {
-      this.removeUnsavedMappingRow(url);
+      this.removeUnsavedMappingRow(url, false);
       return;
     }
     this.showGeneralModal(url);
@@ -650,8 +642,8 @@ export default connect(
     addSelectedAnswers: addSelectedAnswersToState,
     removeAnswer: removeSelectedAnswer,
     createNewAnswerRow: addNewAnswerRow,
-    deleteConcept: removeDictionaryConcept,
-    recreateConcept: createNewConcept,
     unPopulateAnswer: unPopulateThisAnswer,
+    addReferenceToCollection: addReferenceToCollectionAction,
+    deleteReferenceFromCollection: deleteReferenceFromCollectionAction,
   },
 )(EditConcept);

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -382,12 +382,12 @@ export const UpdateMapping = (data) => {
   }));
 };
 
-export const updateConcept = (conceptUrl, data, history) => async (dispatch) => {
+export const updateConcept = (conceptUrl, data, history, source, concept) => async (dispatch) => {
   dispatch(isFetching(true));
   const url = conceptUrl;
   try {
     const response = await instance.put(url, data);
-    CreateMapping(data.mappings, data.from_concept_url, data.source);
+    CreateMapping(data.mappings, concept.url, source);
     UpdateMapping(data.mappings);
     dispatch(isSuccess(response.data, UPDATE_CONCEPT));
     await addAnswerMappingToConcept(response.data.url, response.data.source, data.answers);
@@ -407,7 +407,8 @@ export const updateConcept = (conceptUrl, data, history) => async (dispatch) => 
     }
     dispatch(isFetching(false));
   }
-  return history.goBack();
+  history.goBack();
+  return false;
 };
 
 export const clearPreviousConcept = () => (dispatch) => {

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -276,3 +276,31 @@ export const retireConcept = (conceptUrl, retired) => async (dispatch) => {
     return null;
   }
 }
+
+export const addReferenceToCollectionAction = (type, owner, collection, expressions) => async (dispatch) => {
+  try {
+    return await api.dictionaries.addReferencesToCollection(type, owner, collection, expressions);
+  } catch (e) {
+    if(e && e.response && e.response.data){
+      notify.show(e.response.data, 'error', 3000);
+    }
+    else{
+      notify.show('Failed to update the concept in this collection', 'error', 3000);
+    }
+    return false;
+  }
+};
+
+export const deleteReferenceFromCollectionAction = (type, owner, collection, references) => async (dispatch) => {
+  try {
+    return await api.dictionaries.deleteReferenceFromCollection(type, owner, collection, references);
+  } catch (e) {
+    if(e && e.response && e.response.data){
+      notify.show(e.response.data, 'error', 3000);
+    }
+    else{
+      notify.show('Failed to update the concept in this collection. Please Retry', 'error', 3000);
+    }
+    return false;
+  }
+};

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -38,6 +38,16 @@ export default {
         .get(`${data}`)
         .then(response => response.data),
 
+    addReferencesToCollection: (type, owner, collection, expressions) =>
+      instance.put(`${type}/${owner}/collections/${collection}/references/`, {
+        data: { expressions }
+      }),
+
+    deleteReferenceFromCollection: (type, owner, collection, references) =>
+      instance.delete(`${type}/${owner}/collections/${collection}/references/`, {
+        data: {references}
+      }),
+
     removeDictionaryConcept: (data, type, owner, collectionId) =>
       instance
         .delete(`/${type}/${owner}/collections/${collectionId}/references/`, {data:data})

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -37,11 +37,12 @@ import {
   editDictionary,
   createVersion,
   editMapping,
-  retireConcept,
+  retireConcept, addReferenceToCollectionAction, deleteReferenceFromCollectionAction,
 } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import dictionaries, { sampleDictionaries } from '../../__mocks__/dictionaries';
 import versions, { HeadVersion } from '../../__mocks__/versions';
 import concepts, { sampleConcept, sampleRetiredConcept } from '../../__mocks__/concepts';
+import { notify } from 'react-notify-toast';
 
 jest.mock('react-notify-toast');
 
@@ -620,6 +621,108 @@ describe('Test for successful dictionaries fetch, failure and refresh', () => {
     const url = '/users/nesh/collections/test/1.0/';
     return store.dispatch(createVersion(url, data)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  describe('addReferenceToCollectionAction', () => {
+    beforeEach(() => {
+      moxios.install(instance);
+    });
+
+    afterEach(() => {
+      moxios.uninstall(instance);
+    });
+
+    it('should return the right data on success', async () => {
+      const expectedData = 'data';
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          response: { expectedData },
+        });
+      });
+
+      const result = await addReferenceToCollectionAction()();
+      expect(result.data).toEqual({ expectedData });
+    });
+
+    it('should return false and display an error on an unknown failure', async () => {
+      const notifyMock = jest.fn();
+      notify.show = notifyMock;
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        request.reject();
+      });
+
+      const result = await addReferenceToCollectionAction()();
+      expect(result).toBeFalsy();
+      expect(notifyMock).toHaveBeenCalledWith('Failed to update the concept in this collection', 'error', 3000);
+    });
+
+    it('should return false and display the error on failure', async () => {
+      const message = 'Failed';
+      const notifyMock = jest.fn();
+      notify.show = notifyMock;
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        request.reject({ response: { data: message } });
+      });
+
+      const result = await addReferenceToCollectionAction()();
+      expect(result).toBeFalsy();
+      expect(notifyMock).toHaveBeenCalledWith(message, 'error', 3000);
+    });
+  });
+
+  describe('deleteReferenceFromCollectionAction', () => {
+    beforeEach(() => {
+      moxios.install(instance);
+    });
+
+    afterEach(() => {
+      moxios.uninstall(instance);
+    });
+
+    it('should return the right data on success', async () => {
+      const expectedData = 'data';
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          response: { expectedData },
+        });
+      });
+
+      const result = await deleteReferenceFromCollectionAction()();
+      expect(result.data).toEqual({ expectedData });
+    });
+
+    it('should return false and display an error on an unknown failure', async () => {
+      const notifyMock = jest.fn();
+      notify.show = notifyMock;
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        request.reject();
+      });
+
+      const result = await deleteReferenceFromCollectionAction()();
+      expect(result).toBeFalsy();
+      expect(notifyMock).toHaveBeenCalledWith('Failed to update the concept in this collection. Please Retry', 'error', 3000);
+    });
+
+    it('should return false and display the error failure', async () => {
+      const message = 'Failed';
+      const notifyMock = jest.fn();
+      notify.show = notifyMock;
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        request.reject({ response: { data: message } });
+      });
+
+      const result = await deleteReferenceFromCollectionAction()();
+      expect(result).toBeFalsy();
+      expect(notifyMock).toHaveBeenCalledWith(message, 'error', 3000);
     });
   });
 });

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -643,7 +643,7 @@ describe('Testing Edit concept actions ', () => {
 
     const store = mockStore(mockConceptStore);
     const conceptUrl = '/orgs/EthiopiaNHDD/sources/HMIS-Indicators/concepts/C1.1.1.1/';
-    return store.dispatch(updateConcept(conceptUrl, existingConcept, history)).then(() => {
+    return store.dispatch(updateConcept(conceptUrl, existingConcept, history, 'HMIS-Indicators', existingConcept)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
@@ -669,7 +669,7 @@ describe('Testing Edit concept actions ', () => {
 
     const store = mockStore(mockConceptStore);
     const conceptUrl = '/orgs/EthiopiaNHDD/sources/HMIS-Indicators/concepts/C1.1.1.1/';
-    return store.dispatch(updateConcept(conceptUrl, existingConcept, history)).then(() => {
+    return store.dispatch(updateConcept(conceptUrl, existingConcept, history, 'HMIS-Indicators', existingConcept)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -24,6 +24,8 @@ const editConceptProps = {
   updateConcept: async () => sampleConcept,
   existingConcept: sampleConcept,
   isEditConcept: true,
+  deleteReferenceFromCollection: () => true,
+  addReferenceToCollection: () => true,
 };
 
 describe('Test suite for dictionary concepts components', () => {
@@ -394,7 +396,7 @@ describe('Test suite for mappings on existing concepts', () => {
     };
     expect(instance.state.mappings.filter(_ => _ != null).length).toEqual(2);
     instance.removeMappingRow(url);
-    expect(instance.state.mappings[1].retired).toEqual(true);
+    expect(instance.state.mappings.filter(_ => _ != null).length).toEqual(1);
   });
 
   it('should call removeUnsavedMappingRow function', () => {
@@ -664,5 +666,34 @@ describe('Test suite for mappings on existing concepts', () => {
     submitForm.simulate('submit', { preventDefault: jest.fn() });
     expect(props.removeEditedConceptMappingAction)
       .toHaveBeenCalledWith({ references: [answerUrl] });
+  });
+
+  describe('updateConceptReference', () => {
+    it('should return true on success', async () => {
+      const editConceptInstance = wrapper.find('EditConcept').instance();
+      expect(await editConceptInstance.updateConceptReference(sampleConcept)).toBeTruthy();
+    });
+
+    it('should return false on delete reference failure', async () => {
+      const editConceptWrapper = mount(<Router>
+        <EditConcept
+          {...props}
+          deleteReferenceFromCollection={() => false}
+        />
+      </Router>);
+      const editConceptInstance = editConceptWrapper.find('EditConcept').instance();
+      expect(await editConceptInstance.updateConceptReference(sampleConcept)).toBeFalsy();
+    });
+
+    it('should return false on add reference failure', async () => {
+      const editConceptWrapper = mount(<Router>
+        <EditConcept
+          {...props}
+          addReferenceToCollection={() => false}
+        />
+      </Router>);
+      const editConceptInstance = editConceptWrapper.find('EditConcept').instance();
+      expect(await editConceptInstance.updateConceptReference(sampleConcept)).toBeFalsy();
+    });
   });
 });


### PR DESCRIPTION
JIRA TICKET NAME:
[When you edit a concept, a new version of that concept should be created and its reference refreshed in the collection](https://issues.openmrs.org/browse/OCLOMRS-553)

# Summary:
- I added 4 concepts from CIEL, I created 4, and I edited one of those 4. In our application, I see that I have 8 concepts (which is what I expect). But in traditional OCL I see 5 references to custom concepts, not 4.
- What I think is happening is that when I edit a concept, you create a new concept version of the old concept, and you also create a new concept, and they’re both included in the collection.
- That’s wrong when I edit it should create a new version of one concept, and refresh its reference in the collection.