### PR TITLE
OCLOMRS-615: Filtering and searching at the same time is not working on the dictionary concepts page

### DIFF
--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -11,7 +11,6 @@ import { conceptsProps } from '../proptypes';
 import { getUsername } from '../components/helperFunction';
 import {
   fetchDictionaryConcepts,
-  fetchConceptsByName,
   filterBySource,
   filterByClass,
   paginateConcepts,
@@ -51,7 +50,6 @@ export class DictionaryConcepts extends Component {
     userIsMember: PropTypes.bool.isRequired,
     removeDictionaryConcept: PropTypes.func.isRequired,
     removeConceptMappingAction: PropTypes.func.isRequired,
-    searchByName: PropTypes.func.isRequired,
     retireCurrentConcept: PropTypes.func.isRequired,
     getOriginalConcept: PropTypes.func.isRequired,
     originalConcept: PropTypes.shape({}).isRequired,
@@ -134,6 +132,9 @@ export class DictionaryConcepts extends Component {
       );
     }
 
+    const query = `${searchInput.trim()}*`;
+    this.fetchConcepts(query);
+
     this.setState({
       [inputName]: eventAction,
     });
@@ -210,9 +211,8 @@ export class DictionaryConcepts extends Component {
   handleSearchByName = (event) => {
     event.preventDefault();
     const { searchInput } = this.state;
-    const query = `q=${searchInput.trim()}`;
-    const { searchByName } = this.props;
-    searchByName(query);
+    const query = `${searchInput.trim()}*`;
+    this.fetchConcepts(query);
   };
 
   handleRetireConcept = async (id, retired) => {
@@ -348,7 +348,6 @@ export default connect(
   mapStateToProps,
   {
     fetchDictionaryConcepts,
-    searchByName: fetchConceptsByName,
     filterBySource,
     filterByClass,
     paginateConcepts,

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -162,43 +162,12 @@ export const fetchDictionaryConcepts = (
   dispatch(isFetching(false));
 };
 
-export const fetchConceptsByName = query => async (dispatch) => {
-  dispatch(isFetching(true));
-  const CONCEPT_TYPE = localStorage.getItem('type');
-  const USER_TYPE_NAME = localStorage.getItem('typeName');
-  const DICTIONARY_ID = localStorage.getItem('dictionaryId');
-
-  const url = `${CONCEPT_TYPE}/${USER_TYPE_NAME}/collections/${DICTIONARY_ID}/concepts/?includeMappings=true&${query}*&verbose=true`;
-  try {
-    const response = await instance.get(url);
-    dispatch(isSuccess(response.data, FETCH_DICTIONARY_CONCEPT));
-    dispatch(isFetching(false));
-  } catch (error) {
-    dispatch(isFetching(false));
-    notify.show('Something went wrong with your search, please try again.', 'error', 3000);
-  }
-};
-
-export const filterBySource = (
-  keyword,
-  conceptType,
-  conceptOwner,
-  conceptName,
-  query = '',
-) => (dispatch) => {
+export const filterBySource = keyword => (dispatch) => {
   dispatch({ type: FILTER_BY_SOURCES, payload: keyword });
-  dispatch(fetchDictionaryConcepts(conceptType, conceptOwner, conceptName, query));
 };
 
-export const filterByClass = (
-  keyword,
-  conceptType,
-  conceptOwner,
-  conceptName,
-  query = '',
-) => (dispatch) => {
+export const filterByClass = keyword => (dispatch) => {
   dispatch({ type: FILTER_BY_CLASS, payload: keyword });
-  dispatch(fetchDictionaryConcepts(conceptType, conceptOwner, conceptName, query));
 };
 
 export const queryAnswers = async (source, query, mapType = MAP_TYPE.questionAndAnswer) => {

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -44,7 +44,6 @@ import {
 } from '../../../redux/actions/types';
 import {
   fetchDictionaryConcepts,
-  fetchConceptsByName,
   filterByClass,
   filterBySource,
   createNewName,
@@ -313,48 +312,6 @@ describe('Test suite for dictionary concept actions', () => {
     const store = mockStore(mockConceptStore);
 
     return store.dispatch(fetchDictionaryConcepts('orgs', 'CIEL', 'CIEL')).then(() => {
-      expect(store.getActions()).toEqual(expectedActions);
-    });
-  });
-
-  it('should fetch dictionary concepts by name', () => {
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent();
-      request.respondWith({
-        status: 200,
-        response: [concepts],
-      });
-    });
-
-    const expectedActions = [
-      { type: IS_FETCHING, payload: true },
-      { type: FETCH_DICTIONARY_CONCEPT, payload: [concepts] },
-      { type: IS_FETCHING, payload: false },
-    ];
-
-    const store = mockStore(mockConceptStore);
-
-    return store.dispatch(fetchConceptsByName('search')).then(() => {
-      expect(store.getActions()).toEqual(expectedActions);
-    });
-  });
-
-  it('should handle the error when search by name fails', () => {
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent();
-      request.respondWith({
-        status: 404,
-      });
-    });
-
-    const expectedActions = [
-      { type: IS_FETCHING, payload: true },
-      { type: IS_FETCHING, payload: false },
-    ];
-
-    const store = mockStore(mockConceptStore);
-
-    return store.dispatch(fetchConceptsByName('search')).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
@@ -959,7 +916,6 @@ describe('test for search filter by class', () => {
   const store = mockStore(mockConceptStore);
   const expectedActions = [
     { type: FILTER_BY_CLASS, payload: 'MapType' },
-    { payload: true, type: '[ui] toggle spinner' },
   ];
 
   store.dispatch(filterByClass('MapType', 'users', 'emasys', 'dev-col', 'classes', ''));
@@ -970,7 +926,6 @@ describe('test for search filter by source', () => {
   const store = mockStore(mockConceptStore);
   const expectedActions = [
     { type: FILTER_BY_SOURCES, payload: 'MapType' },
-    { payload: true, type: '[ui] toggle spinner' },
   ];
 
   store.dispatch(filterBySource('MapType', 'users', 'emasys', 'dev-col', 'source', ''));

--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -565,8 +565,10 @@ describe('Test suite for dictionary concepts components', () => {
         <DictionaryConcepts {...props} />
       </Router>
     </Provider>);
+    props.fetchDictionaryConcepts.mockClear();
+    expect(wrapper.find('DictionaryConcepts').props().fetchDictionaryConcepts).not.toHaveBeenCalled();
     wrapper.find('#submit-search-form').simulate('submit');
-    expect(wrapper.find('DictionaryConcepts').props().searchByName).toHaveBeenCalled();
+    expect(wrapper.find('DictionaryConcepts').props().fetchDictionaryConcepts).toHaveBeenCalled();
   });
 
   describe('Retire/Unretire Concepts', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Filtering and searching at the same time is not working on the dictionary concepts page](https://issues.openmrs.org/browse/OCLOMRS-615)

# Summary:
Using one of these features turns off the other. Ideally a user should be able to search through filtered concepts
