### PR TITLE
OCLOMRS-597: When creating a mapping, the to-concept should also be added to the dictionary

### DIFF
--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -95,6 +95,7 @@ export const compareConceptsByUpdateDate = (firstConcept, nextConcept) => {
 export const removeBlankMappings = (mappings) => {
   if (!mappings) return [];
   return mappings.filter(
-    mapping => mapping.to_concept_url || (mapping.to_source_url && mapping.to_concept_code),
+    mapping => mapping.to_concept_url
+      || (mapping.sourceObject && mapping.sourceObject.url && mapping.to_concept_code),
   );
 };

--- a/src/components/dictionaryConcepts/containers/EditConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/EditConcept.jsx
@@ -40,6 +40,8 @@ import {
   removeEditedConceptMapping, addReferenceToCollectionAction, deleteReferenceFromCollectionAction,
 } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import GeneralModel from '../../dashboard/components/dictionary/common/GeneralModal';
+import { recursivelyFetchConceptMappings } from '../../../redux/actions/concepts/addBulkConcepts';
+import api from '../../../redux/api';
 
 export class EditConcept extends Component {
   static propTypes = {
@@ -221,7 +223,20 @@ export class EditConcept extends Component {
     ]);
     if (!response) return false;
 
+    const toConceptReferences = await recursivelyFetchConceptMappings(
+      [conceptRef.id],
+      0,
+      fromConceptCodes => api.mappings.list.fromAConceptInASource(
+        conceptRef.source_url, fromConceptCodes,
+      ),
+    );
+
     response = await addReferenceToCollection(type, typeName, collectionName, [conceptRef.url]);
+    if (toConceptReferences.length) {
+      response = await addReferenceToCollection(
+        type, typeName, collectionName, toConceptReferences, false,
+      );
+    }
     if (!response) return false;
 
     return true;

--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -60,8 +60,12 @@ export const previewConcept = id => (dispatch, getState) => {
   return dispatch(isSuccess(payload[0], PREVIEW_CONCEPT));
 };
 
-export const recursivelyFetchConceptMappings = async (fromConceptCodes, levelsToCheck) => {
-  const startingConceptMappings = await api.mappings.fetchFromPublicSources(fromConceptCodes.join(','));
+export const recursivelyFetchConceptMappings = async (
+  fromConceptCodes,
+  levelsToCheck,
+  fetchMappings = api.mappings.fetchFromPublicSources,
+) => {
+  const startingConceptMappings = await fetchMappings(fromConceptCodes.join(','));
   const mappingsList = [startingConceptMappings.data];
   for (let i = 0; i < levelsToCheck; i += 1) {
     const toConceptCodes = mappingsList[i].map(

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -54,6 +54,7 @@ import {
 
 import instance from '../../../config/axiosConfig';
 import api from '../../api';
+import { recursivelyFetchConceptMappings } from './addBulkConcepts';
 
 export const paginateConcepts = (concepts, limit = 10, offset = 0) => (dispatch, getState) => {
   let conceptList = concepts;
@@ -345,10 +346,27 @@ export const addConceptToDictionary = (id, dataUrl) => async (dispatch) => {
   const userType = urlConstruct[1];
   const sourceName = urlConstruct[4];
   const username = urlConstruct[2];
-  const data = { data: { expressions: [newConcept] } };
-  const url = `${userType}/${username}/collections/${sourceName}/references/?cascade=sourcemappings`;
+  const sourceUrl = `${userType}/${username}/sources/${sourceName}/`;
+
   try {
-    const response = await instance.put(url, data);
+    const toConceptReferences = await recursivelyFetchConceptMappings(
+      [id],
+      0,
+      fromConceptCodes => api.mappings.list.fromAConceptInASource(sourceUrl, fromConceptCodes),
+    );
+    if (toConceptReferences.length) {
+      await api.dictionaries.addReferencesToCollection(
+        userType, username, sourceName, toConceptReferences, false,
+      );
+    }
+  } catch (e) {
+    notify.show('Some mapping concepts were not added to the collection', 'error', 3000);
+  }
+
+  try {
+    const response = await api.dictionaries.addReferencesToCollection(
+      userType, username, sourceName, [newConcept],
+    );
     dispatch(isSuccess(response.data, ADD_CONCEPT_TO_DICTIONARY));
   } catch (error) {
     notify.show('An error occurred', 'error', 3000);

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -281,9 +281,9 @@ export const retireConcept = (conceptUrl, retire) => async (dispatch) => {
   }
 }
 
-export const addReferenceToCollectionAction = (type, owner, collection, expressions) => async (dispatch) => {
+export const addReferenceToCollectionAction = (type, owner, collection, expressions, cascadeMappings = true) => async (dispatch) => {
   try {
-    return await api.dictionaries.addReferencesToCollection(type, owner, collection, expressions);
+    return await api.dictionaries.addReferencesToCollection(type, owner, collection, expressions, cascadeMappings);
   } catch (e) {
     if(e && e.response && e.response.data){
       notify.show(e.response.data, 'error', 3000);

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -38,8 +38,8 @@ export default {
         .get(`${data}`)
         .then(response => response.data),
 
-    addReferencesToCollection: (type, owner, collection, expressions) =>
-      instance.put(`${type}/${owner}/collections/${collection}/references/?cascade=sourcemappings`, {
+    addReferencesToCollection: (type, owner, collection, expressions, cascadeMappings = true) =>
+      instance.put(`${type}/${owner}/collections/${collection}/references/?${cascadeMappings ? 'cascade=sourcemappings' : ''}`, {
         data: { expressions }
       }),
 
@@ -105,6 +105,7 @@ export default {
     fetchFromPublicSources: (fromConcepts) => instance.get(`mappings/?fromConcept=${fromConcepts}&limit=0`),
     list: {
       fromAConceptInACollection: (collectionUrl, fromConceptCode) => instance.get(`${collectionUrl}mappings/?limit=0&fromConcept=${fromConceptCode}`),
+      fromAConceptInASource: (sourceUrl, fromConceptCode) => instance.get(`${sourceUrl}mappings/?limit=0&fromConcept=${fromConceptCode}`),
     }
   },
 };

--- a/src/tests/Dashboard/action/api.test.js
+++ b/src/tests/Dashboard/action/api.test.js
@@ -8,7 +8,6 @@ import {
 } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import organizations from '../../__mocks__/organizations';
 import api from '../../../redux/api';
-import { recursivelyFetchConceptMappings } from '../../../redux/actions/concepts/addBulkConcepts/index';
 
 const mockStore = configureStore([thunk]);
 
@@ -350,5 +349,58 @@ describe('mappings', () => {
           .toContain(`${collectionUrl}mappings/?limit=0&fromConcept=${fromConceptCode}`);
       });
     });
+  });
+});
+
+describe('dictionaries', () => {
+  describe('addReferencesToCollection', () => {
+    beforeEach(() => {
+      moxios.install(instance);
+    });
+
+    afterEach(() => {
+      moxios.uninstall(instance);
+    });
+
+    it('should call addReferencesToCollection with the right parameters', async () => {
+      const type = 'user';
+      const owner ='admin';
+      const collection = 'TEST';
+      const expressions = ['/orgs/CIEL/sources/TEST/concepts/1/'];
+      const cascadeMappings = false;
+      let requestUrl;
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        requestUrl = request.url;
+        request.respondWith({
+          status: 200,
+        });
+      });
+
+      await api.dictionaries.addReferencesToCollection(type, owner, collection, expressions, cascadeMappings);
+      expect(requestUrl).toContain(`${type}/${owner}/collections/${collection}/references/?`);
+
+    })
+
+    it('should should append \'cascade=sourcemappings\' to the url if \'cascadeMappings\' is true', async () => {
+      const type = 'user';
+      const owner ='admin';
+      const collection = 'TEST';
+      const expressions = ['/orgs/CIEL/sources/TEST/concepts/1/'];
+      const cascadeMappings = true;
+      let requestUrl;
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        requestUrl = request.url;
+        request.respondWith({
+          status: 200,
+        });
+      });
+
+      await api.dictionaries.addReferencesToCollection(type, owner, collection, expressions, cascadeMappings);
+      expect(requestUrl).toContain(`${type}/${owner}/collections/${collection}/references/?cascade=sourcemappings`);
+
+    })
+
   });
 });

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -104,6 +104,7 @@ import {
 } from '../../../components/dictionaryConcepts/components/helperFunction';
 import api from '../../../redux/api';
 import { externalSource, internalSource } from '../../__mocks__/sources';
+import mappings from '../../__mocks__/mappings';
 
 jest.mock('uuid/v4', () => jest.fn(() => 1));
 jest.mock('react-notify-toast');
@@ -528,13 +529,19 @@ describe('Test suite for dictionary concept actions', () => {
   });
 
   it('should handle ADD_CONCEPT_TO_DICTIONARY', () => {
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent();
-      request.respondWith({
-        status: 200,
-        response: { added: true },
-      });
+    const listMappingsFromAConceptInASourceMock = jest.fn(() => []);
+    listMappingsFromAConceptInASourceMock.mockResolvedValueOnce({
+      data: [mappings[0]],
     });
+    const addReferencesToCollectionMock = jest.fn();
+    addReferencesToCollectionMock.mockResolvedValue({
+      data: {
+        added: true,
+      },
+    });
+
+    api.mappings.list.fromAConceptInASource = listMappingsFromAConceptInASourceMock;
+    api.dictionaries.addReferencesToCollection = addReferencesToCollectionMock;
 
     const expectedActions = [
       { type: ADD_CONCEPT_TO_DICTIONARY, payload: { added: true } },
@@ -548,13 +555,15 @@ describe('Test suite for dictionary concept actions', () => {
     });
   });
   it('should handle error in ADD_CONCEPT_TO_DICTIONARY', () => {
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent();
-      request.respondWith({
-        status: 400,
-        response: 'bad request',
-      });
+    const listMappingsFromAConceptInASourceMock = jest.fn(() => []);
+    listMappingsFromAConceptInASourceMock.mockResolvedValueOnce({
+      data: [mappings[0]],
     });
+    const addReferencesToCollectionMock = jest.fn();
+    addReferencesToCollectionMock.mockRejectedValueOnce({ response: 'bad request' });
+
+    api.mappings.list.fromAConceptInASource = listMappingsFromAConceptInASourceMock;
+    api.dictionaries.addReferencesToCollection = addReferencesToCollectionMock;
 
     const expectedActions = [{ type: IS_FETCHING, payload: false }];
 

--- a/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/container/EditConcept.test.jsx
@@ -16,6 +16,7 @@ import {
   CONCEPT_TYPE,
   MAP_TYPE,
 } from '../../../components/dictionaryConcepts/components/helperFunction';
+import api from '../../../redux/api';
 
 
 jest.mock('uuid/v4', () => jest.fn(() => '1234'));
@@ -761,6 +762,19 @@ describe('Test suite for mappings on existing concepts', () => {
 
   describe('updateConceptReference', () => {
     it('should return true on success', async () => {
+      const listMappingsFromAConceptInASourceMock = jest.fn(() => []);
+      listMappingsFromAConceptInASourceMock.mockResolvedValueOnce({
+        data: [mockMappings[0]],
+      });
+      const addReferencesToCollectionMock = jest.fn();
+      addReferencesToCollectionMock.mockResolvedValue({
+        data: {
+          added: true,
+        },
+      });
+      api.mappings.list.fromAConceptInASource = listMappingsFromAConceptInASourceMock;
+      api.dictionaries.addReferencesToCollection = addReferencesToCollectionMock;
+
       const editConceptInstance = wrapper.find('EditConcept').instance();
       expect(await editConceptInstance.updateConceptReference(sampleConcept)).toBeTruthy();
     });
@@ -777,6 +791,16 @@ describe('Test suite for mappings on existing concepts', () => {
     });
 
     it('should return false on add reference failure', async () => {
+      const listMappingsFromAConceptInASourceMock = jest.fn(() => []);
+      listMappingsFromAConceptInASourceMock.mockResolvedValueOnce({
+        data: [mockMappings[0]],
+      });
+      const addReferencesToCollectionMock = jest.fn();
+      addReferencesToCollectionMock.mockRejectedValueOnce({ response: 'bad request' });
+
+      api.mappings.list.fromAConceptInASource = listMappingsFromAConceptInASourceMock;
+      api.dictionaries.addReferencesToCollection = addReferencesToCollectionMock;
+
       const editConceptWrapper = mount(<Router>
         <EditConcept
           {...props}


### PR DESCRIPTION
# JIRA TICKET NAME:
[When creating a mapping, the to-concept should also be added to the dictionary](https://issues.openmrs.org/browse/OCLOMRS-597)

# Summary:
When creating a mapping, the to-concept should also be added to the dictionary. Currently, only the concept created is added. However, the to-concepts referenced in the mappings added to a concept need to be present in the collection too.
