### PR TITLE
OCLOMRS-583: Dictionary Summary Page shows 'Invalid Date' after  releasing a new collection version

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -63,7 +63,7 @@ export class DictionaryOverview extends Component {
     this.props.fetchDictionaryConcepts(conceptsUrl);
   }
 
-  componentWillUpdate(prevProps) {
+  componentDidUpdate = (prevProps) => {
     const {
       match: {
         params: {
@@ -73,7 +73,7 @@ export class DictionaryOverview extends Component {
     } = this.props;
     const versionUrl = `/${ownerType}/${owner}/${type}/${name}/versions/?verbose=true`;
 
-    if (prevProps.isReleased !== this.props.isReleased) {
+    if (prevProps.versions.length !== this.props.versions.length) {
       this.props.fetchVersions(versionUrl);
     }
   }

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -155,7 +155,7 @@ describe('DictionaryOverview', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  it('should handle componentWillUpdate in HEAD version release', () => {
+  it('should fetch all released versions when a new collection version is released', () => {
     const props = {
       dictionary,
       versions: [customVersion],
@@ -177,15 +177,10 @@ describe('DictionaryOverview', () => {
       error: [],
       loader: false,
     };
-    const wrapper = mount(<Provider store={store}>
-      <MemoryRouter>
-        <DictionaryOverview {...props} />
-      </MemoryRouter>
-    </Provider>);
-
-    const prevProp = wrapper.props();
-    wrapper.find(DictionaryOverview).instance().componentWillUpdate(prevProp);
+    const wrapper = shallow(<DictionaryOverview {...props} />);
+    wrapper.setProps({ versions: [...props.versions, { id: 2 }] });
     expect(props.fetchVersions).toHaveBeenCalled();
+    wrapper.unmount();
   });
 
   it('should render dictionary versions', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Dictionary Summary Page shows 'Invalid Date' after releasing a new collection version](https://issues.openmrs.org/browse/OCLOMRS-583)

# Summary:
Dictionary Summary page shows an "Invalid date" immediately after releasing a new collection version.
