### PR TITLE
OCLOMRS-598: User cannot delete all characters in the search bar for adding a CIEL concept

### DIFF
--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -22,7 +22,6 @@ export class BulkConceptsPage extends Component {
     setCurrentPage: PropTypes.func.isRequired,
     currentPage: PropTypes.number.isRequired,
     fetchFilteredConcepts: PropTypes.func.isRequired,
-    fetchBulkConcepts: PropTypes.func.isRequired,
     concepts: PropTypes.arrayOf(PropTypes.shape(conceptsProps)).isRequired,
     loading: PropTypes.bool.isRequired,
     preview: PropTypes.shape({
@@ -113,8 +112,7 @@ export class BulkConceptsPage extends Component {
       target: { value },
     } = event;
     if (!value) {
-      const { fetchBulkConcepts: bulkConceptsFetched } = this.props;
-      bulkConceptsFetched(1);
+      this.getBulkConcepts();
     }
     this.setState(() => ({ searchInput: value }));
   };


### PR DESCRIPTION
# JIRA TICKET NAME:
[User cannot delete all characters in the search bar for adding a CIEL concept](https://issues.openmrs.org/browse/OCLOMRS-598)

# Summary:
When adding a CIEL concept, if a user types anything into the search bar, they cannot delete the first character inputted
