### PR TITLE
OCLOMRS-524: When Editing a dictionary the added languages don't show up after updating

### DIFF
--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -31,7 +31,6 @@ export class DictionaryModal extends React.Component {
         conceptUrl: '',
       },
       errors: {},
-      supportedLocalesOptions: [],
       disableButton: false,
     };
   }
@@ -163,7 +162,6 @@ export class DictionaryModal extends React.Component {
   hideModal = () => {
     this.setState({
       errors: {},
-      supportedLocalesOptions: [],
       disableButton: false,
     });
     this.props.modalhide();
@@ -176,7 +174,6 @@ export class DictionaryModal extends React.Component {
         default_locale, repository_type,
       },
     } = this.props;
-    const supportedLocalesOptions = this.preSelectSupportedLocales();
     this.setState({
       data: {
         id,
@@ -190,7 +187,6 @@ export class DictionaryModal extends React.Component {
         repository_type,
       },
       errors: {},
-      supportedLocalesOptions,
     });
   }
 
@@ -200,7 +196,6 @@ export class DictionaryModal extends React.Component {
       organizations, dictionary,
       isEditingDictionary,
     } = this.props;
-    const publicSources = [];
     return (
       <div>
         <Modal
@@ -294,11 +289,6 @@ export class DictionaryModal extends React.Component {
                         </option>
                         )
                       }
-                      {
-                        publicSources.sort((a, b) => a.name > b.name).map(source => (
-                          <option value={source.id}>{source.name}</option>
-                        ))
-                      }
                     </Input>
                   </FormGroup>
                   <FormGroup style={{ marginTop: '12px' }}>
@@ -383,7 +373,7 @@ export class DictionaryModal extends React.Component {
                     closeMenuOnSelect={false}
                     defaultValue={
                       isEditingDictionary
-                        ? this.state.supportedLocalesOptions
+                        ? this.preSelectSupportedLocales()
                         : []}
                     options={
                       languages.filter(


### PR DESCRIPTION
# JIRA TICKET NAME:
[When Editing a dictionary the added languages don't show up after updating](https://issues.openmrs.org/browse/OCLOMRS-524)

# Summary:
When editing a dictionary and adding some other languages, when the dictionary is updated and Edit clicked again, the popup does not show up with the additional languages. After refreshing the page, the languages do show up.
