### PR TITLE
OCLOMRS-644: When adding CIEL concepts, Turn off sorting on table

### DIFF
--- a/src/components/bulkConcepts/component/ConceptTable.jsx
+++ b/src/components/bulkConcepts/component/ConceptTable.jsx
@@ -29,6 +29,7 @@ const ConceptTable = ({
         noDataText="No concepts found!"
         minRows={2}
         limitCount={conceptLimit}
+        sortable={false}
         columns={[
           {
             Header: 'Name',


### PR DESCRIPTION
# JIRA TICKET NAME:
[When adding CIEL concepts, Turn off sorting on table](https://issues.openmrs.org/browse/OCLOMRS-644)

# Summary:
Excerpt from feedback:
Since sorting does not perform a global sort, but rather for only a single page, this is confusing for a user hence it needs to turned off for now

This ticket disables sorting on a single page. It will be implemented in the backend and consumed in MVP+. The complimentary ticket has been created here [OCLOMRS-644](https://issues.openmrs.org/browse/OCLOMRS-644)