### PR TITLE
OCLOMRS-559: Changing a datatype when creating and editing a concept is not saved

### DIFF
--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -79,8 +79,6 @@ export class EditConcept extends Component {
     removeSet: PropTypes.func.isRequired,
     createNewAnswerRow: PropTypes.func.isRequired,
     createNewSetRow: PropTypes.func.isRequired,
-    deleteConcept: PropTypes.func.isRequired,
-    recreateConcept: PropTypes.func.isRequired,
     unPopulateAnswer: PropTypes.func.isRequired,
     dictionaryConcepts: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     addReferenceToCollection: PropTypes.func.isRequired,
@@ -93,7 +91,7 @@ export class EditConcept extends Component {
       notEditable: true,
       id: '',
       concept_class: '',
-      datatype: 'None',
+      datatype: '',
       answers: [],
       sets: [],
       names: [],
@@ -134,6 +132,13 @@ export class EditConcept extends Component {
     fetchAllConceptSources();
   }
 
+  componentDidUpdate = (prevProps) => {
+    if (prevProps.existingConcept !== this.props.existingConcept) {
+      const { existingConcept: { datatype } } = this.props;
+      this.setState({ datatype });
+    }
+  }
+
   componentWillUnmount() {
     this.props.clearSelections();
   }
@@ -152,12 +157,13 @@ export class EditConcept extends Component {
       match: {
         params: { conceptType, conceptId },
       },
+      existingConcept: { datatype },
     } = this.props;
     const concept = conceptType || '';
     this.setState({
-      ...this.state,
       id: conceptId,
       concept_class: concept,
+      datatype,
     });
   }
 

--- a/src/redux/reducers/ConceptReducers.js
+++ b/src/redux/reducers/ConceptReducers.js
@@ -200,6 +200,7 @@ export default (state = initialState, action) => {
         existingConcept: {
           descriptions: [],
           names: [],
+          datatype: ''
         },
       };
     case EDIT_CONCEPT_ADD_DESCRIPTION:

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -23,8 +23,6 @@ jest.mock('react-notify-toast');
 localStorage.setItem('dictionaryPathName', '/');
 
 const editConceptProps = {
-  deleteConcept: jest.fn(),
-  recreateConcept: async () => jest.fn(),
   unretireMapping: jest.fn(),
   dictionaryConcepts: [sampleConcept],
   updateConcept: async () => sampleConcept,
@@ -87,6 +85,10 @@ describe('Test suite for dictionary concepts components', () => {
     removeEditedConceptMapping: jest.fn(),
     unPopulateAnswer: jest.fn(),
     removeEditedConceptMappingAction: jest.fn(),
+    addSelectedSets: jest.fn(),
+    selectedSets: [],
+    removeSet: jest.fn(),
+    createNewSetRow: jest.fn(),
     ...editConceptProps,
   };
 
@@ -366,6 +368,7 @@ describe('Test suite for mappings on existing concepts', () => {
         uuid: '1234',
         name: 'dummy',
       }],
+      datatype: 'Text',
     },
     newRow: '1234',
     fetchAllConceptSources: jest.fn(),
@@ -758,5 +761,19 @@ describe('Test suite for mappings on existing concepts', () => {
       const editConceptInstance = editConceptWrapper.find('EditConcept').instance();
       expect(await editConceptInstance.updateConceptReference(sampleConcept)).toBeFalsy();
     });
+  });
+  it('should update container state when props change', () => {
+    const editWrapper = mount(<EditConcept {...props} />);
+    const instance = editWrapper.instance();
+    const spy = jest.spyOn(instance, 'componentDidUpdate');
+    const newProps = {
+      existingConcept: {
+        ...props.existingConcept,
+        datatype: 'Boolean',
+      },
+    };
+    editWrapper.setProps(newProps);
+    expect(spy).toHaveBeenCalled();
+    expect(instance.state.datatype).toEqual(newProps.existingConcept.datatype);
   });
 });

--- a/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
@@ -352,6 +352,7 @@ describe('Test suite for single dictionary concepts', () => {
     expect(reducer(state, action)).toEqual({
       ...state,
       existingConcept: {
+        datatype: '',
         descriptions: [],
         names: [],
       },


### PR DESCRIPTION


# JIRA TICKET NAME:
[Changing a datatype when creating and editing a concept is not saved](https://issues.openmrs.org/browse/OCLOMRS-559)

# Summary:
When one creates a concept with a datatype other than 'none', the datatype is not reflected when editing the concept. It always displays 'none'.
