### PR TITLE
OCLOMRS-569: Edit set members without having to remove them

### DIFF
--- a/src/components/dictionaryConcepts/components/AnswerRow.jsx
+++ b/src/components/dictionaryConcepts/components/AnswerRow.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SelectAnswers from '../containers/SelectAnswers';
-import { INTERNAL_MAPPING_DEFAULT_SOURCE, MAP_TYPE } from './helperFunction';
+import { INTERNAL_MAPPING_DEFAULT_SOURCE } from './helperFunction';
 
 
 class AnswerRow extends React.Component {
@@ -30,11 +30,13 @@ class AnswerRow extends React.Component {
   }
 
   handleClick = () => {
+    const { toSourceName } = this.props;
     if (!this.state.isClicked) {
       this.setState({
         isClicked: true,
         isEditing: false,
         isPrePopulated: false,
+        source: toSourceName,
       });
     }
   }
@@ -72,7 +74,7 @@ class AnswerRow extends React.Component {
               <input
                 type="text"
                 className="form-control"
-                defaultValue={toSourceName}
+                defaultValue={toSourceName.toUpperCase()}
                 onClick={this.handleClick}
                 required
               />
@@ -81,6 +83,7 @@ class AnswerRow extends React.Component {
                 name="map_scope"
                 className="form-control"
                 onChange={event => this.handleChangeInSource(event)}
+                defaultValue={toSourceName}
                 required
               >
                 <option value={localStorage.getItem('dictionaryId')}>
@@ -107,6 +110,7 @@ class AnswerRow extends React.Component {
               answer={answer}
               answerUrl={answerUrl}
               mapType={mapType}
+              handleClick={this.handleClick}
             />
         }
         </td>
@@ -148,7 +152,7 @@ AnswerRow.propTypes = {
   removeCurrentAnswer: PropTypes.func.isRequired,
   currentDictionaryName: PropTypes.string,
   answer: PropTypes.object.isRequired,
-  mapType: PropTypes.string,
+  mapType: PropTypes.string.isRequired,
 };
 
 AnswerRow.defaultProps = {
@@ -160,7 +164,6 @@ AnswerRow.defaultProps = {
   toSourceName: '',
   currentDictionaryName: '',
   frontEndUniqueKey: 'unique',
-  mapType: MAP_TYPE.questionAndAnswer,
 };
 
 

--- a/src/components/dictionaryConcepts/components/AnswersTable.jsx
+++ b/src/components/dictionaryConcepts/components/AnswersTable.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import uuid from 'uuid/v4';
 import AnswerRow from './AnswerRow';
-import { MAP_TYPE } from './helperFunction';
 
 const AnswersTable = (props) => {
   const {
@@ -60,14 +59,13 @@ AnswersTable.propTypes = {
   removeAnswerRow: PropTypes.func,
   currentDictionaryName: PropTypes.string,
   removeCurrentAnswer: PropTypes.func,
-  mapType: PropTypes.string,
+  mapType: PropTypes.string.isRequired,
 };
 
 AnswersTable.defaultProps = {
   handleAnswerChange: () => {},
   currentDictionaryName: '',
   removeAnswerRow: () => {},
-  mapType: MAP_TYPE.questionAndAnswer,
   removeCurrentAnswer: () => {},
 };
 

--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -205,7 +205,7 @@ const CreateConceptForm = (props) => {
         {(isSetConcept(props.concept.toString().trim()) || !concept || isEditConcept) && (
           <div className="form-group set">
             <div className="row col-12 custom-concept-list">
-              <h6 className="text-left section-header">Sets</h6>
+              <h5 className="text-left section-header">Set Members</h5>
               <AnswersTable
                 handleAsyncSelectChange={handleSetAsyncSelectChange}
                 selectedAnswers={selectedSets}
@@ -214,6 +214,7 @@ const CreateConceptForm = (props) => {
                 currentDictionaryName={currentDictionaryName}
                 isEditConcept={isEditConcept}
                 mapType={MAP_TYPE.conceptSet}
+                removeCurrentAnswer={removeCurrentAnswer}
               />
               <button
                 type="button"
@@ -236,6 +237,7 @@ const CreateConceptForm = (props) => {
                 removeAnswerRow={removeAnswerRow}
                 currentDictionaryName={currentDictionaryName}
                 isEditConcept={isEditConcept}
+                mapType={MAP_TYPE.questionAndAnswer}
                 removeCurrentAnswer={removeCurrentAnswer}
               />
               <button

--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -26,6 +26,7 @@ import {
   addSelectedSetsToState,
   removeSelectedSet,
   addNewSetRow,
+  unpopulateSet,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import {
   INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL, MAP_TYPE, ATTRIBUTE_NAME_SOURCE,
@@ -83,6 +84,7 @@ export class EditConcept extends Component {
     dictionaryConcepts: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     addReferenceToCollection: PropTypes.func.isRequired,
     deleteReferenceFromCollection: PropTypes.func.isRequired,
+    unpopulateCurrentSet: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -550,10 +552,16 @@ export class EditConcept extends Component {
   }
 
   removeCurrentAnswer = (info) => {
-    const { unPopulateAnswer } = this.props;
-    this.editedAnswers = [...this.editedAnswers, info.answerUrl];
-    this.removeUnsavedMappingRow(info.answerUrl);
-    unPopulateAnswer(info.answer);
+    const { answer, answer: { map_type }, answerUrl } = info;
+    const { unPopulateAnswer, unpopulateCurrentSet } = this.props;
+    const { conceptSet, questionAndAnswer } = MAP_TYPE;
+    this.editedAnswers = [...this.editedAnswers, answerUrl];
+    this.removeUnsavedMappingRow(answerUrl);
+    if (map_type === questionAndAnswer) {
+      unPopulateAnswer(answer);
+    } else if (map_type === conceptSet) {
+      unpopulateCurrentSet(answer);
+    }
   };
 
   removeSetRow = (uniqueKey, editing, url, name, prePopulated) => {
@@ -741,6 +749,7 @@ export default connect(
     createNewAnswerRow: addNewAnswerRow,
     createNewSetRow: addNewSetRow,
     unPopulateAnswer: unPopulateThisAnswer,
+    unpopulateCurrentSet: unpopulateSet,
     addReferenceToCollection: addReferenceToCollectionAction,
     deleteReferenceFromCollection: deleteReferenceFromCollectionAction,
   },

--- a/src/components/dictionaryConcepts/containers/SelectAnswers.jsx
+++ b/src/components/dictionaryConcepts/containers/SelectAnswers.jsx
@@ -4,7 +4,7 @@ import { notify } from 'react-notify-toast';
 import { queryAnswers } from '../../../redux/actions/concepts/dictionaryConcepts';
 import {
   KEY_CODE_FOR_ENTER,
-  KEY_CODE_FOR_ESCAPE, MAP_TYPE,
+  KEY_CODE_FOR_ESCAPE,
 } from '../components/helperFunction';
 import { MIN_CHARACTERS_WARNING, MILLISECONDS_TO_SHOW_WARNING } from '../../../redux/reducers/generalSearchReducer';
 
@@ -24,11 +24,12 @@ class SelectAnswers extends Component {
     resetInput = (e) => {
       const value = String(e.key).length === 1 ? e.key : '';
       const {
-        answer, removeCurrentAnswer, answerUrl, frontEndUniqueKey,
+        answer, removeCurrentAnswer, answerUrl, frontEndUniqueKey, handleClick,
       } = this.props;
       if (answer.prePopulated) {
         this.setState({ inputValue: value, hasReset: true });
         removeCurrentAnswer({ answerUrl, frontEndUniqueKey, answer });
+        handleClick();
       }
     };
 
@@ -109,7 +110,8 @@ SelectAnswers.propTypes = {
   answer: PropTypes.object,
   removeCurrentAnswer: PropTypes.func.isRequired,
   answerUrl: PropTypes.string,
-  mapType: PropTypes.string,
+  mapType: PropTypes.string.isRequired,
+  handleClick: PropTypes.func.isRequired,
 };
 
 SelectAnswers.defaultProps = {
@@ -119,7 +121,6 @@ SelectAnswers.defaultProps = {
   isShown: false,
   answer: {},
   answerUrl: '',
-  mapType: MAP_TYPE.questionAndAnswer,
 };
 
 export default SelectAnswers;

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -35,7 +35,9 @@ import {
   ADD_NEW_SET_ROW,
   REMOVE_SELECTED_SET,
   ADD_SELECTED_SETS,
-  PRE_POPULATE_SETS, UNPOPULATE_PRE_POPULATED_SETS,
+  PRE_POPULATE_SETS,
+  UNPOPULATE_PRE_POPULATED_SETS,
+  UNPOPULATE_SET,
 } from '../types';
 import {
   isFetching,
@@ -297,6 +299,17 @@ export const unPopulateThisAnswer = (answer) => {
   return {
     type: UN_POPULATE_THIS_ANSWER,
     payload: newAns,
+  };
+};
+
+export const unpopulateSet = (set) => {
+  const newSet = {
+    ...set,
+    prePopulated: false,
+  };
+  return {
+    type: UNPOPULATE_SET,
+    payload: newSet,
   };
 };
 

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -79,3 +79,4 @@ export const SET_NEXT_PAGE = '[page] next_page';
 export const SET_CURRENT_PAGE = '[page] current_page';
 export const IS_LOADING = '[ui] loader_spinning';
 export const UN_POPULATE_THIS_ANSWER = '[concept] unpopulate an answer';
+export const UNPOPULATE_SET = '[concept] unpopulate a set';

--- a/src/redux/reducers/ConceptReducers.js
+++ b/src/redux/reducers/ConceptReducers.js
@@ -33,8 +33,10 @@ import {
   ADD_NEW_SET_ROW,
   REMOVE_SELECTED_SET,
   ADD_SELECTED_SETS,
-  PRE_POPULATE_SETS, UNPOPULATE_PRE_POPULATED_SETS,
+  PRE_POPULATE_SETS,
+  UNPOPULATE_PRE_POPULATED_SETS,
   REPLACE_CONCEPT,
+  UNPOPULATE_SET,
 } from '../actions/types';
 import {
   filterSources,
@@ -209,7 +211,7 @@ export default (state = initialState, action) => {
         existingConcept: {
           descriptions: [],
           names: [],
-          datatype: ''
+          datatype: '',
         },
       };
     case EDIT_CONCEPT_ADD_DESCRIPTION:
@@ -342,6 +344,14 @@ export default (state = initialState, action) => {
       return {
         ...state,
         selectedAnswers: newAnswers,
+      };
+    }
+
+    case UNPOPULATE_SET: {
+      const newSets = updatePopulatedAnswers(action.payload, state.selectedSets);
+      return {
+        ...state,
+        selectedSets: newSets,
       };
     }
 

--- a/src/tests/bulkConcepts/actions/bulkConcept.test.js
+++ b/src/tests/bulkConcepts/actions/bulkConcept.test.js
@@ -37,7 +37,7 @@ describe('Test suite for addBulkConcepts async actions', () => {
   afterEach(() => {
     moxios.uninstall(instance);
   });
-  it('should add concept on ADD_EXISTING_CONCEPTS action dispatch', () => {
+  it('should add concept on ADD_EXISTING_CONCEPTS action dispatch', async (done) => {
     const notifyMock = jest.fn();
     notify.show = notifyMock;
     moxios.wait(() => {
@@ -58,6 +58,7 @@ describe('Test suite for addBulkConcepts async actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
       expect(notifyMock).toHaveBeenCalledTimes(1);
       expect(notifyMock).toHaveBeenCalledWith('Just Added - lob dev', 'success', 3000);
+      done();
     });
   });
   it('should notify user when one tries to add a duplicate concept', () => {

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -38,7 +38,9 @@ import {
   ADD_NEW_SET_ROW,
   REMOVE_SELECTED_SET,
   ADD_SELECTED_SETS,
-  PRE_POPULATE_SETS, UNPOPULATE_PRE_POPULATED_SETS,
+  PRE_POPULATE_SETS,
+  UNPOPULATE_PRE_POPULATED_SETS,
+  UNPOPULATE_SET,
 } from '../../../redux/actions/types';
 import {
   fetchDictionaryConcepts,
@@ -74,7 +76,9 @@ import {
   removeSelectedSet,
   addSelectedSetsToState,
   addSetMappingToConcept,
-  prePopulateSets, unpopulatePrepopulatedSets,
+  prePopulateSets,
+  unpopulatePrepopulatedSets,
+  unpopulateSet,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import {
   removeDictionaryConcept,
@@ -988,17 +992,40 @@ describe('test suite for synchronous action creators', () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
-  it('should handle UN_POPULATE_THIS_ANSWER', () => {
+  it('should dispatch UN_POPULATE_THIS_ANSWER action type', () => {
     const store = mockStore(mockConceptStore);
     const answer = {
+      frontEndUniqueKey: 'unique',
+      prePopulated: true,
+    };
+    const newAnswer = {
       frontEndUniqueKey: 'unique',
       prePopulated: false,
     };
     const expectedActions = [{
       type: UN_POPULATE_THIS_ANSWER,
-      payload: answer,
+      payload: newAnswer,
     }];
     store.dispatch(unPopulateThisAnswer(answer));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it('should dispatch UNPOPULATE_SET action type', () => {
+    const store = mockStore(mockConceptStore);
+    const set = {
+      frontEndUniqueKey: 'unique',
+      prePopulated: true,
+    };
+    const newSet = {
+      frontEndUniqueKey: 'unique',
+      prePopulated: false,
+    };
+    const expectedActions = [{
+      type: UNPOPULATE_SET,
+      payload: newSet,
+    }];
+    store.dispatch(unpopulateSet(set));
+    expect(store.getActions()).toEqual(expectedActions);
   });
 
   it('should handle PRE_POPULATE_SETS', () => {

--- a/src/tests/dictionaryConcepts/components/AnswerRow.test.js
+++ b/src/tests/dictionaryConcepts/components/AnswerRow.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import AnswerRow from
   '../../../components/dictionaryConcepts/components/AnswerRow';
+import { MAP_TYPE } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 
 describe('Test select input field', () => {
@@ -23,6 +24,7 @@ describe('Test select input field', () => {
       answer: {},
       isClicked: false,
       answerUrl: '',
+      mapType: MAP_TYPE.questionAndAnswer,
     };
   });
 

--- a/src/tests/dictionaryConcepts/components/AnswersTable.test.jsx
+++ b/src/tests/dictionaryConcepts/components/AnswersTable.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import AnswersTable from '../../../components/dictionaryConcepts/components/AnswersTable';
 import selectedAnswers from '../../__mocks__/answers';
+import { MAP_TYPE } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 const defaultProps = {
   selectedAnswers,
@@ -14,6 +15,7 @@ const defaultProps = {
   currentDictionaryName: 'test dictionary',
   isEditConcept: false,
   removeCurrentAnswer: jest.fn(),
+  mapType: MAP_TYPE.conceptSet,
 };
 
 describe('Test suite for AnswersTable', () => {

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -30,6 +30,7 @@ const editConceptProps = {
   isEditConcept: true,
   deleteReferenceFromCollection: () => true,
   addReferenceToCollection: () => true,
+  unpopulateCurrentSet: jest.fn(),
 };
 
 describe('Test suite for dictionary concepts components', () => {

--- a/src/tests/dictionaryConcepts/container/SelectAnswers.test.js
+++ b/src/tests/dictionaryConcepts/container/SelectAnswers.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import SelectAnswers from '../../../components/dictionaryConcepts/containers/SelectAnswers';
-import { KEY_CODE_FOR_ESCAPE, KEY_CODE_FOR_ENTER, KEY_CODE_FOR_SPACE } from '../../../components/dictionaryConcepts/components/helperFunction';
+import { KEY_CODE_FOR_ESCAPE, KEY_CODE_FOR_ENTER, KEY_CODE_FOR_SPACE, MAP_TYPE } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 
 jest.mock('react-notify-toast');
@@ -22,6 +22,8 @@ describe('<SelectAnswers />', () => {
       answer: {},
       answerUrl: '',
       removeCurrentAnswer: jest.fn(),
+      mapType: MAP_TYPE.questionAndAnswer,
+      handleClick: jest.fn(),
     };
     wrapper = mount(<SelectAnswers {...props} />);
   });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Edit set members without having to remove them](https://issues.openmrs.org/browse/OCLOMRS-569)

# Summary:
Currently, it's not possible to edit a set member without first removing it then adding a new one. This PR is to add the functionality to edit a set member directly.