### PR TITLE
OCLOMRS-594: Pressing enter in input field in the edit concept form triggers submit

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -9,6 +9,7 @@ import {
   MAP_TYPE,
   CONCEPT_CLASS,
   isSetConcept,
+  preventFormSubmit,
 } from './helperFunction';
 
 const CreateConceptForm = (props) => {
@@ -43,7 +44,8 @@ const CreateConceptForm = (props) => {
   const descriptions = props.existingConcept.descriptions || props.description;
 
   return (
-    <form className="form-wrapper" onSubmit={props.handleSubmit} id="createConceptForm">
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    <form className="form-wrapper" onKeyPress={preventFormSubmit} onSubmit={props.handleSubmit} id="createConceptForm">
       <div className="concept-form-body">
         <div className="form-row">
           <div className="form-group col-md-7">

--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -84,3 +84,6 @@ export const MAPPINGS_RECURSION_DEPTH = 2;
 export const isSetConcept = conceptClass => conceptClass.toLowerCase().indexOf('set') > -1;
 export const removeDuplicates = items => union(items);
 export const isExternalSource = source => source && includes(['External', 'externalDictionary'], source.source_type);
+export const preventFormSubmit = event => event.target.type !== 'textarea'
+    && event.which === KEY_CODE_FOR_ENTER
+    && event.preventDefault();

--- a/src/tests/dictionaryConcepts/components/helperFunction.test.js
+++ b/src/tests/dictionaryConcepts/components/helperFunction.test.js
@@ -1,0 +1,30 @@
+import {
+  KEY_CODE_FOR_ENTER,
+  KEY_CODE_FOR_SPACE,
+  preventFormSubmit
+} from '../../../components/dictionaryConcepts/components/helperFunction';
+
+describe('preventFormSubmit', () => {
+  it('should return false when target is textarea', () => {
+    expect(preventFormSubmit({ target: { type: 'textarea' } })).toBeFalsy();
+  });
+
+  it('should return false when which is not enter', () => {
+    expect(preventFormSubmit({ target: { type: 'input' }, which: KEY_CODE_FOR_SPACE })).toBeFalsy();
+  });
+
+  it('should call preventDefault if enter is clicked', () => {
+    const event = {
+      target:
+        {
+          type: 'input',
+        },
+      which: KEY_CODE_FOR_ENTER,
+      preventDefault: jest.fn(),
+    };
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    preventFormSubmit(event);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# JIRA TICKET NAME:
[Pressing enter in input field in the edit concept form triggers submit](https://issues.openmrs.org/browse/OCLOMRS-594)

# Summary:
The edit concept form is prematurely submitted when enter is pressed when the cursor is in an input