### PR TITLE
OCLOMRS-647: Searching or filtering on the dictionary concepts page should set the page back to page 1

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -26,6 +26,8 @@ const ConceptTable = ({
   handleDeleteMapping,
   retireConcept,
   isOwner,
+  page,
+  onPageChange,
 }) => (
   <div className="row col-12 custom-concept-list">
     <RemoveConcept
@@ -45,6 +47,8 @@ const ConceptTable = ({
       defaultPageSize={conceptLimit}
       noDataText="No concepts found!"
       minRows={2}
+      page={page}
+      onPageChange={onPageChange}
       columns={[
         {
           Header: 'Name',
@@ -106,6 +110,8 @@ ConceptTable.propTypes = {
   showDeleteMappingModal: PropTypes.func.isRequired,
   retireConcept: PropTypes.func,
   isOwner: PropTypes.bool,
+  page: PropTypes.number.isRequired,
+  onPageChange: PropTypes.func.isRequired,
 };
 ConceptTable.defaultProps = {
   openDeleteModal: false,

--- a/src/components/dictionaryConcepts/components/Sidenav.jsx
+++ b/src/components/dictionaryConcepts/components/Sidenav.jsx
@@ -40,7 +40,7 @@ const Sidenav = ({
           key={classItem}
           filterType="classes"
           handleChange={handleChange}
-          checkValue={toggleCheck.includes(`"${classItem}"`)}
+          checkValue={toggleCheck.includes(`${classItem}`)}
         />
       ))}
     </div>

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -70,6 +70,7 @@ export class DictionaryConcepts extends Component {
       },
       openDeleteModal: false,
       isOwner: false,
+      page: 0,
     };
     autoBind(this);
   }
@@ -95,6 +96,15 @@ export class DictionaryConcepts extends Component {
       typeName,
     });
   }
+
+  componentDidUpdate = (prevProps) => {
+    const { concepts } = this.props;
+    if (prevProps.concepts !== concepts) {
+      this.setState({
+        page: 0,
+      });
+    }
+  };
 
   fetchConcepts(limit = 0) {
     const {
@@ -130,7 +140,7 @@ export class DictionaryConcepts extends Component {
     }
     if (type === 'checkbox' && filterType === 'classes') {
       this.props.filterByClass(
-        `"${inputName}"`,
+        inputName,
         this.state.type,
         typeName,
         collectionName,
@@ -249,6 +259,12 @@ export class DictionaryConcepts extends Component {
     return true;
   };
 
+  setPage = (index) => {
+    this.setState({
+      page: index,
+    });
+  };
+
   render() {
     const {
       match: {
@@ -265,6 +281,8 @@ export class DictionaryConcepts extends Component {
       filteredByClass,
       filteredBySource,
     } = this.props;
+
+    const { page } = this.state;
 
     const myConcepts = this.handleConcepts(concepts);
     const hasPermission = typeName === getUsername() || userIsMember;
@@ -327,6 +345,8 @@ export class DictionaryConcepts extends Component {
               closeDeleteModal={this.closeDeleteModal}
               retireConcept={this.handleRetireConcept}
               isOwner={this.state.isOwner}
+              page={page}
+              onPageChange={this.setPage}
             />
           </div>
         </section>

--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -71,6 +71,66 @@ describe('Test suite for dictionary concepts components', () => {
     jest.runAllTimers();
 
     expect(wrapper).toMatchSnapshot();
+    wrapper.unmount();
+  });
+
+
+  it('should update the current page in the component state', () => {
+    const props = {
+      match: {
+        params: {
+          typeName: 'dev-col',
+          type: 'orgs',
+          collectionName: 'dev-col',
+          dictionaryName: 'dev-col',
+        },
+      },
+      location: {
+        pathname: '/random/path',
+      },
+      fetchDictionaryConcepts: jest.fn(),
+      concepts: [],
+      filteredClass: ['Diagnosis'],
+      filteredSources: ['CIEL'],
+      loading: false,
+      conceptsCount: 1,
+      totalConceptsCount: 1,
+      filterBySource: jest.fn(),
+      filterByClass: jest.fn(),
+      fetchMemberStatus: jest.fn(),
+      paginateConcepts: jest.fn(),
+      totalConceptCount: 20,
+      userIsMember: true,
+      removeDictionaryConcept: jest.fn(),
+      removeConceptMappingAction: jest.fn(),
+      searchByName: jest.fn(),
+      ...retireMockProps,
+    };
+    const newProps = {
+      ...props,
+      concepts: [{
+        id: '1', concept_class: 'MedSet', version_url: '/url', url: 'url', display_name: '1',
+      }, {
+        id: '3', concept_class: 'MedSet', version_url: '/url', url: 'url', display_name: '1',
+      }],
+    };
+    const wrapper = mount(<Provider store={store}>
+      <Router>
+        <DictionaryConcepts {...props} />
+      </Router>
+    </Provider>);
+    const instance = wrapper.find('DictionaryConcepts').instance();
+    expect(instance.state.page).toEqual(0);
+    instance.setPage(1);
+    expect(instance.state.page).toEqual(1);
+    wrapper.setProps({
+      children: <Router>
+        <DictionaryConcepts {...newProps} />
+      </Router>,
+    });
+    instance.forceUpdate();
+    expect(instance.state.page).toEqual(0);
+    wrapper.unmount();
   });
 
   it('should contain strikethrough text for retired concepts', () => {
@@ -85,6 +145,8 @@ describe('Test suite for dictionary concepts components', () => {
       closeDeleteModal: jest.fn(),
       handleDeleteMapping: jest.fn(),
       showDeleteMappingModal: jest.fn(),
+      page: 0,
+      onPageChange: jest.fn(),
     };
     const wrapper = mount(<ConceptTable {...props} />);
     expect(wrapper).toMatchSnapshot();
@@ -105,6 +167,8 @@ describe('Test suite for dictionary concepts components', () => {
         closeDeleteModal: jest.fn(),
         handleDeleteMapping: jest.fn(),
         showDeleteMappingModal: jest.fn(),
+        page: 0,
+        onPageChange: jest.fn(),
       };
 
       localStorage.setItem('username', props.concepts[0].owner);
@@ -124,11 +188,34 @@ describe('Test suite for dictionary concepts components', () => {
         closeDeleteModal: jest.fn(),
         handleDeleteMapping: jest.fn(),
         showDeleteMappingModal: jest.fn(),
+        page: 0,
+        onPageChange: jest.fn(),
       };
 
       localStorage.setItem('username', 'notTheOwner');
       const wrapper = mount(<Router><ConceptTable {...props} /></Router>);
       expect(wrapper.find('#retire')).toHaveLength(0);
+    });
+
+    it('should handle change in pages when the \'next \' button is clicked', () => {
+      const props = {
+        concepts: [{ ...concepts, id: '1' }, { ...concepts, id: '2' }, { ...concepts, id: '3' }],
+        loading: false,
+        org: {},
+        locationPath: {},
+        showDeleteModal: jest.fn(),
+        handleDelete: jest.fn(),
+        conceptLimit: 1,
+        closeDeleteModal: jest.fn(),
+        handleDeleteMapping: jest.fn(),
+        showDeleteMappingModal: jest.fn(),
+        page: 0,
+        onPageChange: jest.fn(),
+      };
+
+      const wrapper = mount(<Router><ConceptTable {...props} /></Router>);
+      wrapper.find('button').at(2).simulate('click');
+      expect(props.onPageChange).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION

# JIRA TICKET NAME:
[Searching or filtering on the dictionary concepts page should set the page back to page 1](https://issues.openmrs.org/browse/OCLOMRS-647)

# Summary:
The current functionality fetches whatever page the user was already on. This is a problem because the user may not realize the best match to their search was on a previous page
