### PR TITLE
OCLOMRS-587: Rename the UUID field to “OpenMRS UUID (OCL External ID)” and add an “OCL ID” field

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -47,14 +47,14 @@ const CreateConceptForm = (props) => {
       <div className="concept-form-body">
         <div className="form-row">
           <div className="form-group col-md-7">
-            <label htmlFor="uuid"><h5>UUID</h5></label>
+            <label htmlFor="external_id"><h5>OpenMRS UUID (OCL External ID)</h5></label>
             <input
               type="text"
               className="form-control"
               readOnly={props.editable}
               onChange={props.handleChange}
-              value={props.state.id}
-              name="id"
+              name="external_id"
+              value={props.state.external_id}
               id="uuid"
               required
             />
@@ -62,6 +62,7 @@ const CreateConceptForm = (props) => {
             Only alphanumeric characters, hyphens, periods, and underscores are allowed.
             </small>
           </div>
+          {(!isEditConcept) && (
           <div className="form-group col-md-3 custom-field">
             <button
               type="submit"
@@ -69,8 +70,29 @@ const CreateConceptForm = (props) => {
               id="toggleUUID"
               onClick={props.toggleUUID}
             >
-            click here to manually enter
+                click here to manually enter
             </button>
+          </div>
+          )}
+        </div>
+        <div className="form-row">
+          <div className="form-group col-md-7">
+            <label htmlFor="id"><h5>OCL ID</h5></label>
+            <input
+              type="text"
+              className="form-control"
+              onChange={props.handleChange}
+              value={props.state.id}
+              readOnly={isEditConcept}
+              name="id"
+              id="id"
+            />
+            <small className="form-text text-muted">
+              This ID is used when viewing your concept in OCL,
+              but it will not be reflected when you download it to OpenMRS.
+              This ID must be unique within your dictionary,
+              and it cannot be changed after creating the concept.
+            </small>
           </div>
         </div>
         <div className="form-row">
@@ -317,6 +339,7 @@ CreateConceptForm.propTypes = {
     datatype: PropTypes.string,
     concept_class: PropTypes.string,
     id: PropTypes.string,
+    external_id: PropTypes.string,
   }).isRequired,
   concept: PropTypes.string.isRequired,
   path: PropTypes.string,

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -51,6 +51,7 @@ export class CreateConcept extends Component {
     description: PropTypes.array.isRequired,
     newConcept: PropTypes.shape({
       id: PropTypes.string,
+      external_id: PropTypes.string,
       concept_class: PropTypes.string,
       datatype: PropTypes.string,
       names: PropTypes.array,
@@ -76,7 +77,8 @@ export class CreateConcept extends Component {
     super(props);
     this.state = {
       notEditable: true,
-      id: String(uuid()),
+      id: '',
+      external_id: String(uuid()),
       concept_class: '',
       datatype: 'None',
       names: [],
@@ -241,11 +243,15 @@ export class CreateConcept extends Component {
     } = this.props;
     const url = `/${type}/${typeName}/sources/${collectionName}/concepts/`;
     const regx = /^[a-zA-Z\d-_]+$/;
-    if (regx.test(this.state.id) && this.state.datatype && this.state.concept_class) {
+    if (regx.test(this.state.id) && regx.test(this.state.external_id)
+      && this.state.datatype && this.state.concept_class) {
       this.props.createNewConcept(this.state, url);
     } else {
+      if (!regx.test(this.state.external_id)) {
+        notify.show('enter a valid uuid for the OpenMRS UUID field', 'error', 3000);
+      }
       if (!regx.test(this.state.id)) {
-        notify.show('enter a valid uuid', 'error', 3000);
+        notify.show('enter a valid id for the OCL ID field', 'error', 3000);
       }
       if (!this.state.datatype) {
         notify.show('choose a datatype', 'error', 3000);
@@ -395,7 +401,6 @@ export class CreateConcept extends Component {
     const concept = conceptType ? `${conceptType}` : '';
     const path = localStorage.getItem('dictionaryPathName');
     const append = concept === 'Set' ? ' of concepts' : ' concept';
-
     return (
       <div className="container create-custom-concept">
         <div className="row create-concept-header">

--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -92,6 +92,7 @@ export class EditConcept extends Component {
     this.state = {
       notEditable: true,
       id: '',
+      external_id: '',
       concept_class: '',
       datatype: '',
       answers: [],
@@ -125,6 +126,7 @@ export class EditConcept extends Component {
         },
       },
       fetchAllConceptSources,
+      existingConcept,
     } = this.props;
     this.conceptUrl = `/${type}/${typeName}/sources/${collectionName}/concepts/${conceptId}/?includeMappings=true&verbose=true`;
     this.createUrl = `/${type}/${typeName}/sources/${collectionName}/concepts/`;
@@ -132,6 +134,7 @@ export class EditConcept extends Component {
       this.oldState = this.state;
     });
     fetchAllConceptSources();
+    this.setState({ external_id: existingConcept.external_id });
   }
 
   componentDidUpdate = (prevProps) => {

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -214,9 +214,11 @@ describe('Test suite for dictionary concepts components', () => {
   });
 
   it('should handle form completion and submission with invalid/incomplete data', () => {
+    const event = { target: { name: 'id', value: '12345ft-007#' } };
+    wrapper.find('#id').simulate('change', event);
     wrapper.find('#toggleUUID').simulate('click');
-    const event = { target: { name: 'id', value: '12345ft-007' } };
-    wrapper.find('#uuid').simulate('change', event);
+    const newEvent = { target: { name: 'external_id', value: '12345ft-007#' } };
+    wrapper.find('#uuid').simulate('change', newEvent);
     wrapper.find('#createConceptForm').simulate('submit', {
       preventDefault: () => {},
     });
@@ -225,8 +227,10 @@ describe('Test suite for dictionary concepts components', () => {
     const conceptDatatype = { target: { name: 'datatype', value: '' } };
     wrapper.find('#datatype').simulate('change', conceptDatatype);
     wrapper.find('#toggleUUID').simulate('click');
-    const uuid = { target: { name: 'id', value: '12345ft-007#' } };
+    const uuid = { target: { name: 'external_id', value: '12345ft-007' } };
     wrapper.find('#uuid').simulate('change', uuid);
+    const newUuid = { target: { name: 'id', value: '12345ft-007' } };
+    wrapper.find('#id').simulate('change', newUuid);
     const conceptDescription = {
       target: { name: 'description', value: 'test concept description' },
     };
@@ -238,9 +242,15 @@ describe('Test suite for dictionary concepts components', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+
   it('should handle form completion and submission with correct data', () => {
     const conceptName = { target: { name: 'name', value: 'test concept' } };
     wrapper.find('#concept-name').simulate('change', conceptName);
+    wrapper.find('#toggleUUID').simulate('click');
+    const uuid = { target: { name: 'external_id', value: '12345ft-007' } };
+    wrapper.find('#uuid').simulate('change', uuid);
+    const newUuid = { target: { name: 'id', value: '12345ft-006' } };
+    wrapper.find('#id').simulate('change', newUuid);
     const conceptClass = { target: { name: 'concept_class', value: 'Procedure' } };
     wrapper.find('#class').simulate('change', conceptClass);
     const conceptDatatype = { target: { name: 'datatype', value: 'Text' } };


### PR DESCRIPTION
# JIRA TICKET NAME:
[Rename the UUID field to “OpenMRS UUID (OCL External ID)” and add an “OCL ID” field](https://issues.openmrs.org/browse/OCLOMRS-587)

# Summary:
When creating a concept, the UUID field should be renamed to “OpenMRS UUID (OCL External ID)”  and we should add another ID field with the name,  “OCL ID”

When editing a concept, both ID fields should not be editable