### PR TITLE
OCLOMRS-623: Hide the 'Start by copying another dictionary' feature on the create dictionary page

### DIFF
--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 import ReactTooltip from 'react-tooltip';
 import {
   fetchingOrganizations,
-  searchDictionaries,
 } from '../../../../../redux/actions/dictionaries/dictionaryActionCreators';
 import InlineError from '../messages/InlineError';
 import languages from './Languages';
@@ -118,21 +117,6 @@ export class DictionaryModal extends React.Component {
      }
    }
    return supportedLocalesOptions;
- }
-
- searchInputValues = (val) => {
-   if (val.length > 0 && val[0] !== '*' && val[0] !== '.') {
-     this.props.searchDictionaries(val);
-   }
- }
-
- handleCopyDictionary = (item) => {
-   this.setState({
-     data: {
-       ...this.state.data,
-       conceptUrl: item.value,
-     },
-   });
  }
 
   validate = (data) => {
@@ -408,21 +392,6 @@ export class DictionaryModal extends React.Component {
                       value="OpenMRSDictionary"
                     />
                   </FormGroup>
-                  {!isEditingDictionary
-                  && (
-                  <FormGroup>
-                    {'Start by copying another dictionary'}
-                    <Select
-                      id="copy_dictionary"
-                      closeMenuOnSelect={false}
-                      options={[...this.props.userDictionaries, ...this.props.dictionaries]}
-                      onChange={val => this.handleCopyDictionary(val)}
-                      onInputChange={val => this.searchInputValues(val)}
-                      placeholder="Search public dictionaries"
-                    />
-                  </FormGroup>
-                  )
-                  }
                 </div>
               </div>
             </form>
@@ -464,9 +433,6 @@ DictionaryModal.propTypes = {
   modalhide: PropTypes.func.isRequired,
   defaultLocaleOption: PropTypes.object,
   isEditingDictionary: PropTypes.bool,
-  searchDictionaries: PropTypes.func.isRequired,
-  dictionaries: PropTypes.array.isRequired,
-  userDictionaries: PropTypes.array.isRequired,
 };
 
 DictionaryModal.defaultProps = {
@@ -481,14 +447,10 @@ DictionaryModal.defaultProps = {
 
 function mapStateToProps(state) {
   return {
-    dictionaries: state.dictionaries.dictionaries
-      .map(({ name, concepts_url }) => ({ label: name, value: concepts_url })),
-    userDictionaries: state.user.userDictionary
-      .map(({ name, concepts_url }) => ({ label: name, value: concepts_url })),
     organizations: state.organizations.organizations,
   };
 }
 export default connect(
   mapStateToProps,
-  { fetchingOrganizations, searchDictionaries },
+  { fetchingOrganizations },
 )(DictionaryModal);

--- a/src/tests/Dictionary/DictionaryModal.test.jsx
+++ b/src/tests/Dictionary/DictionaryModal.test.jsx
@@ -37,6 +37,16 @@ describe('Test suite for dictionary modal', () => {
     wrapper.unmount();
   });
 
+  it('should set focus on the name input when the form to create a new dictionary is rendered', () => {
+    wrapper = mount(<DictionaryModal {...props} />);
+    const instance = wrapper.instance();
+    const spy = jest.spyOn(instance, 'focusInput');
+    expect(instance.state.inputFocus).toBe(false);
+    instance.forceUpdate();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(instance.state.inputFocus).toBe(true);
+  });
+
   it('should take a snapshot', () => {
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.instance().componentDidMount());
@@ -237,23 +247,6 @@ describe('Test suite for dictionary modal', () => {
     expect(wrapper.instance().state.errors).toEqual({});
   });
 
-  it('it should handle search input values', () => {
-    props.isEditingDictionary = false;
-    wrapper = mount(<DictionaryModal {...props} />);
-    const spy = jest.spyOn(wrapper.find('DictionaryModal').instance(), 'searchInputValues');
-    wrapper.find('input#react-select-3-input').simulate('change');
-    expect(spy).toHaveBeenCalledTimes(1);
-    wrapper.instance().searchInputValues('dictionary');
-    expect(props.searchDictionaries).toBeCalled();
-  });
-
-  it('it should handle dictionary copying', () => {
-    const item = {
-      value: '123',
-    };
-    wrapper.find('#copy_dictionary').simulate('change', item);
-  });
-
   it('it should disable button if there is no error', () => {
     wrapper.setState({
       data: {
@@ -272,15 +265,5 @@ describe('Test suite for dictionary modal', () => {
     const submitButtonWrapper = wrapper.find('#addDictionary');
     submitButtonWrapper.simulate('click', preventDefault);
     expect(wrapper.state().disableButton).toBeTruthy();
-  });
-
-  it('should set focus on the name input when the form to create a new dictionary is rendered', () => {
-    wrapper = mount(<DictionaryModal {...props} />);
-    const instance = wrapper.instance();
-    const spy = jest.spyOn(instance, 'focusInput');
-    expect(instance.state.inputFocus).toBe(false);
-    instance.forceUpdate();
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(instance.state.inputFocus).toBe(true);
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Hide the 'Start by copying another dictionary' feature on the create dictionary page](https://issues.openmrs.org/browse/OCLOMRS-623)

# Summary:
Excerpt from user feedback:
Create Dictionary

there’s an option for “Start by copying another dictionary”, but it doesn’t work right. (I tried to copy a dictionary that has 13 concepts, and the resulting dictionary only has 10 concepts.) Please hide this feature for MVP release...

This ticket removes the feature that allowed one to start by copying from another dictionary in the mvp release.

A complimentary ticket to address this bug in MVP+ has been created here [OCLOMRS-624](https://issues.openmrs.org/browse/OCLOMRS-623)