### PR TITLE
OCLOMRS-590: If there is an error while updating a concept after the concept itself has been updated, its reference should still be updated

### DIFF
--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -485,9 +485,11 @@ export const UpdateMapping = (data) => {
 
 export const updateConcept = (conceptUrl, data, history, source, concept) => async (dispatch) => {
   dispatch(isFetching(true));
+  let updatedConcept;
   const url = conceptUrl;
   try {
     const response = await instance.put(url, data);
+    updatedConcept = response.data;
     CreateMapping(data.mappings, concept.url, source);
     UpdateMapping(data.mappings);
     dispatch(isSuccess(response.data, UPDATE_CONCEPT));
@@ -511,6 +513,7 @@ export const updateConcept = (conceptUrl, data, history, source, concept) => asy
     }
     dispatch(isFetching(false));
   }
+  if (updatedConcept) return updatedConcept;
   history.goBack();
   return false;
 };


### PR DESCRIPTION
# JIRA TICKET NAME:
[If there is an error while updating a concept after the concept itself has been updated, its reference should still be updated](https://issues.openmrs.org/browse/OCLOMRS-590)

# Summary:
If a concept's details have been successfully updated, it's reference in the collection should also be updated.

Currently, if there is an error after a concept's details have been updated, but before the update method completes, the concept's reference is not updated, leading to us having an old reference to the concept in our collection