### PR TITLE
OCLOMRS-518: Edit concept should include all mapping types(answers, sets, mappings)

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -202,7 +202,7 @@ const CreateConceptForm = (props) => {
             </div>
           </div>
         </div>
-        {(isSetConcept(props.concept.toString().trim()) || !concept) && (
+        {(isSetConcept(props.concept.toString().trim()) || !concept || isEditConcept) && (
           <div className="form-group set">
             <div className="row col-12 custom-concept-list">
               <h6 className="text-left section-header">Sets</h6>
@@ -225,7 +225,7 @@ const CreateConceptForm = (props) => {
             </div>
           </div>
         )}
-        {(concept.toString().trim() === CONCEPT_CLASS.question || !concept) && (
+        {(concept.toString().trim() === CONCEPT_CLASS.question || !concept || isEditConcept) && (
           <div className="form-group answer">
             <div className="row col-12 custom-concept-list">
               <h5 className="text-left section-header">Answers</h5>

--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -65,6 +65,7 @@ export const CONCEPT_TYPE = {
 
 export const CONCEPT_CLASS = {
   question: 'Question',
+  diagnosis: 'Diagnosis',
 };
 
 export const TRADITIONAL_OCL_HOST = urlConfig.TRADITIONAL_OCL_HOST;

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -414,8 +414,12 @@ export const fetchExistingConcept = conceptUrl => async (dispatch) => {
   try {
     const response = await instance.get(url);
     dispatch(isSuccess(response.data, FETCH_EXISTING_CONCEPT));
-    const answers = response.data.mappings.filter(map => map.map_type === 'Q-AND-A');
-    const sets = response.data.mappings.filter(map => map.map_type === MAP_TYPE.conceptSet);
+
+    let { mappings } = response.data;
+    if (!mappings) mappings = [];
+
+    const answers = mappings.filter(map => map.map_type === 'Q-AND-A');
+    const sets = mappings.filter(map => map.map_type === MAP_TYPE.conceptSet);
     dispatch(prepopulateAnswers(answers));
     dispatch(prePopulateSets(sets));
   } catch (error) {

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -753,3 +753,8 @@ export const newMappings = [{
   isNew: false,
   url: '1435',
 }];
+
+export const conceptWithoutMappings = {
+  ...sampleConcept,
+  mappings: null,
+};

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -88,7 +88,7 @@ import concepts, {
   newConceptData,
   multipleConceptsMockStore,
   newConceptDataWithAnswerAndSetMappings,
-  existingConcept, sampleConcept,
+  existingConcept, sampleConcept, conceptWithoutMappings,
 } from '../../__mocks__/concepts';
 import { CIEL_SOURCE_URL, INTERNAL_MAPPING_DEFAULT_SOURCE, MAP_TYPE } from '../../../components/dictionaryConcepts/components/helperFunction';
 
@@ -550,6 +550,30 @@ describe('Test suite for dictionary concept actions', () => {
     const expectedActions = [
       { type: IS_FETCHING, payload: true },
       { type: FETCH_EXISTING_CONCEPT, payload: existingConcept },
+      { type: PRE_POPULATE_ANSWERS, payload: [] },
+      { type: PRE_POPULATE_SETS, payload: [] },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    const store = mockStore(mockConceptStore);
+    const conceptUrl = '/orgs/EthiopiaNHDD/sources/HMIS-Indicators/concepts/C1.1.1.1/';
+    return store.dispatch(fetchExistingConcept(conceptUrl)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should dispatch the right actions when mappings are empty', () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: conceptWithoutMappings,
+      });
+    });
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: FETCH_EXISTING_CONCEPT, payload: conceptWithoutMappings },
       { type: PRE_POPULATE_ANSWERS, payload: [] },
       { type: PRE_POPULATE_SETS, payload: [] },
       { type: IS_FETCHING, payload: false },

--- a/src/tests/dictionaryConcepts/components/CreateConceptForm.test.jsx
+++ b/src/tests/dictionaryConcepts/components/CreateConceptForm.test.jsx
@@ -142,4 +142,34 @@ describe('Test suite for CreateConceptForm', () => {
     expect(wrapper.find('CreateMapping').length).toBe(1);
     wrapper.unmount();
   });
+
+  it('should display all the possible options when editing a concept', () => {
+    const props = {
+      state: {
+        id: '1',
+      },
+      mappings: [{
+        id: 'uniqueid',
+        retired: false,
+      }],
+      addDescription: jest.fn(),
+      handleNewName: jest.fn(),
+      toggleUUID: jest.fn(),
+      handleChange: jest.fn(),
+      handleSubmit: jest.fn(),
+      addAnswer: jest.fn(),
+      concept: CONCEPT_CLASS.diagnosis,
+      editable: false,
+      nameRows: [],
+      disableButton: false,
+      allSources: [mockSource],
+      isEditConcept: true,
+    };
+    const wrapper = shallow(<CreateConceptForm {...props} />);
+    expect(wrapper.find('CreateConceptTable').length).toBe(1);
+    expect(wrapper.find('DescriptionTable').length).toBe(1);
+    expect(wrapper.find('AnswersTable').length).toBe(2);
+    expect(wrapper.find('CreateMapping').length).toBe(1);
+    wrapper.unmount();
+  });
 });

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -681,7 +681,7 @@ describe('Test suite for mappings on existing concepts', () => {
   });
 
   it('should call removeAnswer and remove the anwser row when a user clicks the remove button while creating a Q-A concept', () => {
-    wrapper.find('button#removeAnswer').simulate('click');
+    wrapper.find('.answer button#removeAnswer').simulate('click');
     expect(props.removeAnswer).toHaveBeenCalledWith(props.selectedAnswers[0].frontEndUniqueKey);
   });
   it('should set `NARROWER-THAN` as the default relationship when the source is changed to `Datatype`'


### PR DESCRIPTION
# JIRA TICKET NAME:
[Edit concept should have all possible options](https://issues.openmrs.org/browse/OCLOMRS-518)

# Summary:
#### What is expected
The edit concept should display answers, sets and mappings for the concept being edited.

#### Currently
The edit another concept page displays only either set or answer mappings and not both.