### PR TITLE
OCLOMRS-609: When creating a mapping, a user should be able to search for more than 10 concepts

### DIFF
--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -98,7 +98,7 @@ export default {
     retireConcept: (conceptUrl, retire) => instance.put(conceptUrl, { retired: retire }),
     list: {
       conceptsInASource: (sourceUrl, query='') =>
-        instance.get(`${sourceUrl}concepts/?q=${query}*`)
+        instance.get(`${sourceUrl}concepts/?limit=0&q=${query}*`)
     },
   },
   mappings: {

--- a/src/tests/Dashboard/action/api.test.js
+++ b/src/tests/Dashboard/action/api.test.js
@@ -298,7 +298,7 @@ describe('concepts', () => {
         });
 
         await api.concepts.list.conceptsInASource(url, query);
-        expect(requestUrl).toContain(`${url}concepts/?q=${query}*`);
+        expect(requestUrl).toContain(`${url}concepts/?limit=0&q=${query}*`);
       });
 
       it('should call the fetchConcepts endpoint with no query term if it is not provided', async ()=> {
@@ -315,7 +315,7 @@ describe('concepts', () => {
         });
 
         await api.concepts.list.conceptsInASource(url);
-        expect(requestUrl).toContain(`${url}concepts/?q=*`);
+        expect(requestUrl).toContain(`${url}concepts/?limit=0&q=*`);
       });
     });
   });


### PR DESCRIPTION
# JIRA TICKET NAME:
[When creating a mapping, a user should be able to search for more than 10 concepts](https://issues.openmrs.org/browse/OCLOMRS-609)

# Summary:
When creating a mapping, a user should be able to search for more than 10 concepts
