### PR TITLE
OCLOMRS-561: Deleting a reference to an old concept fails sometimes

### DIFF
--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -137,8 +137,14 @@ export const fetchDictionaryConcepts = (
   }
   try {
     const response = await instance.get(`${url}&includeRetired=1`);
-    dispatch(getDictionaryConcepts(response.data, FETCH_DICTIONARY_CONCEPT));
-    dispatch(paginateConcepts(response.data));
+    // this filter is to account for situations where a ref to a concept
+    // version is not removed after an update. Pending backend fix.
+    // ticket: https://github.com/OpenConceptLab/ocl_issues/issues/115
+    const concepts = response.data.filter(
+      concept => concept.external_id || concept.is_latest_version,
+    );
+    dispatch(getDictionaryConcepts(concepts, FETCH_DICTIONARY_CONCEPT));
+    dispatch(paginateConcepts(concepts));
     if (query === '' && filterByClass.length === 0 && filterBySource.length === 0) {
       dispatch(populateSidenav());
     }

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -731,7 +731,7 @@ export const sampleConcept = {
       url: '/users/admin/sources/MULAGO/mappings/5c91173cb3f81601aa3809c6/',
     },
   ],
-  is_latest_version: false,
+  is_latest_version: true,
   locale: null,
   version_url: '/users/admin/sources/MULAGO/concepts/2bdf4057-6c31-4c39-bc91-3dbe7935ca9d/5c91173bb3f81601aa3809bf/',
   url: '/users/admin/sources/MULAGO/concepts/2bdf4057-6c31-4c39-bc91-3dbe7935ca9d/',

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -87,7 +87,8 @@ import concepts, {
   newConcept,
   newConceptData,
   multipleConceptsMockStore,
-  existingConcept, newConceptDataWithAnswerAndSetMappings,
+  newConceptDataWithAnswerAndSetMappings,
+  existingConcept, sampleConcept,
 } from '../../__mocks__/concepts';
 import { CIEL_SOURCE_URL, INTERNAL_MAPPING_DEFAULT_SOURCE, MAP_TYPE } from '../../../components/dictionaryConcepts/components/helperFunction';
 
@@ -167,19 +168,20 @@ describe('Test suite for dictionary concept actions', () => {
   });
 
   it('should handle FETCH_DICTIONARY_CONCEPT', () => {
+    const expectedConcepts = [concepts, sampleConcept];
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();
       request.respondWith({
         status: 200,
-        response: [concepts],
+        response: expectedConcepts,
       });
     });
 
     const expectedActions = [
       { type: IS_FETCHING, payload: true },
-      { type: FETCH_DICTIONARY_CONCEPT, payload: [concepts] },
-      { type: TOTAL_CONCEPT_COUNT, payload: 1 },
-      { type: FETCH_NEXT_CONCEPTS, payload: [concepts] },
+      { type: FETCH_DICTIONARY_CONCEPT, payload: expectedConcepts },
+      { type: TOTAL_CONCEPT_COUNT, payload: 2 },
+      { type: FETCH_NEXT_CONCEPTS, payload: expectedConcepts },
       { type: POPULATE_SIDEBAR, payload: [] },
       { type: IS_FETCHING, payload: false },
     ];


### PR DESCRIPTION
# JIRA TICKET NAME:
[Deleting a reference to an old concept fails sometimes](https://issues.openmrs.org/browse/OCLOMRS-561)

# Summary:
This is an issue with the API and an [issue](https://github.com/OpenConceptLab/ocl_issues/issues/115) has been raised. Pending resolution of this issue, the suggestion is not to display concepts that are not the latest version when viewing a dictionary's concepts.