### PR TITLE
OCLOMRS-591: When adding a concept to a collection, its mappings should be added as well

### DIFF
--- a/src/components/bulkConcepts/addBulkConcepts.jsx
+++ b/src/components/bulkConcepts/addBulkConcepts.jsx
@@ -72,7 +72,7 @@ export class AddBulkConcepts extends Component {
         params: { type, typeName, collectionName },
       },
     } = this.props;
-    const url = `${type}/${typeName}/collections/${collectionName}/references/`;
+    const url = `${type}/${typeName}/collections/${collectionName}/references/?cascade=sourcemappings`;
     const { conceptIds } = this.state;
     const conceptIdList = conceptIds.split(/[\s,\r\n]+/);
 

--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -82,7 +82,7 @@ export const recursivelyFetchConceptMappings = async (fromConceptCodes, levelsTo
 
 export const addConcept = (params, data, conceptName, id) => async (dispatch) => {
   const { type, typeName, collectionName } = params;
-  const url = `${type}/${typeName}/collections/${collectionName}/references/`;
+  const url = `${type}/${typeName}/collections/${collectionName}/references/?cascade=sourcemappings`;
   try {
     const referencesToAdd = await recursivelyFetchConceptMappings([id], MAPPINGS_RECURSION_DEPTH);
     data.data.expressions.push(...referencesToAdd);


### PR DESCRIPTION
# JIRA TICKET NAME:
[When adding a concept to a collection, it's mappings should be added as well](https://issues.openmrs.org/browse/OCLOMRS-591)

# Summary:
The endpoint for adding concept references to a collection includes a cascade query option.

We want to add these mappings to the collection, so it should be set to cascade=sourcemappings