### PR TITLE
OCLOMRS-563: Create Another Kind of concept should have all possible options

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -202,7 +202,7 @@ const CreateConceptForm = (props) => {
             </div>
           </div>
         </div>
-        {isSetConcept(props.concept.toString().trim()) ? (
+        {(isSetConcept(props.concept.toString().trim()) || !concept) && (
           <div className="form-group set">
             <div className="row col-12 custom-concept-list">
               <h6 className="text-left section-header">Sets</h6>
@@ -224,8 +224,8 @@ const CreateConceptForm = (props) => {
               </button>
             </div>
           </div>
-        ) : '' }
-        {concept.toString().trim() === CONCEPT_CLASS.question ? (
+        )}
+        {(concept.toString().trim() === CONCEPT_CLASS.question || !concept) && (
           <div className="form-group answer">
             <div className="row col-12 custom-concept-list">
               <h5 className="text-left section-header">Answers</h5>
@@ -247,7 +247,7 @@ const CreateConceptForm = (props) => {
               </button>
             </div>
           </div>
-        ) : null }
+        )}
         <div className="concept-table ">
           <div className="form-group">
             <div className="row col-12 custom-concept-list">

--- a/src/tests/dictionaryConcepts/components/CreateConceptForm.test.jsx
+++ b/src/tests/dictionaryConcepts/components/CreateConceptForm.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import CreateConceptForm from '../../../components/dictionaryConcepts/components/CreateConceptForm';
 import { mockSource } from '../../__mocks__/concepts';
 import { CONCEPT_CLASS } from '../../../components/dictionaryConcepts/components/helperFunction';
@@ -109,5 +109,37 @@ describe('Test suite for CreateConceptForm', () => {
     const wrapper = shallow(<CreateConceptForm {...props} />);
     expect(wrapper.find('.form-group.answer')).toHaveLength(1);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render all the components to display all the possible options available when creating another kind of concept', () => {
+    const props = {
+      state: {
+        id: '1',
+      },
+      concept: '',
+      addDescription: jest.fn(),
+      handleNewName: jest.fn(),
+      path: '',
+      toggleUUID: jest.fn(),
+      handleChange: jest.fn(),
+      handleSubmit: jest.fn(),
+      editable: false,
+      nameRows: [],
+      description: [],
+      addAnswer: jest.fn(),
+      answer: [],
+      disableButton: false,
+      allSources: [mockSource],
+      mappings: [{
+        id: 'uniqueid',
+        retired: false,
+      }],
+    };
+    const wrapper = mount(<CreateConceptForm {...props} />);
+    expect(wrapper.find('CreateConceptTable').length).toBe(1);
+    expect(wrapper.find('DescriptionTable').length).toBe(1);
+    expect(wrapper.find('AnswersTable').length).toBe(2);
+    expect(wrapper.find('CreateMapping').length).toBe(1);
+    wrapper.unmount();
   });
 });


### PR DESCRIPTION


# JIRA TICKET NAME:
[Create Another Kind of concept should have all possible options](https://issues.openmrs.org/browse/OCLOMRS-563)

# Summary:
## What is expected
The create another kind of concept should display answers, sets and mappings for the concept being created.

## Currently
The create another kind of concept page displays only mappings.
