### PR TITLE
OCLOMRS-650: Populate sidenav not dispatched on the dictionary Concepts page

### DIFF
--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -122,7 +122,7 @@ export const fetchDictionaryConcepts = (
   conceptType = 'users',
   conceptOwner = 'emasys',
   conceptName = 'dev-col',
-  query = '',
+  query = '*',
   limit = 0,
   page = 1,
 ) => async (dispatch, getState) => {
@@ -150,7 +150,7 @@ export const fetchDictionaryConcepts = (
     );
     dispatch(getDictionaryConcepts(concepts, FETCH_DICTIONARY_CONCEPT));
     dispatch(paginateConcepts(concepts));
-    if (query === '' && filterByClass.length === 0 && filterBySource.length === 0) {
+    if (query === '*' && filterByClass.length === 0 && filterBySource.length === 0) {
       dispatch(populateSidenav());
     }
   } catch (error) {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Populate sidenav not dispatched on the dictionary Concepts page](https://issues.openmrs.org/browse/OCLOMRS-650)

# Summary:
The condition for dispatching this action checks for an empty query string. This string is now a wildcard.

This updates the condition and default query to reflect this.