### PR TITLE
OCLOMRS-625: Remove the PIH option from Create Dictionary page

### DIFF
--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -298,7 +298,6 @@ export class DictionaryModal extends React.Component {
                       value={data.preferred_source}
                     >
                       <option value="CIEL">CIEL (default source)</option>
-                      <option value="PIH">PIH</option>
                       {
                         isEditingDictionary
                         && (


### PR DESCRIPTION
# JIRA TICKET NAME:
[ Remove the PIH option from Create Dictionary page](https://issues.openmrs.org/browse/OCLOMRS-625)

# Summary:
Excerpt from user feedback:
Create Dictionary

gives two options for Preferred Source (CIEL, PIH) but I think the application only really supports CIEL, right? So, remove the PIH option.
