### PR TITLE
OCLOMRS-616: Names and Descriptions Should Have external_ids as well

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -1,3 +1,4 @@
+import uuid from 'uuid/v4';
 import React, { Component } from 'react';
 import autoBind from 'react-autobind';
 import Select from 'react-select';
@@ -75,6 +76,7 @@ class ConceptNameRows extends Component {
       locale_full: defaultLocale,
       name_type: newRow.name_type || 'Fully Specified',
       locale_preferred: !!newRow.locale_preferred,
+      external_id: newRow.external_id || uuid(),
     });
   }
 

--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -1,3 +1,4 @@
+import uuid from 'uuid/v4';
 import React, { Component } from 'react';
 import Select from 'react-select';
 import autoBind from 'react-autobind';
@@ -67,6 +68,7 @@ class DescriptionRow extends Component {
       locale: newRow.locale || 'en',
       locale_full: defaultLocale,
       description: newRow.description,
+      external_id: newRow.external_id || uuid(),
     });
   }
 

--- a/src/tests/dictionaryConcepts/components/ConceptNameRows.test.jsx
+++ b/src/tests/dictionaryConcepts/components/ConceptNameRows.test.jsx
@@ -84,6 +84,31 @@ describe('Test suite for ConceptNameRows ', () => {
     expect(wrapper.find('#locale_preferred').props().value).toEqual(newProps.newRow.locale_preferred ? 'Yes' : 'No');
   });
 
+  it('should update state with the right values from the props', () => {
+    const newProps = {
+      ...props,
+      newRow: {
+        id: '5',
+        name: 'testing',
+        locale: 'la',
+        locale_full: { value: 'en', label: 'English [en]' },
+        locale_preferred: 'No',
+        name_type: 'test',
+        external_id: 'externalId',
+      },
+      index: 0,
+      nameRows: [],
+      rowId: '3',
+      locale: ['fr', 'sw'],
+      existingConcept: {
+        id: 9,
+      },
+    };
+    wrapper = mount(<table><tbody><ConceptNameRows {...newProps} /></tbody></table>);
+    const instance = wrapper.find('ConceptNameRows').instance();
+    expect(instance.state.external_id).toEqual(newProps.newRow.external_id);
+  });
+
   it('should call update state with selected value when handleNameLocale is invoked', () => {
     const newProps = {
       ...props,


### PR DESCRIPTION
# JIRA TICKET NAME:
[Names and Descriptions Should Have external_ids as well](https://issues.openmrs.org/browse/OCLOMRS-616)

# Summary:
external_ids are required to perform imports in OpenMRS
Names and descriptions are currently creating these as null
