### PR TITLE
OCLOMRS-575: Allow a user to search for concepts from internal sources while creating mappings

### DIFF
--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -47,6 +47,7 @@ import {
 } from '../globalActionCreators/index';
 
 import instance from '../../../config/axiosConfig';
+import api from '../../api';
 
 export const paginateConcepts = (concepts, limit = 10, offset = 0) => (dispatch, getState) => {
   let conceptList = concepts;
@@ -380,6 +381,20 @@ export const buildNewMappingData = (mapping, fromConceptUrl) => {
     to_concept_url: `${mapping.source}concepts/${mapping.to_concept_code}/`,
     to_concept_name: mapping.to_concept_name,
   });
+};
+
+export const fetchConceptsFromASource = async (sourceUrl, query) => {
+  try {
+    const response = await api.concepts.list.conceptsInASource(sourceUrl, query);
+    return response.data;
+  } catch (error) {
+    if (error.response && error.response.data) {
+      notify.show(`Could not load concepts: ${error.response.data}. Please retry.`, 'error', 2000);
+    } else {
+      notify.show('Could not load concepts. Please retry.', 'error', 2000);
+    }
+    return [];
+  }
 };
 
 export const CreateMapping = (data, from_concept_url, source) => {

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -5,7 +5,7 @@ export default {
     createDictionary: data => instance
       .post(`orgs/${data.owner}/collections/`, data)
     /* eslint-disable */
-        .then((response) => { 
+        .then((response) => {
           instance.post(`orgs/${data.owner}/sources/`, data);
           return response;
         }),
@@ -17,7 +17,7 @@ export default {
           instance.post('user/sources/', data);
           return response;
         }),
-    
+
     editDictionary: (url, data) =>
       instance
         .put(url, data)
@@ -27,7 +27,7 @@ export default {
       instance
       .get(`collections/?q=${''}&limit=${0}&page=${1}&verbose=true`)
       .then(payload => payload.data),
-      
+
     searchDictionaries: (searchTerm) =>
       instance
       .get(`collections/?q=${searchTerm}&limit=${0}&page=${1}&verbose=true`)
@@ -68,11 +68,11 @@ export default {
         .get(`${data}`)
         .then(response => response.data),
 
-    creatingVersion: (url,data) => 
+    creatingVersion: (url,data) =>
       instance
          .post(`${url}`, data)
          .then(response => response.data),
-    
+
     realisingHeadVersion: (url, data) =>
       instance
         .put(url, data)
@@ -91,6 +91,10 @@ export default {
   },
   concepts: {
     retireConcept: (conceptUrl, retire) => instance.put(conceptUrl, { retired: retire }),
+    list: {
+      conceptsInASource: (sourceUrl, query='') =>
+        instance.get(`${sourceUrl}concepts/?q=${query}*`)
+    },
   },
   mappings: {
     fetchFromPublicSources: (fromConcepts) => instance.get(`mappings/?fromConcept=${fromConcepts}`),

--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -423,7 +423,7 @@ input[type=text] {
     margin: 1px;
     padding: 5px;
   }
-  li:hover {
+  li:hover:not(.message) {
     background: #cccccc;
   }
   button {

--- a/src/tests/Dashboard/action/api.test.js
+++ b/src/tests/Dashboard/action/api.test.js
@@ -236,3 +236,51 @@ describe('Test suite for Traditional OCL actions', () => {
     expect(requestUrl).toContain(`mappings/?fromConcept=${fromConcepts}`);
   })
 });
+
+describe('concepts', () => {
+  describe('list', () => {
+    describe('conceptsInASource', () => {
+      beforeEach(() => {
+        moxios.install(instance);
+      });
+
+      afterEach(() => {
+        moxios.uninstall(instance);
+      });
+
+      it('should call the fetchConcepts endpoint with the right query', async ()=> {
+        const url = '/test/url';
+        const query = 'testQuery';
+        let requestUrl;
+
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent();
+          requestUrl = request.url;
+          request.respondWith({
+            status: 200,
+          });
+        });
+
+        await api.concepts.list.conceptsInASource(url, query);
+        expect(requestUrl).toContain(`${url}concepts/?q=${query}*`);
+      });
+
+      it('should call the fetchConcepts endpoint with no query term if it is not provided', async ()=> {
+        const url = '/test/url';
+        const query = 'testQuery';
+        let requestUrl;
+
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent();
+          requestUrl = request.url;
+          request.respondWith({
+            status: 200,
+          });
+        });
+
+        await api.concepts.list.conceptsInASource(url);
+        expect(requestUrl).toContain(`${url}concepts/?q=*`);
+      });
+    });
+  });
+});

--- a/src/tests/dictionaryConcepts/components/CreateMapping.test.js
+++ b/src/tests/dictionaryConcepts/components/CreateMapping.test.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { MemoryRouter as Router } from 'react-router';
+import { notify } from 'react-notify-toast';
 import CreateMapping from '../../../components/dictionaryConcepts/components/CreateMapping';
 import { INTERNAL_MAPPING_DEFAULT_SOURCE, KEY_CODE_FOR_ENTER } from '../../../components/dictionaryConcepts/components/helperFunction';
-import { mockSource } from '../../__mocks__/concepts';
+import concept, { mockSource } from '../../__mocks__/concepts';
+import api from '../../../redux/api';
 
 
 describe('Test suite for dictionary concepts components', () => {
@@ -79,6 +81,7 @@ describe('Test suite for dictionary concepts components', () => {
   it('should handle update of new mappings row source data when isNew is true', () => {
     const newProps = {
       ...props,
+      to_concept_name: 'malaria',
       isNew: true,
     };
 
@@ -118,6 +121,28 @@ describe('Test suite for dictionary concepts components', () => {
     const inputField = wrapper.find('CreateMapping');
     inputField.find('#ConceptName').simulate('change');
     expect(props.updateEventListener).toHaveBeenCalled();
+  });
+
+  it('should call handleKeyPress when a key is pressed in the concept name input', () => {
+    const newProps = {
+      ...props,
+      isNew: true,
+      source: 'maptypes',
+    };
+
+    wrapper = mount(<Router>
+      <table><tbody><CreateMapping {...newProps} /></tbody></table>
+    </Router>);
+
+    const createMappingRow = wrapper.find('CreateMapping');
+
+    const handleKeyPressSpy = jest.spyOn(createMappingRow.instance(), 'handleKeyPress');
+
+    expect(handleKeyPressSpy).not.toHaveBeenCalled();
+
+    createMappingRow.find('#ConceptName').simulate('keyDown');
+    createMappingRow.find('#to_concept_code').simulate('keyDown');
+    expect(handleKeyPressSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should handle change when a user inputs concept name mappings data for for existing concepts', () => {
@@ -168,6 +193,104 @@ describe('Test suite for dictionary concepts components', () => {
     const event = { key: 'Space' };
     inputField.find('#searchInputCiel').simulate('keyDown', event);
     expect(spy).toHaveBeenCalled();
+  });
+
+  it('should call action to query internal concepts and set the results to state', async () => {
+    const data = [concept];
+    const conceptsInASourceMock = jest.fn(() => ({ data }));
+    api.concepts.list.conceptsInASource = conceptsInASourceMock;
+    const event = {
+      keyCode: KEY_CODE_FOR_ENTER,
+    };
+    const inputValue = 'testQuery';
+    const url = '/test/url';
+    const newProps = {
+      ...props,
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+    };
+
+    wrapper = mount(<Router>
+      <table><tbody><CreateMapping {...newProps} /></tbody></table>
+    </Router>);
+
+    const createMapping = wrapper.find('CreateMapping');
+    const createMappingInstance = createMapping.instance();
+
+    expect(createMapping.state().internalConceptOptions).toHaveLength(0);
+    expect(createMapping.state().isInternalConceptOptionsListVisible).toBeFalsy();
+
+    await createMappingInstance.handleKeyPress(event, inputValue, url, false);
+
+    expect(createMapping.state().internalConceptOptions).toEqual(data);
+    expect(createMapping.state().isInternalConceptOptionsListVisible).toBeTruthy();
+  });
+
+  it('should notify a user when they try to search with less than three characters', async () => {
+    const notifyMock = jest.fn();
+    const event = {
+      keyCode: KEY_CODE_FOR_ENTER,
+    };
+    const inputValue = 'te';
+    const url = '/test/url';
+    const newProps = {
+      ...props,
+      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+    };
+
+    notify.show = notifyMock;
+
+    wrapper = mount(<Router>
+      <table><tbody><CreateMapping {...newProps} /></tbody></table>
+    </Router>);
+    const createMappingInstance = wrapper.find('CreateMapping').instance();
+
+    expect(notifyMock).not.toHaveBeenCalled();
+
+    await createMappingInstance.handleKeyPress(event, inputValue, url, false);
+
+    expect(notifyMock).toHaveBeenCalledWith('Query must have at least three characters', 'warning', 2000);
+  });
+
+  it('should display "No concepts matching this query" when there are no concepts to select from', (done) => {
+    const newProps = {
+      ...props,
+      isNew: true,
+      source: 'maptypes',
+    };
+
+    const mappingRow = shallow(<CreateMapping {...newProps} />);
+
+    mappingRow.setState({
+      internalConceptOptions: [],
+      isInternalConceptOptionsListVisible: true,
+    }, () => {
+      const message = mappingRow.find('.message');
+      expect(message).toHaveLength(1);
+      expect(message.text()).toEqual('No concepts matching this query');
+      done();
+    });
+  });
+
+  it('should handle click when a user selects a preferred mapping from the list', (done) => {
+    const newProps = {
+      ...props,
+      isNew: true,
+      source: 'maptypes',
+    };
+
+    const mappingRow = shallow(<CreateMapping {...newProps} />);
+
+    mappingRow.setState({
+      internalConceptOptions: [concept],
+      isInternalConceptOptionsListVisible: true,
+    }, () => {
+      const conceptOption = mappingRow.find(`#concept-id-${concept.id}`);
+      const spy = jest.spyOn(mappingRow.instance(), 'selectInternalMapping');
+      expect(spy).not.toHaveBeenCalled();
+      conceptOption.simulate('click');
+      expect(spy).toHaveBeenCalled();
+      done();
+    });
   });
 
   it('Should handle click event when a user click to select a prefered concept name for existing rows', () => {
@@ -255,5 +378,39 @@ describe('Test suite for dictionary concepts components', () => {
     inputField.find('#searchInputCielIsnew').simulate('keyDown', event);
     await inputField.instance().handleKeyPress(event, 'malaria');
     expect(spy).toHaveBeenCalled();
+  });
+
+  describe('selectInternalMapping', () => {
+    it('should call updateEventListener twice with the expected arguments', () => {
+      const newProps = {
+        ...props,
+        source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+      };
+      const url = '/test/url';
+
+      wrapper = mount(<Router>
+        <table><tbody><CreateMapping {...newProps} /></tbody></table>
+      </Router>);
+      const createMappingInstance = wrapper.find('CreateMapping').instance();
+      props.updateEventListener.mockClear();
+
+      expect(props.updateEventListener).not.toHaveBeenCalled();
+
+      createMappingInstance.selectInternalMapping(concept, url);
+
+      expect(props.updateEventListener).toHaveBeenCalledTimes(2);
+      expect(props.updateEventListener.mock.calls[0]).toEqual([{
+        target: {
+          value: concept.display_name,
+          name: 'to_concept_name',
+        },
+      }, url]);
+      expect(props.updateEventListener.mock.calls[1]).toEqual([{
+        target: {
+          value: concept.id,
+          name: 'to_concept_code',
+        },
+      }, url]);
+    });
   });
 });

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -48,6 +48,7 @@ describe('Test suite for dictionary concepts components', () => {
     },
     history: {
       push: jest.fn(),
+      goBack: jest.fn(),
     },
     createNewName: jest.fn(),
     addNewDescription: jest.fn(),
@@ -338,6 +339,7 @@ describe('Test suite for mappings on existing concepts', () => {
     },
     history: {
       push: jest.fn(),
+      goBack: jest.fn(),
     },
     createNewName: jest.fn(),
     addNewDescription: jest.fn(),


### PR DESCRIPTION
# JIRA TICKET NAME:
[Allow a user to search for concepts from internal sources while creating mappings](https://issues.openmrs.org/browse/OCLOMRS-575)

# Summary:
When creating mappings, a user should be able to search for concepts from internal sources that they might want to select