### PR TITLE
OCLOMRS-617: The locale_preffered field for names displays an incorrect value

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -44,7 +44,7 @@ class ConceptNameRows extends Component {
       name: '',
       locale: defaultLocale.value,
       locale_full: defaultLocale,
-      locale_preferred: 'Yes',
+      locale_preferred: true,
       name_type: 'Fully Specified',
     };
     autoBind(this);
@@ -74,14 +74,19 @@ class ConceptNameRows extends Component {
       locale: newRow.locale || defaultLocale.value,
       locale_full: defaultLocale,
       name_type: newRow.name_type || 'Fully Specified',
-      locale_preferred: newRow.locale_preferred || 'Yes',
+      locale_preferred: !!newRow.locale_preferred,
     });
   }
 
   handleChange(event) {
     const {
-      target: { value, name },
+      target: { name },
     } = event;
+    let {
+      target: { value },
+    } = event;
+
+    if (name === 'locale_preferred') value = value === 'Yes';
 
     this.setState(() => ({ [name]: value }));
     this.sendToTopComponent();
@@ -154,7 +159,7 @@ class ConceptNameRows extends Component {
           <select
             id="locale_preferred"
             name="locale_preferred"
-            value={this.state.locale_preferred}
+            value={this.state.locale_preferred ? 'Yes' : 'No'}
             className="form-control"
             onChange={this.handleChange}
           >

--- a/src/tests/dictionaryConcepts/components/ConceptNameRows.test.jsx
+++ b/src/tests/dictionaryConcepts/components/ConceptNameRows.test.jsx
@@ -38,6 +38,7 @@ describe('Test suite for ConceptNameRows ', () => {
         name: 'testing',
         locale_full: { value: 'en', label: 'English [en]' },
         name_type: 'test',
+        locale_preferred: true,
       },
       locale: ['fr', 'sw'],
       existingConcept: {
@@ -65,7 +66,7 @@ describe('Test suite for ConceptNameRows ', () => {
         name: 'testing',
         locale: 'la',
         locale_full: { value: 'en', label: 'English [en]' },
-        locale_preferred: 'No',
+        locale_preferred: false,
         name_type: 'test',
       },
       index: 0,
@@ -80,6 +81,7 @@ describe('Test suite for ConceptNameRows ', () => {
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.length).toBe(1);
     expect(wrapper.find('#concept-name').props().value).toEqual(newProps.newRow.name);
+    expect(wrapper.find('#locale_preferred').props().value).toEqual(newProps.newRow.locale_preferred ? 'Yes' : 'No');
   });
 
   it('should call update state with selected value when handleNameLocale is invoked', () => {
@@ -106,5 +108,33 @@ describe('Test suite for ConceptNameRows ', () => {
     expect(spy).toHaveBeenCalled();
     expect(instance.state.locale).toEqual(selectedOptions.value);
     expect(instance.state.locale_full).toEqual(selectedOptions);
+  });
+
+  it('should update state and call sendToTopComponent when the name type is updated', () => {
+    const newProps = {
+      ...props,
+      newRow: {
+        id: '5',
+        name: 'testing',
+        locale_full: { value: 'en', label: 'English [en]' },
+        name_type: 'test',
+      },
+      locale: ['fr', 'sw'],
+      existingConcept: {
+        id: 9,
+      },
+    };
+    wrapper = mount(<table><tbody><ConceptNameRows {...newProps} /></tbody></table>);
+    const instance = wrapper.find('ConceptNameRows').instance();
+    const spy = jest.spyOn(instance, 'sendToTopComponent');
+
+    expect(spy).not.toHaveBeenCalled();
+    instance.handleChange({ target: { name: 'locale_preferred', value: 'Yes' } });
+    expect(instance.state.locale_preferred).toEqual(true);
+
+    instance.handleChange({ target: { name: 'locale_preferred', value: 'No' } });
+    expect(instance.state.locale_preferred).toEqual(false);
+
+    expect(spy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[The locale_preffered field for names displays an incorrect value](https://issues.openmrs.org/browse/OCLOMRS-617)

# Summary:
The condition for displaying this field assumed that the field contains a 'Yes', 'No'. It contains a true/false. This needs to be updated.
