### PR TITLE
OCLOMRS-638: Fallback to English as default locale when creating names and descriptions

### DIFF
--- a/src/components/dashboard/components/dictionary/common/Languages.js
+++ b/src/components/dashboard/components/dictionary/common/Languages.js
@@ -185,4 +185,8 @@ const locale = [
   { value: 'zu', label: 'Zulu [zu]' },
 ];
 
+export const findLocale = (localeCode, fallback = 'en') => locale.find(
+  currentLocale => currentLocale.value === localeCode,
+) || locale.find(currentLocale => currentLocale.value === fallback);
+
 export default locale;

--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import autoBind from 'react-autobind';
 import Select from 'react-select';
 import PropTypes from 'prop-types';
-import locale from '../../dashboard/components/dictionary/common/Languages';
+import locale, { findLocale } from '../../dashboard/components/dictionary/common/Languages';
 
 class ConceptNameRows extends Component {
   static propTypes = {
@@ -36,9 +36,7 @@ class ConceptNameRows extends Component {
 
   constructor(props) {
     super(props);
-    const defaultLocale = locale.find(
-      currentLocale => currentLocale.value === props.pathName.language,
-    );
+    const defaultLocale = findLocale(props.pathName.language);
     const { rowId } = this.props;
     this.state = {
       id: rowId,
@@ -65,14 +63,12 @@ class ConceptNameRows extends Component {
 
   updateState() {
     const { newRow } = this.props;
-    const defaultLocale = locale.find(
-      currentLocale => currentLocale.value === newRow.locale,
-    ) || locale[0];
+    const defaultLocale = findLocale(newRow.locale);
     this.setState({
       ...this.state,
       uuid: newRow.uuid || '',
       name: newRow.name || '',
-      locale: newRow.locale || defaultLocale.value,
+      locale: defaultLocale.value,
       locale_full: defaultLocale,
       name_type: newRow.name_type,
       locale_preferred: !!newRow.locale_preferred,

--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import Select from 'react-select';
 import autoBind from 'react-autobind';
 import PropTypes from 'prop-types';
-import locale from '../../dashboard/components/dictionary/common/Languages';
+import locale, { findLocale } from '../../dashboard/components/dictionary/common/Languages';
 
 class DescriptionRow extends Component {
   static propTypes = {
@@ -32,9 +32,7 @@ class DescriptionRow extends Component {
 
   constructor(props) {
     super(props);
-    const defaultLocale = locale.find(
-      currentLocale => currentLocale.value === props.pathName.language,
-    );
+    const defaultLocale = findLocale(props.pathName.language);
     const { rowId } = this.props;
     this.state = {
       id: rowId,
@@ -59,13 +57,11 @@ class DescriptionRow extends Component {
 
   updateState() {
     const { newRow } = this.props;
-    const defaultLocale = locale.find(
-      currentLocale => currentLocale.value === newRow.locale,
-    );
+    const defaultLocale = findLocale(newRow.locale, 'en');
     this.setState({
       ...this.state,
       uuid: newRow.uuid,
-      locale: newRow.locale || 'en',
+      locale: defaultLocale.value,
       locale_full: defaultLocale,
       description: newRow.description,
       external_id: newRow.external_id || uuid(),


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fallback to English as default locale when creating names and descriptions](https://issues.openmrs.org/browse/OCLOMRS-638)

# Summary:
In situations when we cannot find the locale we need from the default list, we should fall back to english