### PR TITLE
OCLOMRS-626: The class breakdown shows incorrect class counts

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -8,6 +8,7 @@ import {
 } from '../../../../redux/actions/dictionaries/dictionaryActionCreators';
 import EditDictionary from './EditDictionary';
 import GeneralModel from './common/GeneralModal';
+import { DIAGNOSIS_CLASS, PROCEDURE_CLASS } from '../../../../constants';
 
 export class DictionaryOverview extends Component {
   static propTypes = {
@@ -188,14 +189,14 @@ export class DictionaryOverview extends Component {
       concept => concept.owner !== 'CIEL',
     ).length.toString();
     const diagnosisConcepts = this.props.dictionaryConcepts.filter(
-      concept => concept.concept_class === 'diagnosis',
+      concept => concept.concept_class === DIAGNOSIS_CLASS,
     ).length.toString();
     const procedureConcepts = this.props.dictionaryConcepts.filter(
-      concept => concept.concept_class === 'procedure',
+      concept => concept.concept_class === PROCEDURE_CLASS,
     ).length.toString();
     const otherConcepts = this.props.dictionaryConcepts.filter(
-      concept => concept.concept_class !== 'diagnosis'
-      && concept.concept_class !== 'procedure',
+      concept => concept.concept_class !== DIAGNOSIS_CLASS
+      && concept.concept_class !== PROCEDURE_CLASS,
     ).length.toString();
     const headVersion = this.props.versions.filter(version => version.id === 'HEAD')[0];
     const headVersionIdObj = Object.assign({}, headVersion);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,2 @@
+export const DIAGNOSIS_CLASS = 'Diagnosis';
+export const PROCEDURE_CLASS = 'Procedure';

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -104,6 +104,7 @@ import {
 import api from '../../../redux/api';
 import { externalSource, internalSource } from '../../__mocks__/sources';
 import mappings from '../../__mocks__/mappings';
+import { PROCEDURE_CLASS } from '../../../constants';
 
 jest.mock('uuid/v4', () => jest.fn(() => 1));
 jest.mock('react-notify-toast');
@@ -260,7 +261,7 @@ describe('Test suite for dictionary concept actions', () => {
     ];
 
     mockConceptStore.concepts.filteredBySource = [];
-    mockConceptStore.concepts.filteredByClass = ['procedure'];
+    mockConceptStore.concepts.filteredByClass = [PROCEDURE_CLASS];
     const store = mockStore(mockConceptStore);
 
     return store.dispatch(fetchDictionaryConcepts('orgs', 'CIEL', 'CIEL')).then(() => {
@@ -286,8 +287,8 @@ describe('Test suite for dictionary concept actions', () => {
     ];
 
     mockConceptStore.concepts.filteredBySource = ['CIEL'];
-    mockConceptStore.concepts.filteredByClass = ['procedure'];
-    const store = mockStore({ ...mockConceptStore, filteredByClass: ['procedure'] });
+    mockConceptStore.concepts.filteredByClass = [PROCEDURE_CLASS];
+    const store = mockStore({ ...mockConceptStore, filteredByClass: [PROCEDURE_CLASS] });
 
     return store.dispatch(fetchDictionaryConcepts('orgs', 'CIEL', 'CIEL')).then(() => {
       expect(store.getActions()).toEqual(expectedActions);


### PR DESCRIPTION
# JIRA TICKET NAME:
[The class breakdown shows incorrect class counts](https://issues.openmrs.org/browse/OCLOMRS-626)

# Summary:
The “By class” breakdown isn’t working right. It shows “Diagnosis: 0” when I have a lot of diagnoses