### PR TITLE
OCLOMRS-572: Concept count on dictionary summary page and concepts list do not match

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -59,7 +59,7 @@ export class DictionaryOverview extends Component {
     this.props.fetchDictionary(url);
     this.props.fetchVersions(versionUrl);
 
-    const conceptsUrl = `/${ownerType}/${owner}/collections/${name}/concepts/?includeRetired=true&q=&limit=0&page=1&verbose=true`;
+    const conceptsUrl = `/${ownerType}/${owner}/collections/${name}/concepts/?includeRetired=true&q=&limit=0&page=1&verbose=true&is_latest_version=true`;
     this.props.fetchDictionaryConcepts(conceptsUrl);
   }
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[Concept count on dictionary summary page and concepts list do not match](https://issues.openmrs.org/browse/OCLOMRS-572)

# Summary:
The concept count on the dictionary summary page also includes non latest concepts that might still belong to the collection.
