### PR TITLE
OCLOMRS-628: Name types should be; Fully Specified, null: Synonym in UI, SHORT: Short in UI, Index Term

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -74,7 +74,7 @@ class ConceptNameRows extends Component {
       name: newRow.name || '',
       locale: newRow.locale || defaultLocale.value,
       locale_full: defaultLocale,
-      name_type: newRow.name_type || 'Fully Specified',
+      name_type: newRow.name_type,
       locale_preferred: !!newRow.locale_preferred,
       external_id: newRow.external_id || uuid(),
     });
@@ -89,6 +89,7 @@ class ConceptNameRows extends Component {
     } = event;
 
     if (name === 'locale_preferred') value = value === 'Yes';
+    else if (name === 'name_type') value = value === 'null' ? null : value;
 
     this.setState(() => ({ [name]: value }));
     this.sendToTopComponent();
@@ -136,15 +137,16 @@ class ConceptNameRows extends Component {
           <select
             id="type"
             name="name_type"
-            value={this.state.name_type}
+            value={this.state.name_type === null ? 'null' : this.state.name_type}
             className="form-control"
             onChange={this.handleChange}
             required
           >
             <option />
-            <option>Fully Specified</option>
-            <option>Synonym</option>
-            <option>Search Term</option>
+            <option value="Fully Specified">Fully Specified</option>
+            <option value="null">Synonym</option>
+            <option value="Short">Short</option>
+            <option value="Index Term">Index Term</option>
           </select>
         </td>
         <th scope="row" className="concept-language">

--- a/src/tests/dictionaryConcepts/components/ConceptNameRows.test.jsx
+++ b/src/tests/dictionaryConcepts/components/ConceptNameRows.test.jsx
@@ -135,7 +135,7 @@ describe('Test suite for ConceptNameRows ', () => {
     expect(instance.state.locale_full).toEqual(selectedOptions);
   });
 
-  it('should update state and call sendToTopComponent when the name type is updated', () => {
+  it('should update state and call sendToTopComponent when the locale_preferred is updated', () => {
     const newProps = {
       ...props,
       newRow: {
@@ -159,6 +159,34 @@ describe('Test suite for ConceptNameRows ', () => {
 
     instance.handleChange({ target: { name: 'locale_preferred', value: 'No' } });
     expect(instance.state.locale_preferred).toEqual(false);
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should update the name_type in state with null when a synonym is selected and the selected value otherwise', () => {
+    const newProps = {
+      ...props,
+      newRow: {
+        id: '5',
+        name: 'testing',
+        locale_full: { value: 'en', label: 'English [en]' },
+        name_type: 'test',
+      },
+      locale: ['fr', 'sw'],
+      existingConcept: {
+        id: 9,
+      },
+    };
+    wrapper = mount(<table><tbody><ConceptNameRows {...newProps} /></tbody></table>);
+    const instance = wrapper.find('ConceptNameRows').instance();
+    const spy = jest.spyOn(instance, 'sendToTopComponent');
+
+    expect(spy).not.toHaveBeenCalled();
+    instance.handleChange({ target: { name: 'name_type', value: 'null' } });
+    expect(instance.state.name_type).toEqual(null);
+
+    instance.handleChange({ target: { name: 'name_type', value: 'Fully Specified' } });
+    expect(instance.state.name_type).toEqual('Fully Specified');
 
     expect(spy).toHaveBeenCalled();
   });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Name types should be; Fully Specified, null: Synonym in UI, SHORT: Short in UI, Index Term](https://issues.openmrs.org/browse/OCLOMRS-628)

# Summary:
 I try to create a concept with two names in English, the first one has type=Fully Specified, the second has type=Synonym. I get “An error occurred when creating a concept. Invalid name type” for the one that’s a synonym. (Possibly OpenMRS calls this “synonym” but OCL backend calls this nametype=null.)