### PR TITLE
OCLOMRS-614: Fix incorrect filter for latest concept versions on dictionaryConcepts page

### DIFF
--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -146,7 +146,7 @@ export const fetchDictionaryConcepts = (
     // version is not removed after an update. Pending backend fix.
     // ticket: https://github.com/OpenConceptLab/ocl_issues/issues/115
     const concepts = response.data.filter(
-      concept => concept.external_id || concept.is_latest_version,
+      concept => concept.is_latest_version,
     );
     dispatch(getDictionaryConcepts(concepts, FETCH_DICTIONARY_CONCEPT));
     dispatch(paginateConcepts(concepts));

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -768,3 +768,8 @@ export const conceptWithoutMappings = {
   ...sampleConcept,
   mappings: null,
 };
+
+export const conceptThatIsNotTheLatestVersion = {
+  ...sampleConcept,
+  is_latest_version: false,
+};

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -94,7 +94,7 @@ import concepts, {
   newConceptData,
   multipleConceptsMockStore,
   newConceptDataWithAnswerAndSetMappings,
-  existingConcept, sampleConcept, conceptWithoutMappings,
+  existingConcept, sampleConcept, conceptWithoutMappings, conceptThatIsNotTheLatestVersion,
 } from '../../__mocks__/concepts';
 import {
   CIEL_SOURCE_URL,
@@ -194,6 +194,27 @@ describe('Test suite for dictionary concept actions', () => {
 
     return store.dispatch(fetchDictionaryConcepts('orgs', 'CIEL', 'CIEL')).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should return only the latest version of each concept', () => {
+    const conceptData = [concepts, conceptThatIsNotTheLatestVersion];
+
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+        response: conceptData,
+      });
+    });
+
+    const store = mockStore(mockConceptStore);
+
+    return store.dispatch(fetchDictionaryConcepts()).then(() => {
+      expect(store.getActions()[1]).toEqual({
+        type: FETCH_DICTIONARY_CONCEPT,
+        payload: [concepts],
+      });
     });
   });
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix incorrect filter for latest concept versions on dictionaryConcepts page](https://issues.openmrs.org/browse/OCLOMRS-614)

# Summary:
Previously, concepts created within OCL had a null external id. This is no longer the case. This updates the filter to reflect that.