### PR TITLE
OCLOMRS-580: Cursor moves back to the name field when filling other fields when creating a new dictionary

### DIFF
--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -32,6 +32,7 @@ export class DictionaryModal extends React.Component {
       },
       errors: {},
       disableButton: false,
+      inputFocus: false,
     };
     this.nameInput = undefined;
   }
@@ -46,14 +47,15 @@ export class DictionaryModal extends React.Component {
   }
 
   componentDidUpdate = () => {
-    this.focusInput();
-  }
-
-  focusInput = () => {
-    if (this.nameInput) {
-      this.nameInput.focus();
+    if (this.nameInput && !this.state.inputFocus) {
+      this.focusInput(this.nameInput);
+      this.setState({ inputFocus: true });
     }
-  }
+  };
+
+  focusInput = (input) => {
+    input.focus();
+  };
 
   onChange = (e) => {
     const { organizations } = this.props;
@@ -174,6 +176,7 @@ export class DictionaryModal extends React.Component {
     this.setState({
       errors: {},
       disableButton: false,
+      inputFocus: false,
     });
     this.props.modalhide();
   }

--- a/src/tests/Dictionary/DictionaryModal.test.jsx
+++ b/src/tests/Dictionary/DictionaryModal.test.jsx
@@ -273,4 +273,14 @@ describe('Test suite for dictionary modal', () => {
     submitButtonWrapper.simulate('click', preventDefault);
     expect(wrapper.state().disableButton).toBeTruthy();
   });
+
+  it('should set focus on the name input when the form to create a new dictionary is rendered', () => {
+    wrapper = mount(<DictionaryModal {...props} />);
+    const instance = wrapper.instance();
+    const spy = jest.spyOn(instance, 'focusInput');
+    expect(instance.state.inputFocus).toBe(false);
+    instance.forceUpdate();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(instance.state.inputFocus).toBe(true);
+  });
 });


### PR DESCRIPTION

# JIRA TICKET NAME:
[Cursor moves back to the name field when filling other fields when creating a new dictionary](https://issues.openmrs.org/browse/OCLOMRS-580)

# Summary:
When one is creating a new dictionary, the cursor still moves back to the name field when trying to fill other fields.
