### PR TITLE
OCLOMRS-651: Searching for public dictionaries returns dictionaries with validation that is not OpenMRS

### DIFF
--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -88,7 +88,8 @@ export const searchDictionaries = searchItem => async (dispatch) => {
   try {
     const payload = await api.dictionaries
       .searchDictionaries(searchItem);
-    dispatch(isSuccess(payload));
+    const result = filterPayload(payload);
+    dispatch(isSuccess(result));
     dispatch(isFetching(false));
   }
   catch (error) {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Searching for public dictionaries returns dictionaries with validation that is not OpenMRS](https://issues.openmrs.org/browse/OCLOMRS-651)

# Summary:
From [OCLOMRS-87](https://issues.openmrs.org/browse/OCLOMRS-87), the public dictionaries page is expected to display only OpenMRS validated dictionaries