### PR TITLE
OCLOMRS-600: Creating mappings to internal concepts should all have a single searchable field

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -32,7 +32,6 @@ const CreateConceptForm = (props) => {
     isEditConcept,
     allSources,
     removeMappingRow,
-    updateAsyncSelectValue,
     removeCurrentAnswer,
   } = props;
 
@@ -299,7 +298,6 @@ const CreateConceptForm = (props) => {
                       updateEventListener={updateEventListener}
                       updateSourceEventListener={updateSourceEventListener}
                       removeMappingRow={removeMappingRow}
-                      updateAsyncSelectValue={updateAsyncSelectValue}
                       key={mapping.id}
                       index={i}
                       isEditConcept={isEditConcept}
@@ -366,7 +364,6 @@ CreateConceptForm.propTypes = {
   updateSourceEventListener: PropTypes.func,
   showModal: PropTypes.func,
   removeMappingRow: PropTypes.func,
-  updateAsyncSelectValue: PropTypes.func,
   allSources: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   addAnswerRow: PropTypes.func,
   removeAnswerRow: PropTypes.func,
@@ -393,7 +390,6 @@ CreateConceptForm.defaultProps = {
   updateEventListener: null,
   updateSourceEventListener: null,
   removeMappingRow: null,
-  updateAsyncSelectValue: null,
   addAnswerRow: () => {},
   removeAnswerRow: () => {},
   currentDictionaryName: '',

--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -24,7 +24,7 @@ import {
 import { fetchConceptSources } from '../../../redux/actions/bulkConcepts';
 import {
   MAP_TYPE, CANCEL_WARNING, LEAVE_PAGE, STAY_ON_PAGE, LEAVE_PAGE_POPUP_TITLE,
-  INTERNAL_MAPPING_DEFAULT_SOURCE, MAP_TYPES_DEFAULTS,
+  MAP_TYPES_DEFAULTS, CIEL_SOURCE_URL,
 } from '../components/helperFunction';
 import GeneralModel from '../../dashboard/components/dictionary/common/GeneralModal';
 
@@ -325,7 +325,7 @@ export class CreateConcept extends Component {
         modifyMap[name] = value;
         modifyMap.sourceObject = source;
 
-        if (modifyMap.source !== INTERNAL_MAPPING_DEFAULT_SOURCE) {
+        if (source && source.url !== CIEL_SOURCE_URL) {
           modifyMap.map_type = defaultRelationship;
         } else {
           modifyMap.map_type = relationship;
@@ -347,20 +347,6 @@ export class CreateConcept extends Component {
       return modifyMap;
     });
     this.setState({ mappings: newMappings });
-  }
-
-  updateAsyncSelectValue = (value) => {
-    const { mappings } = this.state;
-    const updateAsyncMappings = mappings.map((map) => {
-      const updatedMap = map;
-      if (value !== null && value.index !== undefined && updatedMap.url === value.index) {
-        updatedMap.to_source_url = value.value;
-        updatedMap.to_concept_name = value.label;
-        updatedMap.to_concept_code = value.to_concept_code;
-      }
-      return updatedMap;
-    });
-    this.setState({ mappings: updateAsyncMappings });
   }
 
   removeMappingRow = (url) => {
@@ -452,7 +438,6 @@ export class CreateConcept extends Component {
                 updateEventListener={this.updateEventListener}
                 updateSourceEventListener={this.updateSourceEventListener}
                 removeMappingRow={this.removeMappingRow}
-                updateAsyncSelectValue={this.updateAsyncSelectValue}
                 allSources={this.props.allSources}
                 showModal={this.showModal}
                 handleSetAsyncSelectChange={this.handleSetAsyncSelectChange}

--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -30,7 +30,7 @@ import {
   unpopulateSet,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import {
-  INTERNAL_MAPPING_DEFAULT_SOURCE, CIEL_SOURCE_URL, MAP_TYPE, ATTRIBUTE_NAME_SOURCE,
+  CIEL_SOURCE_URL, MAP_TYPE, ATTRIBUTE_NAME_SOURCE,
   CANCEL_WARNING, LEAVE_PAGE, STAY_ON_PAGE, LEAVE_PAGE_POPUP_TITLE,
   MAP_TYPES_DEFAULTS,
 } from '../components/helperFunction';
@@ -332,7 +332,7 @@ export class EditConcept extends Component {
       if (modifyMap.url === url) {
         modifyMap[name] = value;
         modifyMap.sourceObject = source;
-        if (modifyMap.source !== INTERNAL_MAPPING_DEFAULT_SOURCE) {
+        if (source && source.url !== CIEL_SOURCE_URL) {
           modifyMap.map_type = defaultRelationship;
         } else {
           modifyMap.map_type = relationship;
@@ -358,20 +358,6 @@ export class EditConcept extends Component {
       return modifyMap;
     });
     this.setState({ mappings: newMappings });
-  }
-
-  updateAsyncSelectValue = (value) => {
-    const { mappings } = this.state;
-    const updateAsyncMappings = mappings.map((map) => {
-      const updatedMap = map;
-      if (value !== null && value.index !== undefined && updatedMap.url === value.index) {
-        updatedMap.to_source_url = value.value;
-        updatedMap.to_concept_name = value.label;
-        updatedMap.to_concept_code = value.to_concept_code;
-      }
-      return updatedMap;
-    });
-    this.setState({ mappings: updateAsyncMappings });
   }
 
   hideGeneralModal = () => this.setState({ openGeneralModal: false });
@@ -469,32 +455,17 @@ export class EditConcept extends Component {
 
   organizeMappings = (mappings) => {
     const { allSources } = this.props;
-    const filteredMappings = mappings.map((mapping, i) => {
-      if (mapping.to_source_url === CIEL_SOURCE_URL) {
-        return {
-          id: i,
-          map_type: mapping.map_type,
-          source: INTERNAL_MAPPING_DEFAULT_SOURCE,
-          sourceObject: find(allSources, { url: mapping.to_source_url }),
-          to_concept_code: mapping.to_concept_code,
-          to_concept_name: mapping.to_concept_name,
-          to_source_url: mapping.to_concept_url,
-          url: mapping.url,
-          retired: mapping.retired,
-        };
-      }
-      return {
-        id: i,
-        map_type: mapping.map_type,
-        source: mapping.to_source_url,
-        sourceObject: find(allSources, { url: mapping.to_source_url }),
-        to_concept_code: mapping.to_concept_code,
-        to_concept_name: mapping.to_concept_name,
-        to_source_url: mapping.to_concept_url,
-        url: mapping.url,
-        retired: mapping.retired,
-      };
-    });
+    const filteredMappings = mappings.map((mapping, i) => ({
+      id: i,
+      map_type: mapping.map_type,
+      source: mapping.to_source_url,
+      sourceObject: find(allSources, { url: mapping.to_source_url }),
+      to_concept_code: mapping.to_concept_code,
+      to_concept_name: mapping.to_concept_name,
+      to_source_url: mapping.to_concept_url,
+      url: mapping.url,
+      retired: mapping.retired,
+    }));
     this.setState({
       mappings: filteredMappings,
       from_concept_url: mappings[0].from_concept_url,
@@ -662,7 +633,6 @@ Concept
                 updateEventListener={this.updateEventListener}
                 updateSourceEventListener={this.updateSourceEventListener}
                 removeMappingRow={this.removeMappingRow}
-                updateAsyncSelectValue={this.updateAsyncSelectValue}
                 allSources={this.props.allSources}
                 handleAsyncSelectChange={this.handleAsyncSelectChange}
                 selectedAnswers={selectedAnswers}

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -359,22 +359,6 @@ export const addConceptToDictionary = (id, dataUrl) => async (dispatch) => {
   dispatch(isFetching(false));
 };
 
-export const fetchSourceConcepts = async (source, query, index) => {
-  try {
-    const url = `/orgs/${source}/sources/${source}/concepts/?q=${query}*&limit=0&verbose=true`;
-    const response = await instance.get(url);
-    const options = response.data.map(concept => ({
-      value: concept.url,
-      label: `ID(${concept.id}) - ${concept.display_name}`,
-      to_concept_code: concept.id,
-      index,
-    }));
-    return options;
-  } catch (error) {
-    return [];
-  }
-};
-
 export const buildNewMappingData = (mapping, fromConceptUrl) => {
   const {
     sourceObject,

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -118,16 +118,6 @@ describe('Test suite for dictionary concept actions', () => {
     moxios.uninstall(instance);
   });
 
-  it('should call the fetchSourceConcepts and fetch concepts', async () => {
-    const expectedPosts = ['malaria', 'tuberclosis'];
-
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent();
-      request.respondWith({ status: 200, response: expectedPosts });
-    });
-    await fetchSourceConcepts('source', 'query');
-  });
-
   it('should query possible answer concepts', async () => {
     const expectedAnswers = [{
       id: 'Answer 1',
@@ -620,15 +610,6 @@ describe('Test suite for dictionary concept actions', () => {
     return store.dispatch(fetchExistingConcept(conceptUrl)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
-  });
-
-  it('should handle errors if fetching Source Concepts fails', async () => {
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent();
-      request.respondWith({ status: 200, response: '' });
-    });
-    const expectedResult = [];
-    expect(await fetchSourceConcepts('expect', 'to', 'fail')).toEqual(expectedResult);
   });
 });
 

--- a/src/tests/dictionaryConcepts/components/CreateMapping.test.js
+++ b/src/tests/dictionaryConcepts/components/CreateMapping.test.js
@@ -8,18 +8,19 @@ import { INTERNAL_MAPPING_DEFAULT_SOURCE, KEY_CODE_FOR_ENTER } from '../../../co
 import concept, { mockSource } from '../../__mocks__/concepts';
 import api from '../../../redux/api';
 import apiInstance from '../../../config/axiosConfig';
+import { externalSource, internalSource } from '../../__mocks__/sources';
 
 
 describe('Test suite for dictionary concepts components', () => {
   const props = {
     map_type: 'same as',
-    source: INTERNAL_MAPPING_DEFAULT_SOURCE,
+    sourceObject: internalSource,
     to_concept_code: '674647-75775',
     to_concept_name: 'malaria',
     index: 1,
     updateEventListener: jest.fn(),
     removeMappingRow: jest.fn(),
-    updateAsyncSelectValue: jest.fn(),
+    updateSourceEventListener: jest.fn(),
     allSources: [mockSource],
     url: 'uniqueMappingUrl',
   };
@@ -36,15 +37,10 @@ describe('Test suite for dictionary concepts components', () => {
     moxios.uninstall(apiInstance);
   });
 
-  it('should call handleInputChange', () => {
-    const instance = wrapper.find('CreateMapping').instance();
-    instance.handleInputChange('malaria');
-  });
-
   it('should call updateEventListener', () => {
     const newProps = {
       ...props,
-      source: 'SNOMED',
+      sourceObject: externalSource,
     };
 
     wrapper = mount(<Router>
@@ -52,7 +48,7 @@ describe('Test suite for dictionary concepts components', () => {
     </Router>);
 
     const inputField = wrapper.find('CreateMapping');
-    inputField.find('#searchInputNotCiel').simulate('change');
+    inputField.find(`#to-concept-name-${props.url}`).simulate('change');
     expect(props.updateEventListener).toHaveBeenCalled();
   });
 
@@ -66,33 +62,18 @@ describe('Test suite for dictionary concepts components', () => {
     const newProps = {
       ...props,
       isNew: true,
-      source: 'Snomed',
     };
 
     wrapper = mount(<Router>
       <table><tbody><CreateMapping {...newProps} /></tbody></table>
     </Router>);
     const inputs = wrapper.find('input');
-    expect(inputs).toHaveLength(3);
-  });
-
-  it('should render when isNew is true and source equal to CIEL', () => {
-    const newProps = {
-      ...props,
-      isNew: true,
-    };
-
-    wrapper = mount(<Router>
-      <table><tbody><CreateMapping {...newProps} /></tbody></table>
-    </Router>);
-    const inputs = wrapper.find('select');
-    expect(inputs).toHaveLength(2);
+    expect(inputs).toHaveLength(1);
   });
 
   it('should handle update of new mappings row source data when isNew is true', () => {
     const newProps = {
       ...props,
-      to_concept_name: 'malaria',
       isNew: true,
     };
 
@@ -101,14 +82,16 @@ describe('Test suite for dictionary concepts components', () => {
     </Router>);
     const inputField = wrapper.find('CreateMapping');
     inputField.find('#source').simulate('change');
-    expect(props.updateEventListener).toHaveBeenCalled();
+    expect(props.updateSourceEventListener).toHaveBeenCalled();
   });
 
-  it('should handel update of new mappings row data for non Ciel concepts when isNew is true', () => {
+  it('should handle update of new mappings row data for external concepts when isNew is true', () => {
     const newProps = {
       ...props,
+      to_concept_name: null,
+      to_concept_code: null,
       isNew: true,
-      source: 'Classes',
+      sourceObject: externalSource,
     };
 
     wrapper = mount(<Router>
@@ -119,26 +102,10 @@ describe('Test suite for dictionary concepts components', () => {
     expect(props.updateEventListener).toHaveBeenCalled();
   });
 
-  it('should handle update of new mappings row concept name for Ciel concepts when isNew is true', () => {
-    const newProps = {
-      ...props,
-      isNew: true,
-      source: 'maptypes',
-    };
-
-    wrapper = mount(<Router>
-      <table><tbody><CreateMapping {...newProps} /></tbody></table>
-    </Router>);
-    const inputField = wrapper.find('CreateMapping');
-    inputField.find('#ConceptName').simulate('change');
-    expect(props.updateEventListener).toHaveBeenCalled();
-  });
-
   it('should call handleKeyPress when a key is pressed in the internal concepts search input', () => {
     const newProps = {
       ...props,
       isNew: true,
-      source: 'maptypes',
     };
 
     wrapper = mount(<Router>
@@ -151,7 +118,7 @@ describe('Test suite for dictionary concepts components', () => {
 
     expect(handleKeyPressSpy).not.toHaveBeenCalled();
 
-    createMappingRow.find(`#search-internal-mappings-${newProps.url}`).simulate('keyDown');
+    createMappingRow.find(`#to-concept-name-${newProps.url}`).simulate('keyDown');
     expect(handleKeyPressSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -160,7 +127,6 @@ describe('Test suite for dictionary concepts components', () => {
     const newProps = {
       ...props,
       isNew: true,
-      source: 'maptypes',
     };
 
     wrapper = mount(<Router>
@@ -170,9 +136,9 @@ describe('Test suite for dictionary concepts components', () => {
     const createMappingRow = wrapper.find('CreateMapping');
     const instance = createMappingRow.instance();
 
-    expect(instance.state.internalConceptSearchQuery).toEqual('');
+    expect(instance.state.internalConceptSearchQuery).toEqual(props.to_concept_name);
 
-    createMappingRow.find(`#search-internal-mappings-${newProps.url}`).simulate('change', {
+    createMappingRow.find(`#to-concept-name-${newProps.url}`).simulate('change', {
       target: {
         value: searchQuery,
       },
@@ -184,7 +150,6 @@ describe('Test suite for dictionary concepts components', () => {
     const newProps = {
       ...props,
       isNew: true,
-      source: 'maptypes',
     };
 
     wrapper = mount(<Router>
@@ -203,56 +168,6 @@ describe('Test suite for dictionary concepts components', () => {
     });
   });
 
-  it('should handle change when a user inputs concept name mappings data for for existing concepts', () => {
-    const newProps = {
-      ...props,
-      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
-    };
-
-    wrapper = mount(<Router>
-      <table><tbody><CreateMapping {...newProps} /></tbody></table>
-    </Router>);
-
-    const inputField = wrapper.find('CreateMapping');
-    const spy = jest.spyOn(inputField.instance(), 'handleInputChange');
-    inputField.find('#searchInputCiel').simulate('change');
-    expect(spy).toHaveBeenCalled();
-  });
-
-  it('should handle change when a user inputs concept name mappings data for new rows when isNew is true', () => {
-    const newProps = {
-      ...props,
-      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
-      isNew: true,
-    };
-
-    wrapper = mount(<Router>
-      <table><tbody><CreateMapping {...newProps} /></tbody></table>
-    </Router>);
-
-    const inputField = wrapper.find('CreateMapping');
-    const spy = jest.spyOn(inputField.instance(), 'handleInputChange');
-    inputField.find('#searchInputCielIsnew').simulate('change');
-    expect(spy).toHaveBeenCalled();
-  });
-
-  it('Should handle key down event when a user presses the enter button to search mappings for existing rows', () => {
-    const newProps = {
-      ...props,
-      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
-    };
-
-    wrapper = mount(<Router>
-      <table><tbody><CreateMapping {...newProps} /></tbody></table>
-    </Router>);
-
-    const inputField = wrapper.find('CreateMapping');
-    const spy = jest.spyOn(inputField.instance(), 'handleKeyPress');
-    const event = { key: 'Space' };
-    inputField.find('#searchInputCiel').simulate('keyDown', event);
-    expect(spy).toHaveBeenCalled();
-  });
-
   it('should call action to query internal concepts and set the results to state', async () => {
     const data = [concept];
     const conceptsInASourceMock = jest.fn(() => ({ data }));
@@ -264,7 +179,6 @@ describe('Test suite for dictionary concepts components', () => {
     const url = '/test/url';
     const newProps = {
       ...props,
-      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
     };
 
     wrapper = mount(<Router>
@@ -292,7 +206,6 @@ describe('Test suite for dictionary concepts components', () => {
     const url = '/test/url';
     const newProps = {
       ...props,
-      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
     };
 
     notify.show = notifyMock;
@@ -309,47 +222,10 @@ describe('Test suite for dictionary concepts components', () => {
     expect(notifyMock).toHaveBeenCalledWith('Query must have at least three characters', 'warning', 2000);
   });
 
-  it('should call action to query ciel concepts and set the results to state', async () => {
-    const data = [concept];
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent();
-      request.respondWith({
-        status: 200,
-        response: data,
-      });
-    });
-
-    const event = {
-      keyCode: KEY_CODE_FOR_ENTER,
-    };
-    const inputValue = 'testQuery';
-    const url = '/test/url';
-    const newProps = {
-      ...props,
-      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
-    };
-
-    wrapper = mount(<Router>
-      <table><tbody><CreateMapping {...newProps} /></tbody></table>
-    </Router>);
-
-    const createMapping = wrapper.find('CreateMapping');
-    const createMappingInstance = createMapping.instance();
-
-    expect(createMapping.state().options).toHaveLength(0);
-    expect(createMapping.state().isVisible).toBeFalsy();
-
-    await createMappingInstance.handleKeyPress(event, inputValue, url, true);
-
-    expect(createMapping.state().options[0].to_concept_code).toEqual(data[0].id);
-    expect(createMapping.state().isVisible).toBeTruthy();
-  });
-
   it('should display "No concepts matching this query" when there are no concepts to select from', (done) => {
     const newProps = {
       ...props,
       isNew: true,
-      source: 'maptypes',
     };
 
     const mappingRow = shallow(<CreateMapping {...newProps} />);
@@ -369,7 +245,6 @@ describe('Test suite for dictionary concepts components', () => {
     const newProps = {
       ...props,
       isNew: true,
-      source: 'maptypes',
     };
 
     const mappingRow = shallow(<CreateMapping {...newProps} />);
@@ -387,98 +262,10 @@ describe('Test suite for dictionary concepts components', () => {
     });
   });
 
-  it('Should handle click event when a user click to select a prefered concept name for existing rows', () => {
-    const newProps = {
-      ...props,
-      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
-      isNew: false,
-      isShown: true,
-    };
-
-    wrapper = mount(<table><tbody><CreateMapping {...newProps} /></tbody></table>);
-
-    const inputField = wrapper.find('CreateMapping');
-    inputField.setState({
-      options: [{
-        index: '1',
-        label: 'mala',
-        value: '/orgs/CIEL/sources/CIEL/concepts/32/',
-      }],
-    }, () => {
-      const spy = jest.spyOn(inputField.instance(), 'handleSelect');
-      wrapper.find('#selectMappingnotNew').simulate('click');
-      expect(spy).toHaveBeenCalled();
-    });
-  });
-
-  it('should handle click when a user click to select a prefered concept mapping name for new rows', () => {
-    const newProps = {
-      ...props,
-      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
-      isNew: true,
-      isShown: true,
-    };
-
-    wrapper = mount(<table><tbody><CreateMapping {...newProps} /></tbody></table>);
-
-    const inputField = wrapper.find('CreateMapping');
-    inputField.setState({
-      options: [{
-        index: '1',
-        label: 'mala',
-        value: '/orgs/CIEL/sources/CIEL/concepts/32/',
-      }],
-    }, () => {
-      const spy = jest.spyOn(inputField.instance(), 'handleSelect');
-      wrapper.find('#selectMappingNew').simulate('click');
-      expect(spy).toHaveBeenCalled();
-    });
-  });
-
-  it('should handle key down event when a user presses the enter button to search mappings for existing rows', () => {
-    const newProps = {
-      ...props,
-      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
-    };
-
-    wrapper = mount(<Router>
-      <table><tbody><CreateMapping {...newProps} /></tbody></table>
-    </Router>);
-
-    const inputField = wrapper.find('CreateMapping');
-    const handleKeyPressMock = jest.fn();
-    inputField.instance().handleKeyPress = handleKeyPressMock;
-
-    const event = { keyCode: KEY_CODE_FOR_ENTER };
-    inputField.find('#searchInputCiel').simulate('keyDown', event);
-    expect(handleKeyPressMock).toHaveBeenCalled();
-  });
-
-  it('should handle key down event when a user presses the enter button to search mappings for new rows (isNew is true)', () => {
-    const newProps = {
-      ...props,
-      source: INTERNAL_MAPPING_DEFAULT_SOURCE,
-      isNew: true,
-    };
-
-    wrapper = mount(<Router>
-      <table><tbody><CreateMapping {...newProps} /></tbody></table>
-    </Router>);
-
-    const inputField = wrapper.find('CreateMapping');
-    const handleKeyPressMock = jest.fn();
-    inputField.instance().handleKeyPress = handleKeyPressMock;
-
-    const event = { keyCode: KEY_CODE_FOR_ENTER };
-    inputField.find('#searchInputCielIsnew').simulate('keyDown', event);
-    expect(handleKeyPressMock).toHaveBeenCalled();
-  });
-
   describe('selectInternalMapping', () => {
     it('should call updateEventListener twice with the expected arguments', () => {
       const newProps = {
         ...props,
-        source: INTERNAL_MAPPING_DEFAULT_SOURCE,
       };
       const url = '/test/url';
 
@@ -495,7 +282,7 @@ describe('Test suite for dictionary concepts components', () => {
       expect(props.updateEventListener).toHaveBeenCalledTimes(2);
       expect(props.updateEventListener.mock.calls[0]).toEqual([{
         target: {
-          value: concept.display_name,
+          value: `ID(${concept.id}) - ${concept.display_name}`,
           name: 'to_concept_name',
         },
       }, url]);

--- a/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/CreateConcept.test.jsx
@@ -113,15 +113,6 @@ describe('Test suite for dictionary concepts components', () => {
     expect(instance.state.mappings[1].retired).toEqual(true);
   });
 
-  it('should call updateAsyncSelectValue function', () => {
-    const value = { index: '1234', value: 'malaria 1', label: 'malaria 1' };
-    const instance = wrapper.find('CreateConcept').instance();
-    instance.updateAsyncSelectValue(null);
-    expect(instance.state.mappings[0].to_concept_name).toEqual(null);
-    instance.updateAsyncSelectValue(value);
-    expect(instance.state.mappings[0].to_concept_name).toEqual('malaria 1');
-  });
-
   it('should call updateEventListener function', () => {
     const event = {
       target: {
@@ -410,7 +401,7 @@ describe('Test suite for dictionary concepts components', () => {
       source: 'MapTypes',
       url,
     };
-    instance.updateSourceEventListener(event, url);
+    instance.updateSourceEventListener(event, url, { url: '/not/ciel/' });
     setImmediate(() => {
       expect(instance.state.mappings[1].map_type).toEqual('NARROWER-THAN');
     });

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -532,15 +532,6 @@ describe('Test suite for mappings on existing concepts', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it('should call updateAsyncSelectValue function', () => {
-    const value = { index: '1234', value: 'malaria 1', label: 'malaria 1' };
-    const instance = wrapper.find('EditConcept').instance();
-    instance.updateAsyncSelectValue(null);
-    expect(instance.state.mappings[0].to_concept_name).toEqual(null);
-    instance.updateAsyncSelectValue(value);
-    expect(instance.state.mappings[0].to_concept_name).toEqual('malaria 1');
-  });
-
   it('should call updateEventListener function', () => {
     const event = {
       target: {
@@ -703,7 +694,7 @@ describe('Test suite for mappings on existing concepts', () => {
       source: 'Datatype',
       url: '1435',
     };
-    instance.updateSourceEventListener(event, url);
+    instance.updateSourceEventListener(event, url, { url: '/not/ciel' });
     expect(instance.state.mappings[0].map_type).toEqual('NARROWER-THAN');
   });
   it('should set `SAME-AS` as the default relationship when the source is changed to `CIEL`'
@@ -712,7 +703,7 @@ describe('Test suite for mappings on existing concepts', () => {
       target: {
         tabIndex: 0,
         name: 'source',
-        value: INTERNAL_MAPPING_DEFAULT_SOURCE,
+        value: CIEL_SOURCE_URL,
       },
     };
     const url = '1234';
@@ -720,7 +711,7 @@ describe('Test suite for mappings on existing concepts', () => {
     instance.state.mappings[1] = {
       url,
     };
-    instance.updateSourceEventListener(event, url);
+    instance.updateSourceEventListener(event, url, { url: CIEL_SOURCE_URL });
     expect(instance.state.mappings[1].map_type).toEqual('SAME-AS');
   });
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[Creating mappings to internal concepts should all have a single searchable field](https://issues.openmrs.org/browse/OCLOMRS-600)

# Summary:
- Creating mappings to internal concepts should all have only one single search field
- Currently, there are three fields, which can be confusing to the user
