### PR TITLE
OCLOMRS-562:     When you retire/ unretire, a new version of that concept should be created and its reference refreshed in the collection

### DIFF
--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -13,7 +13,7 @@ import {
   realisingHeadSuccess,
   editDictionarySuccess,
   creatingVersionsSuccess,
-  creatingVersionsError,
+  creatingVersionsError, replaceConcept,
 } from './dictionaryActions';
 import { filterPayload } from '../../reducers/util';
 import { addDictionaryReference } from '../bulkConcepts';
@@ -265,14 +265,18 @@ export const createVersion = (url, data) => (dispatch) => {
     });
 };
 
-export const retireConcept = (conceptUrl, retired) => async (dispatch) => {
+export const retireConcept = (conceptUrl, retire) => async (dispatch) => {
+  const retiredMessage = retire ? 'retired' : 'un-retired';
+  const retiringMessage = retire ? 'Retiring' : 'Un-Retiring';
+  notify.show(retiringMessage, 'warning', 2000);
   try {
-    const response = await axiosInstance.put(conceptUrl, { retired });
-    notify.show('Concept successfully un-retired', 'success', 3000);
+    const response = await api.concepts.retireConcept(conceptUrl, retire);
+    dispatch(replaceConcept(response.data));
+    notify.show(`Concept successfully ${retiredMessage}`, 'success', 3000);
     return response.data;
   } catch (error) {
     error && error.response && error.response.data && dispatch(isErrored(error.response.data));
-    notify.show('Failed to un-retire the concept', 'error', 3000);
+    notify.show(`Failed to ${retiredMessage} the concept`, 'error', 3000);
     return null;
   }
 }

--- a/src/redux/actions/dictionaries/dictionaryActions.js
+++ b/src/redux/actions/dictionaries/dictionaryActions.js
@@ -14,7 +14,7 @@ import {
   REMOVE_MAPPING,
   CREATING_RELEASED_VERSION,
   CREATING_RELEASED_VERSION_FAILED,
-  RELEASING_HEAD_VERSION,
+  RELEASING_HEAD_VERSION, REPLACE_CONCEPT,
 } from '../types';
 
 export const addDictionary = response => ({
@@ -69,6 +69,11 @@ export const clearDictionary = () => ({
 
 export const removeConcept = payload => ({
   type: REMOVE_CONCEPT,
+  payload,
+});
+
+export const replaceConcept = payload => ({
+  type: REPLACE_CONCEPT,
   payload,
 });
 

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -16,6 +16,7 @@ export const CLEAR_DICTIONARIES = '[dictionaries] clear dictionaries';
 export const FETCHING_DICTIONARY = '[dictionary] fetch dictionary';
 export const CLEAR_DICTIONARY = '[dictionary] clear dictionary';
 export const REMOVE_CONCEPT = '[concepts] remove concept';
+export const REPLACE_CONCEPT = '[concepts] replace concept';
 export const REMOVE_MAPPING = '[mappings] remove mapping';
 export const FETCHING_VERSIONS = '[dictionary] fetch versions of a dictionary';
 export const RELEASING_HEAD_VERSION = '[dictionary] releasing HEAD version of a dictionary';

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -89,4 +89,7 @@ export default {
         .get(`users/${localStorage.username}/orgs/`)
         .then(response => response.data),
   },
+  concepts: {
+    retireConcept: (conceptUrl, retire) => instance.put(conceptUrl, { retired: retire }),
+  }
 };

--- a/src/redux/reducers/ConceptReducers.js
+++ b/src/redux/reducers/ConceptReducers.js
@@ -34,6 +34,7 @@ import {
   REMOVE_SELECTED_SET,
   ADD_SELECTED_SETS,
   PRE_POPULATE_SETS, UNPOPULATE_PRE_POPULATED_SETS,
+  REPLACE_CONCEPT,
 } from '../actions/types';
 import {
   filterSources,
@@ -111,6 +112,14 @@ export default (state = initialState, action) => {
           .filter(concept => concept.version_url !== action.payload),
         dictionaryConcepts: state.dictionaryConcepts
           .filter(concept => concept.version_url !== action.payload),
+      };
+    case REPLACE_CONCEPT:
+      return {
+        ...state,
+        paginatedConcepts: state.paginatedConcepts
+          .map(concept => (concept.id === action.payload.id ? action.payload : concept)),
+        dictionaryConcepts: state.dictionaryConcepts
+          .map(concept => (concept.id === action.payload.id ? action.payload : concept)),
       };
     case TOTAL_CONCEPT_COUNT:
       return {

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -16,7 +16,7 @@ import {
   RELEASING_HEAD_VERSION,
   REMOVE_CONCEPT,
   CREATING_RELEASED_VERSION,
-  CREATING_RELEASED_VERSION_FAILED,
+  CREATING_RELEASED_VERSION_FAILED, REPLACE_CONCEPT,
 } from '../../../redux/actions/types';
 import {
   fetchOrganizations,
@@ -25,7 +25,7 @@ import {
   isErrored,
   isSuccess,
   clearDictionary,
-  removeConcept,
+  removeConcept, replaceConcept,
 } from '../../../redux/actions/dictionaries/dictionaryActions';
 import {
   fetchDictionaries,
@@ -79,6 +79,16 @@ describe('Test for successfully removing a Concept from a dictionary', () => {
 
   it('should return action type and payload after removing a concept', () => {
     expect(removeConcept(response)).toEqual(removeDictionaryConcept);
+  });
+});
+
+describe('replaceConcept', () => {
+  it('should return action type and payload', () => {
+    const expected = {
+      type: REPLACE_CONCEPT,
+      payload: concepts,
+    };
+    expect(replaceConcept(concepts)).toEqual(expected);
   });
 });
 

--- a/src/tests/Dashboard/reducer/conceptReducer.test.js
+++ b/src/tests/Dashboard/reducer/conceptReducer.test.js
@@ -14,8 +14,10 @@ import {
   REMOVE_SELECTED_SET,
   ADD_SELECTED_SETS,
   PRE_POPULATE_SETS, UNPOPULATE_PRE_POPULATED_SETS,
+  REPLACE_CONCEPT,
 } from '../../../redux/actions/types';
-import concepts from '../../__mocks__/concepts';
+import concepts, { multipleConceptsMockStore } from '../../__mocks__/concepts';
+import { replaceConcept } from '../../../redux/actions/dictionaries/dictionaryActions';
 
 const initialState = {
   concepts: [],
@@ -280,5 +282,18 @@ describe('Test suite for concepts reducer', () => {
     expect(state.selectedSets).toContainEqual(existingSet);
     state = reducer(initialState, { type: REMOVE_SELECTED_SET, payload: setToRemoveKey });
     expect(state.selectedSets).not.toContainEqual(existingSet);
+  });
+
+  describe(REPLACE_CONCEPT, () => {
+    it('should replace a concept in dictionaryConcepts and paginatedConcepts', () => {
+      let state = reducer(multipleConceptsMockStore.concepts, 'init');
+      const conceptToReplace = state.dictionaryConcepts[0];
+      const newConcept = concepts;
+      newConcept.id = conceptToReplace.id;
+      expect(conceptToReplace).not.toEqual(newConcept);
+      state = reducer(state, replaceConcept(newConcept));
+      expect(state.dictionaryConcepts[0]).toEqual(newConcept);
+      expect(state.paginatedConcepts[0]).toEqual(newConcept);
+    });
   });
 });

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -133,6 +133,7 @@ export const multipleConceptsMockStore = {
   concepts: {
     concepts: [],
     loading: false,
+    paginatedConcepts: mockConcepts.slice(0, 10),
     dictionaryConcepts: mockConcepts,
     filteredSources: ['dev-col', 'MapTypes', 'Classes'],
     filteredClass: ['Diagnosis', 'MapType', 'Concept Class'],


### PR DESCRIPTION
# JIRA TICKET NAME:
[When you retire/ unretire, a new version of that concept should be created and its reference refreshed in the collection](https://issues.openmrs.org/browse/OCLOMRS-562)

# Summary:
Quoting from #553
- I added 4 concepts from CIEL, I created 4, and I edited one of those 4. In our application, I see that I have 8 concepts (which is what I expect). But in traditional OCL I see 5 references to custom concepts, not 4.
- What I think is happening is that when I edit a concept, you create a new concept version of the old concept, and you also create a new concept, and they’re both included in the collection.
- That’s wrong when I edit it should create a new version of one concept, and refresh its reference in the collection.

This behavior applies for retiring/ un-retiring concepts as well