### PR TITLE
OCLOMRS-649: The preffered language on a collection shows English even after it is changed to another language

### DIFF
--- a/src/components/dashboard/components/dictionary/EditDictionary.jsx
+++ b/src/components/dashboard/components/dictionary/EditDictionary.jsx
@@ -16,28 +16,6 @@ export class EditDictionary extends React.Component {
     };
   }
 
-  componentDidMount() {
-    this.preSelectDefaultLocale();
-  }
-
-  preSelectDefaultLocale = () => {
-    const { dictionary } = this.props;
-    for (let i = 0; i < languages.length; i += 1) {
-      if (languages[i].value === dictionary.default_locale) {
-        const option = (
-          <option value={languages[i].value} selected>
-            {languages[i].label}
-          </option>
-        );
-        this.setState({
-          ...this.state,
-          defaultLocaleOption: option,
-        });
-      }
-    }
-    return null;
-  }
-
   submit = (data) => {
     const {
       dictionary: {

--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -373,7 +373,7 @@ export class DictionaryModal extends React.Component {
                       id="default_locale"
                       placeholder="English"
                       onChange={this.onChange}
-                      value={this.props.defaultLocaleOption}
+                      value={data.default_locale}
                     >
                       {languages
                       && languages.map(language => (


### PR DESCRIPTION
# JIRA TICKET NAME:
[The preffered language on a collection shows English even after it is changed to another language](https://issues.openmrs.org/browse/OCLOMRS-649)

# Summary:
The preffered language on a collection shows English even after it is changed to another language.

This field uses an incorrect value, which does not exist. Updating this to the value in state.