### PR TITLE
OCLOMRS-621: Add clear all buttons for filter options

### DIFF
--- a/src/components/bulkConcepts/component/Sidenav.jsx
+++ b/src/components/bulkConcepts/component/Sidenav.jsx
@@ -1,17 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { includes } from 'lodash';
+import { Button } from 'reactstrap';
 import SideNavItems from './SideNavItems';
+import { FILTER_TYPES } from '../../../constants';
 
 const Sidenav = (props) => {
   const {
-    classes, datatypes, datatypeInput, classInput, handleChange, datatypeList, classList,
+    classes,
+    datatypes,
+    datatypeInput,
+    classInput,
+    handleChange,
+    datatypeList,
+    classList,
+    clearAllBulkFilters,
   } = props;
   return (
     <div className="col-12 col-md-3 custom-full-width">
       <div className="sidenav-container">
         <div className="row">
-          <h6 className="sidenav-header">Datatypes</h6>
+          <h5 className="sidenav-header">
+            Datatypes
+            {datatypes.length && (
+              <Button id="clear-datatype-filters" onClick={() => clearAllBulkFilters(FILTER_TYPES.DATATYPE)} className="btn btn-sm btn-outline-secondary clear-filter-button">Clear all</Button>
+            )}
+          </h5>
         </div>
         {datatypes.map(datatype => (
           <SideNavItems
@@ -24,7 +38,12 @@ const Sidenav = (props) => {
           />
         ))}
         <div className="row mt-3">
-          <h6 className="sidenav-header">Classes</h6>
+          <h5 className="sidenav-header">
+            Classes
+            {classes.length && (
+              <Button id="clear-class-filters" onClick={() => clearAllBulkFilters(FILTER_TYPES.CLASSES)} className="btn btn-sm btn-outline-secondary clear-filter-button">Clear all</Button>
+            )}
+          </h5>
         </div>
         {classes.map(classItem => (
           <SideNavItems
@@ -49,6 +68,7 @@ Sidenav.propTypes = {
   handleChange: PropTypes.func.isRequired,
   datatypeList: PropTypes.array,
   classList: PropTypes.array,
+  clearAllBulkFilters: PropTypes.func,
 };
 
 Sidenav.defaultProps = {
@@ -56,6 +76,7 @@ Sidenav.defaultProps = {
   classInput: '',
   datatypeList: [],
   classList: [],
+  clearAllBulkFilters: () => {},
 };
 
 export default Sidenav;

--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -12,6 +12,7 @@ import {
   addConcept,
   fetchFilteredConcepts,
   setCurrentPage,
+  clearAllBulkFilters,
 } from '../../../redux/actions/concepts/addBulkConcepts';
 import { conceptsProps } from '../../dictionaryConcepts/proptypes';
 import { MIN_CHARACTERS_WARNING, MILLISECONDS_TO_SHOW_WARNING } from '../../../redux/reducers/generalSearchReducer';
@@ -42,12 +43,14 @@ export class BulkConceptsPage extends Component {
     }).isRequired,
     datatypeList: PropTypes.array,
     classList: PropTypes.array,
+    clearAllBulkFilters: PropTypes.func,
   };
 
   static defaultProps = {
     preview: {},
     datatypeList: [],
     classList: [],
+    clearAllBulkFilters: () => {},
   };
 
   constructor(props) {
@@ -100,6 +103,12 @@ export class BulkConceptsPage extends Component {
     } else {
       this.props.addToFilterList(targetName[0], 'classes', query, currentPage);
     }
+  };
+
+  clearBulkFilters = (filterType) => {
+    const { clearAllBulkFilters: clearFilters, currentPage } = this.props;
+    const query = `q=${this.state.searchInput}`;
+    clearFilters(filterType, query, currentPage);
   };
 
   getBulkConcepts = () => {
@@ -181,6 +190,7 @@ export class BulkConceptsPage extends Component {
             handleChange={this.handleFilter}
             datatypeList={datatypeList}
             classList={classList}
+            clearAllBulkFilters={this.clearBulkFilters}
           />
           <div className="col-10 col-md-9 bulk-concept-wrapper custom-full-width">
             <SearchBar
@@ -225,5 +235,6 @@ export default connect(
     addConcept,
     fetchFilteredConcepts,
     setCurrentPage,
+    clearAllBulkFilters,
   },
 )(BulkConceptsPage);

--- a/src/components/dictionaryConcepts/components/Sidenav.jsx
+++ b/src/components/dictionaryConcepts/components/Sidenav.jsx
@@ -1,14 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Button } from 'reactstrap';
 import SideNavItem from './SideNavItem';
+import { FILTER_TYPES } from '../../../constants';
 
 const Sidenav = ({
-  filteredClass, filteredSources, handleChange, toggleCheck,
+  filteredClass, filteredSources, handleChange, toggleCheck, clearAllFilters,
 }) => (
   <div className="col-12 col-md-2 custom-full-width">
     <div className="sidenav-container">
       <div className="row">
-        <h6 className="sidenav-header">Source</h6>
+        <h5 className="sidenav-header">
+          Source
+          {filteredSources.length && (
+            <Button id="clear-source-filters" onClick={() => clearAllFilters(FILTER_TYPES.SOURCES)} className="btn btn-sm btn-outline-secondary clear-filter-button">Clear all</Button>
+          )}
+        </h5>
       </div>
       {filteredSources.map(source => (
         <SideNavItem
@@ -20,7 +27,12 @@ const Sidenav = ({
         />
       ))}
       <div className="row mt-3">
-        <h6 className="sidenav-header">Class</h6>
+        <h5 className="sidenav-header">
+          Class
+          {filteredClass.length && (
+            <Button id="clear-class-filters" onClick={() => clearAllFilters(FILTER_TYPES.CLASSES)} className="btn btn-sm btn-outline-secondary clear-filter-button">Clear all</Button>
+          )}
+        </h5>
       </div>
       {filteredClass.map(classItem => (
         <SideNavItem
@@ -41,10 +53,12 @@ Sidenav.propTypes = {
   toggleCheck: PropTypes.array.isRequired,
   filteredClass: PropTypes.array.isRequired,
   handleChange: PropTypes.func.isRequired,
+  clearAllFilters: PropTypes.func,
 };
 
 Sidenav.defaultProps = {
-  toggleCheck: []
+  toggleCheck: [],
+  clearAllFilters: () => {},
 }
 
 export default Sidenav;

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -15,6 +15,7 @@ import {
   filterByClass,
   paginateConcepts,
   fetchExistingConcept,
+  clearAllFilters,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import {
   removeDictionaryConcept,
@@ -55,6 +56,7 @@ export class DictionaryConcepts extends Component {
     originalConcept: PropTypes.shape({}).isRequired,
     addReferenceToCollection: PropTypes.func.isRequired,
     deleteReferenceFromCollection: PropTypes.func.isRequired,
+    clearAllFilters: PropTypes.func,
   };
 
   constructor(props) {
@@ -94,12 +96,16 @@ export class DictionaryConcepts extends Component {
     });
   }
 
-  fetchConcepts(query = '', limit = 0) {
+  fetchConcepts(limit = 0) {
     const {
       match: {
         params: { collectionName, type, typeName },
       },
     } = this.props;
+
+    const { searchInput } = this.state;
+    const query = `${searchInput.trim()}*`;
+
     this.props.fetchDictionaryConcepts(type, typeName, collectionName, query, limit);
   }
 
@@ -132,12 +138,17 @@ export class DictionaryConcepts extends Component {
       );
     }
 
-    const query = `${searchInput.trim()}*`;
-    this.fetchConcepts(query);
+    this.fetchConcepts();
 
     this.setState({
       [inputName]: eventAction,
     });
+  }
+
+  clearAllFilters(filterType) {
+    const { clearAllFilters: clearFilters } = this.props;
+    clearFilters(filterType);
+    this.fetchConcepts();
   }
 
   checkMembershipStatus(username) {
@@ -210,9 +221,7 @@ export class DictionaryConcepts extends Component {
 
   handleSearchByName = (event) => {
     event.preventDefault();
-    const { searchInput } = this.state;
-    const query = `${searchInput.trim()}*`;
-    this.fetchConcepts(query);
+    this.fetchConcepts();
   };
 
   handleRetireConcept = async (id, retired) => {
@@ -295,6 +304,7 @@ export class DictionaryConcepts extends Component {
             filteredSources={filteredSources}
             handleChange={this.handleSearch}
             toggleCheck={filters}
+            clearAllFilters={this.clearAllFilters}
           />
           <div className="col-12 col-md-10 custom-full-width">
             <SearchBar
@@ -328,6 +338,7 @@ export class DictionaryConcepts extends Component {
 DictionaryConcepts.defaultProps = {
   filteredByClass: [],
   filteredBySource: [],
+  clearAllFilters: () => {},
 };
 
 export const mapStateToProps = state => ({
@@ -358,5 +369,6 @@ export default connect(
     removeConceptMappingAction: removeConceptMapping,
     retireCurrentConcept: retireConcept,
     getOriginalConcept: fetchExistingConcept,
+    clearAllFilters,
   },
 )(DictionaryConcepts);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,2 +1,8 @@
 export const DIAGNOSIS_CLASS = 'Diagnosis';
 export const PROCEDURE_CLASS = 'Procedure';
+
+export const FILTER_TYPES = {
+  DATATYPE: 'datatype',
+  CLASSES: 'classes',
+  SOURCES: 'sources',
+};

--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -11,9 +11,11 @@ import {
   SET_PERVIOUS_PAGE,
   SET_NEXT_PAGE,
   SET_CURRENT_PAGE,
+  CLEAR_BULK_FILTERS,
 } from '../../types';
 import api from '../../../api';
 import { MAPPINGS_RECURSION_DEPTH, removeDuplicates } from '../../../../components/dictionaryConcepts/components/helperFunction';
+import { FILTER_TYPES } from '../../../../constants';
 
 export const fetchFilteredConcepts = (source = 'CIEL', query = '', currentPage = 1, conceptLimit = 10) => async (
   dispatch,
@@ -44,12 +46,17 @@ export const fetchFilteredConcepts = (source = 'CIEL', query = '', currentPage =
 };
 
 export const addToFilterList = (item, type, query, currentPage) => (dispatch) => {
-  if (type === 'datatype') {
+  if (type === FILTER_TYPES.DATATYPE) {
     dispatch(isSuccess(item, ADD_TO_DATATYPE_LIST));
     return dispatch(fetchFilteredConcepts('CIEL', query, currentPage));
   }
   dispatch(isSuccess(item, ADD_TO_CLASS_LIST));
   return dispatch(fetchFilteredConcepts('CIEL', query, currentPage));
+};
+
+export const clearAllBulkFilters = (filterType, query, currentPage) => (dispatch) => {
+  dispatch({ type: CLEAR_BULK_FILTERS, payload: filterType });
+  dispatch(fetchFilteredConcepts('CIEL', query, currentPage));
 };
 
 export const previewConcept = id => (dispatch, getState) => {

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -43,7 +43,7 @@ import {
   ADD_SELECTED_SETS,
   PRE_POPULATE_SETS,
   UNPOPULATE_PRE_POPULATED_SETS,
-  UNPOPULATE_SET,
+  UNPOPULATE_SET, CLEAR_FILTERS,
 } from '../types';
 import {
   isFetching,
@@ -168,6 +168,10 @@ export const filterBySource = keyword => (dispatch) => {
 
 export const filterByClass = keyword => (dispatch) => {
   dispatch({ type: FILTER_BY_CLASS, payload: keyword });
+};
+
+export const clearAllFilters = filterType => (dispatch) => {
+  dispatch({ type: CLEAR_FILTERS, payload: filterType });
 };
 
 export const queryAnswers = async (source, query, mapType = MAP_TYPE.questionAndAnswer) => {

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -27,6 +27,7 @@ export const CREATING_RELEASED_VERSION_FAILED = '[dictionary] creating a release
 
 export const FILTER_BY_SOURCES = '[concepts] filter concepts by sources';
 export const FILTER_BY_CLASS = '[concepts] filter concepts by class';
+export const CLEAR_FILTERS = '[concepts] clear filters';
 export const POPULATE_SIDEBAR = '[concepts] populate sidebar';
 export const CREATE_NEW_NAMES = '[concepts] create_new_name';
 export const REMOVE_ONE_NAME = '[concepts] remove_one_name';
@@ -62,6 +63,7 @@ export const CLEAR_SOURCE_CONCEPTS = '[concepts] clear source_concept_sources';
 export const FETCH_BULK_CONCEPTS = '[concept] fetch_bulk_concepts';
 export const ADD_EXISTING_BULK_CONCEPTS = '[concept] add_existing_bulk_concepts';
 export const ADD_TO_DATATYPE_LIST = '[concept] add_to_datatype_list';
+export const CLEAR_BULK_FILTERS = '[bulk concept] clear bulk filters';
 export const ADD_TO_CLASS_LIST = '[concept] add_to_class_list';
 export const FETCH_FILTERED_CONCEPTS = '[concept] fetch_filtered_concepts';
 export const PREVIEW_CONCEPT = '[concept] preview_concept';

--- a/src/redux/reducers/ConceptReducers.js
+++ b/src/redux/reducers/ConceptReducers.js
@@ -37,6 +37,7 @@ import {
   UNPOPULATE_PRE_POPULATED_SETS,
   REPLACE_CONCEPT,
   UNPOPULATE_SET,
+  CLEAR_FILTERS,
 } from '../actions/types';
 import {
   filterSources,
@@ -48,6 +49,7 @@ import {
   updatePopulatedAnswers,
   addDescription,
 } from './util';
+import { FILTER_TYPES } from '../../constants';
 
 const initialState = {
   concepts: [],
@@ -145,6 +147,12 @@ export default (state = initialState, action) => {
         classList: normalizeList(action.payload, [action.payload, ...state.classList]),
         filteredByClass: filterList(action.payload, state.classList),
       };
+    case CLEAR_FILTERS:
+      switch (action.payload) {
+        case FILTER_TYPES.SOURCES: return { ...state, filteredBySource: [], sourceList: [] };
+        case FILTER_TYPES.CLASSES: return { ...state, filteredByClass: [], classList: [] };
+        default: return state;
+      }
     case FETCH_DICTIONARY_CONCEPT:
       return {
         ...state,

--- a/src/redux/reducers/bulkConceptReducer.js
+++ b/src/redux/reducers/bulkConceptReducer.js
@@ -7,9 +7,11 @@ import {
   SET_PERVIOUS_PAGE,
   SET_NEXT_PAGE,
   SET_CURRENT_PAGE,
+  CLEAR_BULK_FILTERS,
 } from '../actions/types';
 import { normalizeList } from './util';
 import { classes as classList, DATA_TYPES as dataTypesList } from '../../components/dictionaryConcepts/components/helperFunction';
+import { FILTER_TYPES } from '../../constants';
 
 const userInitialState = {
   bulkConcepts: [],
@@ -65,6 +67,12 @@ const bulkConcepts = (state = userInitialState, action) => {
         ...state,
         classList: normalizeList(action.payload, [action.payload, ...state.classList]),
       };
+    case CLEAR_BULK_FILTERS:
+      switch (action.payload) {
+        case FILTER_TYPES.DATATYPE: return { ...state, datatypeList: [] };
+        case FILTER_TYPES.CLASSES: return { ...state, classList: [] };
+        default: return state;
+      }
     default:
       return state;
   }

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -129,3 +129,7 @@
 .react-async {
   width: 40%;
 }
+
+.btn-outline-secondary {
+  background-color: transparent;
+}

--- a/src/styles/dictionary_concepts.scss
+++ b/src/styles/dictionary_concepts.scss
@@ -54,6 +54,20 @@ body {
   box-shadow: 0 4px 15px 1px #00000012;
   font-size: medium;
   margin-bottom: 2rem;
+
+  .sidenav-button-wrapper {
+    padding: 12px;
+  }
+
+  .sidenav-header {
+    width: 100%;
+  }
+
+  .clear-filter-button {
+    padding: 1px 2px;
+    float: right;
+    font-size: 0.8rem;
+  }
 }
 
 .sidenav-container .sidenav-header {

--- a/src/tests/bulkConcepts/actions/bulkConcept.test.js
+++ b/src/tests/bulkConcepts/actions/bulkConcept.test.js
@@ -14,6 +14,7 @@ import {
   SET_CURRENT_PAGE,
   SET_NEXT_PAGE,
   SET_PERVIOUS_PAGE,
+  CLEAR_BULK_FILTERS,
 } from '../../../redux/actions/types';
 import {
   addToFilterList,
@@ -23,6 +24,7 @@ import {
   setCurrentPage,
   setNextPage,
   setPreviousPage, recursivelyFetchConceptMappings,
+  clearAllBulkFilters,
 } from '../../../redux/actions/concepts/addBulkConcepts';
 import concepts, { mockConceptStore } from '../../__mocks__/concepts';
 import mappings from '../../__mocks__/mappings';
@@ -370,6 +372,36 @@ describe('test suite for addBulkConcepts synchronous action creators', () => {
     expect(store.getActions()[0]).toEqual(expectedActions[0]);
     expect(store.getActions()[1]).toEqual(expectedActions[1]);
   });
+
+  describe('clearAllBulkFilters', () => {
+    beforeEach(() => {
+      moxios.install(instance);
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          response: {},
+        });
+      });
+    });
+
+    afterEach(() => {
+      moxios.uninstall(instance);
+    });
+
+    it('should dispatch CLEAR_BULK_FILTERS with the right filterType', async () => {
+      const filterType = 'classes';
+      const store = mockStore(mockConceptStore);
+      const expectedActions = [
+        { type: CLEAR_BULK_FILTERS, payload: filterType },
+        { payload: true, type: '[ui] toggle spinner' },
+      ];
+      await store.dispatch(clearAllBulkFilters(filterType));
+      expect(store.getActions()[0]).toEqual(expectedActions[0]);
+      expect(store.getActions()[1]).toEqual(expectedActions[1]);
+    });
+  });
+
   it('should handle PREVIEW_CONCEPT', async () => {
     const store = mockStore(mockConceptStore);
     const expectedActions = [{ type: PREVIEW_CONCEPT, payload: { id: 123 } }];

--- a/src/tests/bulkConcepts/components/Sidenav.test.jsx
+++ b/src/tests/bulkConcepts/components/Sidenav.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Sidenav from '../../../components/bulkConcepts/component/Sidenav';
+import { FILTER_TYPES } from '../../../constants';
+
+let props;
+
+describe('SideNav', () => {
+  beforeEach(() => {
+    props = {
+      classList: ['Diagnosis'],
+      datatypeList: ['Boolean'],
+      handleChange: jest.fn(),
+      toggleCheck: ['Diagnosis', 'CIEL'],
+      clearAllBulkFilters: jest.fn(),
+      datatypes: ['Boolean'],
+      classes: ['Diagnosis'],
+    };
+  });
+
+  it('should call clear all source filters when the clear source filters button is clicked', () => {
+    const sidenav = shallow(<Sidenav {...props} />);
+    sidenav.find('#clear-datatype-filters').simulate('click');
+    expect(props.clearAllBulkFilters).toHaveBeenCalledWith(FILTER_TYPES.DATATYPE);
+  });
+
+  it('should call clear all class filters when the clear class filters button is clicked', () => {
+    const sidenav = shallow(<Sidenav {...props} />);
+    sidenav.find('#clear-class-filters').simulate('click');
+    expect(props.clearAllBulkFilters).toHaveBeenCalledWith(FILTER_TYPES.CLASSES);
+  });
+});

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -316,4 +316,24 @@ describe('Test suite for BulkConceptsPage component', () => {
     expect(mapStateToProps(initialState).preview).toEqual([]);
     expect(mapStateToProps(initialState).loading).toEqual(false);
   });
+
+  describe('clearBulkFilters', () => {
+    it('should call clearAllBulkFilters', () => {
+      const newProps = {
+        ...props,
+        clearAllBulkFilters: jest.fn(),
+      };
+      const wrapper = mount(<Provider store={store}>
+        <Router>
+          <BulkConceptsPage {...newProps} />
+        </Router>
+      </Provider>);
+
+      const instance = wrapper.find('BulkConceptsPage').instance();
+
+      expect(newProps.clearAllBulkFilters).not.toHaveBeenCalled();
+      instance.clearBulkFilters();
+      expect(newProps.clearAllBulkFilters).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/tests/bulkConcepts/reducer/index.test.js
+++ b/src/tests/bulkConcepts/reducer/index.test.js
@@ -9,6 +9,7 @@ import {
   SET_CURRENT_PAGE,
   SET_NEXT_PAGE,
   SET_PERVIOUS_PAGE,
+  CLEAR_BULK_FILTERS,
 } from '../../../redux/actions/types';
 import concepts, { concept2, multipleConceptsMockStore } from '../../__mocks__/concepts';
 import { classes as classList, DATA_TYPES as dataTypesList } from '../../../components/dictionaryConcepts/components/helperFunction';
@@ -117,6 +118,53 @@ describe('Test suite for bulkConcepts reducer', () => {
     expect(reducer(state, action)).toEqual({
       ...state,
       classList: ['Diagnosis'],
+    });
+  });
+  describe('CLEAR_BULK_FILTERS', () => {
+    it('should handle CLEAR_BULK_FILTERS for classes', () => {
+      state = {
+        classList: [1, 2, 3],
+      };
+
+      action = {
+        type: CLEAR_BULK_FILTERS,
+        payload: 'classes',
+      };
+
+      expect(reducer(state, action)).toEqual({
+        ...state,
+        classList: [],
+      });
+    });
+
+    it('should handle CLEAR_BULK_FILTERS for datatype', () => {
+      state = {
+        datatypeList: [1, 2, 3],
+      };
+
+      action = {
+        type: CLEAR_BULK_FILTERS,
+        payload: 'datatype',
+      };
+
+      expect(reducer(state, action)).toEqual({
+        ...state,
+        datatypeList: [],
+      });
+    });
+
+    it('should return the same state if the filterType is unknown', () => {
+      state = {
+        sourceList: [1, 2, 3],
+        datatypeList: [1, 2, 3],
+      };
+
+      action = {
+        type: CLEAR_BULK_FILTERS,
+        payload: 'unknownType',
+      };
+
+      expect(reducer(state, action)).toEqual(state);
     });
   });
   it('should handle FETCH_FILTERED_CONCEPTS', () => {

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -41,6 +41,7 @@ import {
   PRE_POPULATE_SETS,
   UNPOPULATE_PRE_POPULATED_SETS,
   UNPOPULATE_SET,
+  CLEAR_FILTERS,
 } from '../../../redux/actions/types';
 import {
   fetchDictionaryConcepts,
@@ -80,6 +81,7 @@ import {
   unpopulateSet,
   buildNewMappingData,
   fetchConceptsFromASource, buildUpdateMappingData,
+  clearAllFilters,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import {
   removeDictionaryConcept,
@@ -931,6 +933,19 @@ describe('test for search filter by source', () => {
 
   store.dispatch(filterBySource('MapType', 'users', 'emasys', 'dev-col', 'source', ''));
   expect(store.getActions()).toEqual(expectedActions);
+});
+
+describe('clearAllFilters', () => {
+  it('should dispatch CLEAR_FILTERS with the right type', () => {
+    const store = mockStore(mockConceptStore);
+    const filterType = 'sources';
+    const expectedActions = [
+      { type: CLEAR_FILTERS, payload: filterType },
+    ];
+
+    store.dispatch(clearAllFilters(filterType));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
 });
 
 describe('test suite for synchronous action creators', () => {

--- a/src/tests/dictionaryConcepts/components/Sidenav.test.jsx
+++ b/src/tests/dictionaryConcepts/components/Sidenav.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Sidenav from '../../../components/dictionaryConcepts/components/Sidenav';
+import { FILTER_TYPES } from '../../../constants';
+
+let props;
+
+describe('SideNav', () => {
+  beforeEach(() => {
+    props = {
+      filteredClass: ['Diagnosis'],
+      filteredSources: ['CIEL'],
+      handleChange: jest.fn(),
+      toggleCheck: ['Diagnosis', 'CIEL'],
+      clearAllFilters: jest.fn(),
+    };
+  });
+
+  it('should call clear all source filters when the clear source filters button is clicked', () => {
+    const sidenav = shallow(<Sidenav {...props} />);
+    sidenav.find('#clear-source-filters').simulate('click');
+    expect(props.clearAllFilters).toHaveBeenCalledWith(FILTER_TYPES.SOURCES);
+  });
+
+  it('should call clear all class filters when the clear class filters button is clicked', () => {
+    const sidenav = shallow(<Sidenav {...props} />);
+    sidenav.find('#clear-class-filters').simulate('click');
+    expect(props.clearAllFilters).toHaveBeenCalledWith(FILTER_TYPES.CLASSES);
+  });
+});

--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -743,5 +743,30 @@ describe('Test suite for dictionary concepts components', () => {
         expect(result).toEqual(false);
       });
     });
+
+    describe('clearAllFilters', () => {
+      it('should call clearFilters and fetchConcepts', () => {
+        const newProps = {
+          ...props,
+          clearAllFilters: jest.fn(),
+        };
+        wrapper = mount(<Provider store={store}>
+          <Router>
+            <DictionaryConcepts {...newProps} />
+          </Router>
+        </Provider>);
+        const dictionaryConcepts = wrapper.find('DictionaryConcepts');
+        const instance = dictionaryConcepts.instance();
+        instance.fetchConcepts = jest.fn();
+
+        expect(instance.fetchConcepts).not.toHaveBeenCalled();
+        expect(newProps.clearAllFilters).not.toHaveBeenCalled();
+
+        instance.clearAllFilters();
+
+        expect(instance.fetchConcepts).toHaveBeenCalledTimes(1);
+        expect(newProps.clearAllFilters).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });

--- a/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
@@ -25,6 +25,7 @@ import {
   EDIT_CONCEPT_CREATE_NEW_NAMES,
   EDIT_CONCEPT_REMOVE_ONE_NAME,
   REMOVE_CONCEPT,
+  CLEAR_FILTERS,
 } from '../../../redux/actions/types';
 
 describe('Test suite for single dictionary concepts', () => {
@@ -132,6 +133,56 @@ describe('Test suite for single dictionary concepts', () => {
       ...state,
       classList: ['dev-col'],
       filteredByClass: ['dev-col'],
+    });
+  });
+
+  describe('CLEAR_FILTERS', () => {
+    it('should handle CLEAR_FILTERS for classes', () => {
+      state = {
+        classList: [1, 2, 3],
+      };
+
+      action = {
+        type: CLEAR_FILTERS,
+        payload: 'classes',
+      };
+
+      expect(reducer(state, action)).toEqual({
+        ...state,
+        classList: [],
+        filteredByClass: [],
+      });
+    });
+
+    it('should handle CLEAR_FILTERS for sources', () => {
+      state = {
+        sourceList: [1, 2, 3],
+      };
+
+      action = {
+        type: CLEAR_FILTERS,
+        payload: 'sources',
+      };
+
+      expect(reducer(state, action)).toEqual({
+        ...state,
+        sourceList: [],
+        filteredBySource: [],
+      });
+    });
+
+    it('should return the same state if the filterType is unknown', () => {
+      state = {
+        sourceList: [1, 2, 3],
+        classList: [1, 2, 3],
+      };
+
+      action = {
+        type: CLEAR_FILTERS,
+        payload: 'unknownType',
+      };
+
+      expect(reducer(state, action)).toEqual(state);
     });
   });
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[Add clear all buttons for filter options](https://issues.openmrs.org/browse/OCLOMRS-621)

# Summary:
I expected a “clear all” link for Datatypes and Classes (if I’ve checked 5-6 of them, don’t make me manually uncheck all of them to remove filters)
