### PR TITLE
OCLOMRS-612: Fix incorrect check for blank answer and set mappings

### DIFF
--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -99,3 +99,9 @@ export const removeBlankMappings = (mappings) => {
       || (mapping.sourceObject && mapping.sourceObject.url && mapping.to_concept_code),
   );
 };
+export const removeBlankSetsOrAnswers = (items) => {
+  if (!items) return [];
+  return items.filter(
+    item => item.url,
+  );
+};

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -7,7 +7,7 @@ import {
   MAP_TYPE,
   isExternalSource,
   compareConceptsByUpdateDate,
-  removeBlankMappings,
+  removeBlankMappings, removeBlankSetsOrAnswers,
 } from '../../../components/dictionaryConcepts/components/helperFunction';
 
 import {
@@ -433,14 +433,14 @@ export const createNewConcept = (data, dataUrl) => async (dispatch) => {
       await addAnswerMappingToConcept(
         response.data.url,
         response.data.source,
-        removeBlankMappings(data.answers),
+        removeBlankSetsOrAnswers(data.answers),
       );
     }
     if (data.sets) {
       await addSetMappingToConcept(
         response.data.url,
         response.data.source,
-        removeBlankMappings(data.sets),
+        removeBlankSetsOrAnswers(data.sets),
       );
     }
     await CreateMapping(
@@ -545,12 +545,12 @@ export const updateConcept = (conceptUrl, data, history, source, concept, collec
     await addAnswerMappingToConcept(
       response.data.url,
       response.data.source,
-      removeBlankMappings(data.answers),
+      removeBlankSetsOrAnswers(data.answers),
     );
     await addSetMappingToConcept(
       response.data.url,
       response.data.source,
-      removeBlankMappings(data.sets),
+      removeBlankSetsOrAnswers(data.sets),
     );
 
     dispatch(isSuccess(response.data, UPDATE_CONCEPT));

--- a/src/tests/__mocks__/answers.js
+++ b/src/tests/__mocks__/answers.js
@@ -1,3 +1,5 @@
+import { MAP_TYPE } from '../../components/dictionaryConcepts/components/helperFunction';
+
 export default [{
   frontEndUniqueKey: 'testID1',
   display_name: 'test display name 1',
@@ -5,3 +7,12 @@ export default [{
   frontEndUniqueKey: 'testID2',
   display_name: 'test display name 2',
 }];
+
+export const answer = {
+  url: 'some/test.url',
+  map_scope: 'Internal',
+  map_type: MAP_TYPE.questionAndAnswer,
+  to_concept_code: '429b6715-774d-4d64-b043-ae5e177df57f',
+  to_concept_name: 'CIEL: MALARIAL SMEAR',
+  to_concept_source: '/orgs/CIEL/sources/CIEL/concepts/32/',
+};

--- a/src/tests/dictionaryConcepts/components/helperFunction.test.js
+++ b/src/tests/dictionaryConcepts/components/helperFunction.test.js
@@ -2,8 +2,9 @@ import {
   compareConceptsByUpdateDate,
   KEY_CODE_FOR_ENTER,
   KEY_CODE_FOR_SPACE,
-  preventFormSubmit
+  preventFormSubmit, removeBlankMappings, removeBlankSetsOrAnswers,
 } from '../../../components/dictionaryConcepts/components/helperFunction';
+import { answer } from '../../__mocks__/answers';
 
 describe('preventFormSubmit', () => {
   it('should return false when target is textarea', () => {
@@ -48,5 +49,30 @@ describe('compareConceptsByUpdateDate', () => {
 
   it('should return 0 if the concepts have the same update time', () => {
     expect(compareConceptsByUpdateDate(olderConcept, olderConcept)).toEqual(0);
+  });
+});
+
+describe('removeBlankMappings', () => {
+  it('should return an empty list when there are no mappings', () => {
+    expect(removeBlankMappings(null)).toEqual([]);
+  });
+});
+
+describe('removeBlankSetsOrAnswers', () => {
+  it('should remove blank mappings', () => {
+    const data = [
+      answer,
+      { ...answer, url: '' },
+    ];
+
+    const expectedResult = [
+      answer,
+    ];
+
+    expect(removeBlankSetsOrAnswers(data)).toEqual(expectedResult);
+  });
+
+  it('should return an empty list when there are no mappings', () => {
+    expect(removeBlankSetsOrAnswers(null)).toEqual([]);
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix incorrect check for blank answer and set mappings](https://issues.openmrs.org/browse/OCLOMRS-612)

# Summary:
The check for whether a mapping is blank is different from the one for whether an answer or set is blank. A new method is needed to reflect this.
