### PR TITLE
OCLOMRS-565: Raise Test Coverage

### DIFF
--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -369,7 +369,9 @@ describe('Test suite for dictionary concepts components', () => {
     dictionaryConceptsWrapper.forceUpdate();
     wrapper.find('#CIEL').simulate('change', sourceEvent);
     wrapper.find('#Diagnosis').simulate('change', classesEvent);
-    expect(spy).toHaveBeenCalledTimes(2);
+    classesEvent.target.type = undefined;
+    wrapper.find('#Diagnosis').simulate('change', classesEvent);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 
   it('should test componentWillReceiveProps', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Raise Test Coverage](https://issues.openmrs.org/browse/OCLOMRS-565)

# Summary:
Account for drop in coverage on PR for ticket [OCLOMRS-562](https://github.com/openmrs/openmrs-ocl-client/pull/441).