### PR TITLE
OCLOMRS-613: When a concept has no mapping references, we should not attempt to delete them

### DIFF
--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -535,10 +535,12 @@ export const updateConcept = (conceptUrl, data, history, source, concept, collec
     );
     // we delete all of this concept's mappings references in the collection
     // so we can take advantage of cascadeMappings when updating the concept in the collection later
-    await api.dictionaries.references.delete.fromACollection(
-      collectionUrl,
-      currentMappings.data.map(mapping => mapping.version_url),
-    );
+    if (currentMappings && currentMappings.data && currentMappings.data.length) {
+      await api.dictionaries.references.delete.fromACollection(
+        collectionUrl,
+        currentMappings.data.map(mapping => mapping.version_url),
+      );
+    }
 
     await CreateMapping(removeBlankMappings(data.mappings), concept.url, source);
     await UpdateMapping(removeBlankMappings(data.mappings));

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -742,6 +742,38 @@ describe('Testing Edit concept actions ', () => {
     });
   });
 
+  it('should not attempt to delete references when the data is empty', () => {
+    const listReferencesInCollectionMock = jest.fn(() => ({ data: [] }));
+    const deleteReferencesFromCollectionMock = jest.fn();
+
+    api.mappings.list.fromAConceptInACollection = listReferencesInCollectionMock;
+    api.dictionaries.references.delete.fromACollection = deleteReferencesFromCollectionMock;
+
+    moxios.stubRequest(/(.*?)/, {
+      status: 200,
+      response: existingConcept,
+    });
+
+    const history = {
+      goBack: () => '',
+    };
+
+    const expectedActions = [
+      { type: IS_FETCHING, payload: true },
+      { type: UPDATE_CONCEPT, payload: existingConcept },
+      { type: IS_FETCHING, payload: false },
+    ];
+
+    const store = mockStore(mockConceptStore);
+    const conceptUrl = '/orgs/EthiopiaNHDD/sources/HMIS-Indicators/concepts/C1.1.1.1/';
+
+    expect(deleteReferencesFromCollectionMock).not.toHaveBeenCalled();
+    return store.dispatch(updateConcept(conceptUrl, existingConcept, history, 'HMIS-Indicators', existingConcept)).then(() => {
+      expect(deleteReferencesFromCollectionMock).not.toHaveBeenCalled();
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
   it('updateConcept should still return the updated concept if updating the mappings fails', async () => {
     const dispatchMock = jest.fn();
     moxios.wait(() => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[When a concept has no mapping references, we should not attempt to delete them](https://issues.openmrs.org/browse/OCLOMRS-613)

# Summary:
Attempting to request delete of an empty list of references returns a 400, causing the concept mappings not to be updated