### PR TITLE
OCLOMRS-606: Logging out on one tab should log the user out in all other tabs and windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "axios": "^0.18.0",
     "bootstrap": "^4.1.3",
     "downshift": "3.1.7",
+    "history": "^4.9.0",
     "lodash": "^4.17.10",
     "match-sorter": "^2.3.0",
     "prop-types": "^15.6.1",

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
+/* eslint-disable react/jsx-indent */
 import React, { Fragment } from 'react';
 import { Provider } from 'react-redux';
-import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { Router, Route, Switch } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import store from './redux/reducers/store';
 import Login from './components/login/container';
@@ -19,10 +20,11 @@ import AddBulkConcepts from './components/bulkConcepts/addBulkConcepts';
 import BulkConceptPage from './components/bulkConcepts/container/BulkConceptsPage';
 import { Signup } from './components/Signup/components/container';
 import Notifications from './components/Notifications';
+import history from './config/history';
 
 const App = () => (
   <Provider store={store}>
-    <BrowserRouter>
+    <Router history={history}>
       <Fragment>
         <div className="App">
           <Navbar />
@@ -80,7 +82,7 @@ const App = () => (
           </Switch>
         </div>
       </Fragment>
-    </BrowserRouter>
+    </Router>
   </Provider>
 );
 export default App;

--- a/src/components/Auth/index.jsx
+++ b/src/components/Auth/index.jsx
@@ -1,12 +1,28 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { notify } from 'react-notify-toast';
+import history from '../../config/history';
 
-export const mapStateToProps = ({ users: { loggedIn } }) => ({
-  loggedIn,
-});
+export const checkAuth = (event) => {
+  if (event.key === null) {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      notify.show('You have been logged out', 'warning', 3000);
+      history.go(0);
+    }
+  }
+  if (event.key === 'token') {
+    const token = localStorage.getItem('token');
+    if (token) {
+      notify.show('Logged in successfully', 'success', 3000);
+      history.go(0);
+    }
+  }
+};
 
 export const AuthWrapper = (WrappedComponent) => {
+  window.addEventListener('storage', event => checkAuth(event));
   class Authenticate extends Component {
     static propTypes = {
       loggedIn: PropTypes.bool,
@@ -41,4 +57,8 @@ export const AuthWrapper = (WrappedComponent) => {
   return Authenticate;
 };
 
-export default Authenticate => connect(mapStateToProps, null)(AuthWrapper(Authenticate));
+export const mapStateToProps = ({ users: { loggedIn } }) => ({
+  loggedIn,
+});
+
+export default Authenticate => connect(mapStateToProps)(AuthWrapper(Authenticate));

--- a/src/config/axiosConfig.js
+++ b/src/config/axiosConfig.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
+import { notify } from 'react-notify-toast';
 import urlConfig from './index';
+import history from './history';
 
 const instance = axios.create({
   baseURL: urlConfig.OCL_API_HOST,
@@ -9,8 +11,15 @@ instance.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlenco
 instance.defaults.headers.put['Content-Type'] = 'application/x-www-form-urlencoded';
 
 instance.interceptors.request.use((config) => {
-  // eslint-disable-next-line
-  config.headers['Authorization'] = localStorage.getItem('token');
+  const token = localStorage.getItem('token');
+  if (token) {
+    // eslint-disable-next-line
+    config.headers['Authorization'] = token;
+  } else if (!token) {
+    notify.show('Please log in first', 'warning', 3000);
+    history.push('/');
+    throw new axios.Cancel('Request cancelled. Authentication required');
+  }
   return config;
 });
 

--- a/src/config/history.js
+++ b/src/config/history.js
@@ -1,0 +1,3 @@
+import { createBrowserHistory } from 'history';
+
+export default createBrowserHistory();

--- a/src/redux/reducers/authReducers.js
+++ b/src/redux/reducers/authReducers.js
@@ -10,7 +10,6 @@ const initialState = {
   user: {},
   loginAction: () => {},
   logoutAction: () => {},
-  history: {},
   loading: false,
 };
 
@@ -30,14 +29,13 @@ export default (state = initialState, action) => {
         loading: false,
       };
     case AUTHENTICATION_FAILED:
+    case LOGGED_OUT:
       return {
         ...state,
         payload: action.payload,
         loggedIn: false,
         loading: false,
       };
-    case LOGGED_OUT:
-      return { loggedIn: false };
     default:
       return state;
   }

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -26,3 +26,5 @@ global.uuid = uuid;
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 global.XMLHttpRequest = undefined;
+localStorage.setItem('token', 'Token mytoken');
+localStorage.setItem('username', 'Dann');

--- a/src/tests/Auth/index.test.jsx
+++ b/src/tests/Auth/index.test.jsx
@@ -4,9 +4,12 @@ import { Provider } from 'react-redux';
 import { createMockStore } from 'redux-test-utils';
 import { MemoryRouter as Router } from 'react-router';
 
-import Authenticate from '../../components/Auth';
+import { notify } from 'react-notify-toast';
+import Authenticate, { checkAuth } from '../../components/Auth';
 import { authenticated, notAuthenticated } from '../__mocks__/fakeStore';
 import TestComponent from '../__mocks__/FakeComponent';
+
+jest.mock('react-notify-toast');
 
 let store = createMockStore(authenticated);
 const props = {
@@ -30,11 +33,34 @@ describe('higher-order component', () => {
 
   test('[Authenticate] should render with unauthenticated data without crashing', () => {
     store = createMockStore(notAuthenticated);
+    localStorage.clear();
     const wrapper = mount(<Provider store={store}>
       <Router>
         <WrapperComponent {...props} />
       </Router>
     </Provider>);
     expect(wrapper).toMatchSnapshot();
+  });
+});
+
+describe('checking for authentication', () => {
+  it('should log out user', () => {
+    const notifyMock = jest.fn();
+    notify.show = notifyMock;
+    const event = { key: null };
+    localStorage.clear();
+    checkAuth(event);
+    expect(notifyMock).toHaveBeenCalledWith('You have been logged out', 'warning', 3000);
+    notifyMock.mockRestore();
+  });
+
+  it('should redirect user to login page on logout', () => {
+    localStorage.setItem('token', 'Token sdfghxscfvgbh');
+    const notifyMock = jest.fn();
+    const event = { key: 'token' };
+    notify.show = notifyMock;
+    checkAuth(event);
+    expect(notifyMock).toHaveBeenCalledWith('Logged in successfully', 'success', 3000);
+    notifyMock.mockRestore();
   });
 });

--- a/src/tests/AuthReducers.test.js
+++ b/src/tests/AuthReducers.test.js
@@ -93,6 +93,8 @@ describe('AuthReducer', () => {
 
     expect(authReducer(state, action)).toEqual({
       loggedIn: false,
+      loading: false,
+      payload: undefined,
     });
   });
 });

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -95,6 +95,8 @@ describe('replaceConcept', () => {
 describe('Test suite for dictionary actions', () => {
   beforeEach(() => {
     moxios.install(instance);
+    localStorage.setItem('token', 'Token mytoken');
+    localStorage.setItem('username', 'Dann');
   });
   const responseDict = {
     type: CLEAR_DICTIONARY,
@@ -182,6 +184,18 @@ describe('Test suite for dictionary actions', () => {
     const store = mockStore({ payload: {} });
     return store.dispatch(fetchDictionary('/users/chriskala/collections/over/')).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should alert a user and cancel the request if not logged in', () => {
+    const notifyMock = jest.fn();
+    notify.show = notifyMock;
+    localStorage.clear();
+    const store = mockStore({ payload: {} });
+    return store.dispatch(fetchDictionary('/users/Dann/collections/over/')).catch((error) => {
+      expect(error.message).toEqual('Request cancelled. Authentication required');
+      expect(notifyMock).toHaveBeenCalledWith('Please log in first', 'warning', 3000);
+      notifyMock.mockClear();
     });
   });
 

--- a/src/tests/Login/container/index.test.jsx
+++ b/src/tests/Login/container/index.test.jsx
@@ -43,6 +43,7 @@ describe('Login Component', () => {
   it('should handle UNSAFE_componentWillReceiveProps when logged in', () => {
     jest.mock('react-notify-toast');
     notify.show = jest.fn();
+    localStorage.setItem('token', 'Token token');
 
     const nextProps = {
       payload: {},
@@ -53,6 +54,7 @@ describe('Login Component', () => {
     wrapper.find(Login).instance().UNSAFE_componentWillReceiveProps(nextProps);
 
     expect(notify.show).toHaveBeenCalledWith('Logged in successfully as ', 'success', 3000);
+    localStorage.clear();
   });
 
   it('should handle UNSAFE_componentWillReceiveProps when loading', () => {

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -53,7 +53,6 @@ import {
   removeDescription,
   clearSelections,
   createNewConcept,
-  fetchSourceConcepts,
   queryAnswers,
   addConceptToDictionary,
   paginateConcepts,
@@ -102,6 +101,7 @@ import {
   INTERNAL_MAPPING_DEFAULT_SOURCE,
   MAP_TYPE,
   MAP_TYPES_DEFAULTS,
+  getUsername,
 } from '../../../components/dictionaryConcepts/components/helperFunction';
 import api from '../../../redux/api';
 import { externalSource, internalSource } from '../../__mocks__/sources';
@@ -1247,7 +1247,8 @@ describe('Add set mappings to concept', () => {
 
     const url = '/url/test/';
     const source = '2434435454545';
-    const mappingUrl = `/users/null/sources/${source}/mappings/`;
+    const username = getUsername()
+    const mappingUrl = `/users/${username}/sources/${source}/mappings/`;
 
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();


### PR DESCRIPTION
# JIRA TICKET NAME:
[Logging out on one tab should log the user out in all other tabs and windows](https://issues.openmrs.org/browse/OCLOMRS-606)

# Summary:
When one logs out on one tab, they are not logged out from other tabs and can still try to perform actions that require authentication. This fails and sometimes causes the app to crash.

This ticket is to fix this and make it such that when one logs outs, they are automatically logged out from all the other windows and tabs automatically. Also, when one logs in, they'll be automatically logged in to any open windows and/or tabs and be able to make authenticated requests.