### PR TITLE
OCLOMRS-654: A user should be able to view and manage collections belonging to organisations they are part of- 1

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -42,9 +42,9 @@ const DictionaryDetailCard = (props) => {
     versionId,
     inputLength,
     download,
+    userCanEditDictionary,
   } = props;
 
-  const username = localStorage.getItem('username');
 
   const DATE_OPTIONS = {
     weekday: 'long',
@@ -124,7 +124,7 @@ Dictionary
               {' '}
               {new Date(updated_on).toLocaleDateString('en-US', DATE_OPTIONS)}
             </p>
-            {owner === username && (
+            {userCanEditDictionary && (
               <button
                 type="button"
                 className="btn btn-primary m-3"
@@ -196,7 +196,7 @@ Dictionary
 Browse in traditional OCL
                 </a>
               </li>
-              { owner === username
+              { userCanEditDictionary
                 ? (
                   <li>
                     <a
@@ -289,6 +289,11 @@ DictionaryDetailCard.propTypes = {
   versionDescription: PropTypes.string.isRequired,
   versionId: PropTypes.string.isRequired,
   disableButton: PropTypes.bool.isRequired,
+  userCanEditDictionary: PropTypes.bool,
+};
+
+DictionaryDetailCard.defaultProps = {
+  userCanEditDictionary: false,
 };
 
 export default DictionaryDetailCard;

--- a/src/components/userDasboard/container/UserDashboard.jsx
+++ b/src/components/userDasboard/container/UserDashboard.jsx
@@ -129,7 +129,7 @@ New Dictionary
 
 export const mapStateToProps = state => ({
   user: state.user.user,
-  userDictionary: state.user.userDictionary,
+  userDictionary: state.user.userDictionary.concat(state.organizations.dictionariesOwnedByUsersOrg),
   userOrganization: state.user.userOrganization,
   loading: state.user.loading,
   networkError: state.user.networkError,

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,3 +6,5 @@ export const FILTER_TYPES = {
   CLASSES: 'classes',
   SOURCES: 'sources',
 };
+
+export const ORGANIZATIONS = 'orgs';

--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -1,0 +1,1 @@
+export const getLoggedInUsername = () => localStorage.getItem('username');

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -82,3 +82,5 @@ export const SET_CURRENT_PAGE = '[page] current_page';
 export const IS_LOADING = '[ui] loader_spinning';
 export const UN_POPULATE_THIS_ANSWER = '[concept] unpopulate an answer';
 export const UNPOPULATE_SET = '[concept] unpopulate a set';
+
+export const SET_DICTIONARIES_OWNED_BY_A_USERS_ORGS = '[dictionaries] set dictionaries owned by a user\'s orgs';

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -2,6 +2,9 @@ import instance from '../config/axiosConfig';
 
 export default {
   dictionaries: {
+    list: {
+      fromAnOrganization: organizationUrl => instance.get(`${organizationUrl}collections/?limit=0&verbose=true`),
+    },
     createDictionary: data => instance
       .post(`orgs/${data.owner}/collections/`, data)
     /* eslint-disable */

--- a/src/redux/reducers/dictionaryReducer.js
+++ b/src/redux/reducers/dictionaryReducer.js
@@ -1,11 +1,21 @@
-import { FETCHING_ORGANIZATIONS } from '../actions/types';
+import { FETCHING_ORGANIZATIONS, SET_DICTIONARIES_OWNED_BY_A_USERS_ORGS } from '../actions/types';
 
-export default (state = {}, action) => {
+export const defaultState = {
+  organizations: [],
+  dictionariesOwnedByUsersOrg: [],
+};
+
+export default (state = defaultState, action) => {
   switch (action.type) {
     case FETCHING_ORGANIZATIONS:
       return {
         ...state,
         organizations: action.payload,
+      };
+    case SET_DICTIONARIES_OWNED_BY_A_USERS_ORGS:
+      return {
+        ...state,
+        dictionariesOwnedByUsersOrg: action.payload,
       };
     default:
       return state;

--- a/src/redux/reducers/store.js
+++ b/src/redux/reducers/store.js
@@ -4,7 +4,7 @@ import reduxThunk from 'redux-thunk';
 import logger from 'redux-logger';
 import rootReducer from './index';
 
-export const STORE_VERSION = '2';
+export const STORE_VERSION = '3';
 export const CURRENT_STORE_VERSION_KEY = 'currentStoreVersion';
 
 const saveState = (state) => {

--- a/src/tests/Dashboard/action/api.test.js
+++ b/src/tests/Dashboard/action/api.test.js
@@ -54,6 +54,28 @@ describe('Test suite for dictionary actions', () => {
     moxios.uninstall(instance);
   });
 
+  describe('list', () => {
+    describe('fromAnOrganization', () => {
+      it('should call the correct endpoint', async () => {
+        let url;
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent();
+          url = request.url;
+          request.respondWith({
+            status: 200,
+            response: {
+              data: [],
+            }
+          });
+        });
+
+        const orgUrl = '/test/url/';
+        await api.dictionaries.list.fromAnOrganization(orgUrl);
+        expect(url).toContain(`${orgUrl}collections/?limit=0&verbose=true`);
+      });
+    });
+  });
+
   it('should dispatch ADD_DICTIONARY for organization', () => {
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();

--- a/src/tests/Dashboard/reducer/dictionaryReducers.test.js
+++ b/src/tests/Dashboard/reducer/dictionaryReducers.test.js
@@ -1,4 +1,4 @@
-import reducer from '../../../redux/reducers/dictionaryReducer';
+import reducer, { defaultState as initialState } from '../../../redux/reducers/dictionaryReducer';
 import dictionaryreducer from '../../../redux/reducers/dictionaryReducers';
 import userReducer from '../../../redux/reducers/user/index';
 import {
@@ -16,7 +16,6 @@ import {
 import dictionaries from '../../__mocks__/dictionaries';
 import versions from '../../__mocks__/versions';
 
-const initialState = {};
 describe('Test suite for vote reducer', () => {
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual(initialState);

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -11,6 +11,7 @@ import {
 import dictionary from '../__mocks__/dictionaries';
 import versions, { customVersion, HeadVersion } from '../__mocks__/versions';
 import concepts, { conceptWithoutDescriptions } from '../__mocks__/concepts';
+import { ORGANIZATIONS } from '../../constants';
 
 const store = createMockStore({
   organizations: {
@@ -29,8 +30,42 @@ const store = createMockStore({
 
 jest.mock('../../components/dashboard/components/dictionary/AddDictionary');
 describe('DictionaryOverview', () => {
+  const defaultProps = {
+    dictionary,
+    versions: [],
+    match: {},
+    dictionaryConcepts: [],
+    fetchDictionary: jest.fn(),
+    loader: false,
+    fetchVersions: jest.fn(),
+    fetchDictionaryConcepts: jest.fn(),
+    createVersion: jest.fn(() => Promise.resolve(true)),
+    error: [],
+    releaseHead: jest.fn(),
+    isReleased: false,
+  };
+
   beforeEach(() => {
     window.URL.createObjectURL = sinon.stub().returns('/url');
+  });
+
+  it('should dispatch the fetchMemberShipStatus if the ownerType is an organization', () => {
+    const props = {
+      ...defaultProps,
+      dictionary: { ...defaultProps.dictionary, ownerType: ORGANIZATIONS },
+      fetchMemberStatus: jest.fn(),
+      match: {
+        params: {
+          ownerType: ORGANIZATIONS,
+          owner: defaultProps.dictionary.owner,
+          type: defaultProps.dictionary.type,
+          name: defaultProps.dictionary.name,
+        },
+      },
+    };
+    expect(props.fetchMemberStatus).not.toHaveBeenCalled();
+    shallow(<DictionaryOverview {...props} />);
+    expect(props.fetchMemberStatus).toHaveBeenCalled();
   });
 
   it('should render without any data', () => {
@@ -130,7 +165,7 @@ describe('DictionaryOverview', () => {
       match: {
         params: {
           ownerType: 'testing',
-          owner: 'tester',
+          owner: dictionary.owner,
           type: 'collection',
           name: 'chris',
         },
@@ -373,7 +408,7 @@ describe('DictionaryOverview', () => {
       match: {
         params: {
           ownerType: 'users',
-          owner: 'nesh',
+          owner: dictionary.owner,
           type: 'collection',
           name: 'test',
         },
@@ -416,7 +451,7 @@ describe('DictionaryOverview', () => {
       match: {
         params: {
           ownerType: 'users',
-          owner: 'nesh',
+          owner: dictionary.owner,
           type: 'collection',
           name: 'test',
         },
@@ -462,7 +497,7 @@ describe('DictionaryOverview', () => {
       match: {
         params: {
           ownerType: 'users',
-          owner: 'nesh',
+          owner: dictionary.owner,
           type: 'collection',
           name: 'test',
         },
@@ -508,7 +543,7 @@ describe('DictionaryOverview', () => {
       match: {
         params: {
           ownerType: 'users',
-          owner: 'nesh',
+          owner: dictionary.owner,
           type: 'collection',
           name: 'test',
         },
@@ -601,6 +636,8 @@ describe('DictionaryOverview', () => {
       error: [],
       isReleased: true,
     };
+    localStorage.setItem('username', props.match.params.owner);
+
     const wrapper = mount(<Provider store={store}>
       <MemoryRouter>
         <DictionaryOverview {...props} />
@@ -662,6 +699,7 @@ describe('DictionaryOverview', () => {
       dictionaries: {
         dictionary,
       },
+      user: { userIsMember: false },
     };
     expect(mapStateToProps(initialState).dictionaryConcepts).toEqual([]);
   });

--- a/src/tests/Dictionary/dictionaryReducer.test.js
+++ b/src/tests/Dictionary/dictionaryReducer.test.js
@@ -1,0 +1,18 @@
+import { SET_DICTIONARIES_OWNED_BY_A_USERS_ORGS } from '../../redux/actions/types';
+import dictionaryReducer from '../../redux/reducers/dictionaryReducer';
+import { setDictionariesOwnedByAUsersOrgs } from '../../redux/actions/user';
+import dictionary from '../__mocks__/dictionaries';
+
+describe('dictionaryReducer', () => {
+  describe(SET_DICTIONARIES_OWNED_BY_A_USERS_ORGS, () => {
+    it('should set the dictionaries to dictionariesOwnedByUsersOrg', () => {
+      const expectedDictionaries = [
+        dictionary,
+      ];
+      expect(dictionaryReducer(
+        undefined,
+        setDictionariesOwnedByAUsersOrgs(expectedDictionaries),
+      ).dictionariesOwnedByUsersOrg).toEqual(expectedDictionaries);
+    });
+  });
+});

--- a/src/tests/userDashboard/container/UserDashboard.test.jsx
+++ b/src/tests/userDashboard/container/UserDashboard.test.jsx
@@ -8,11 +8,10 @@ import dictionary, { mockDictionaries } from '../../__mocks__/dictionaries';
 import UserDashboard, {
   mapStateToProps,
 } from '../../../components/userDasboard/container/UserDashboard';
+import { defaultState as organizationsDefaultState } from '../../../redux/reducers/dictionaryReducer';
 
 const storeObject = {
-  organizations: {
-    organizations: [],
-  },
+  organizations: organizationsDefaultState,
   sources: {
     sources: [],
   },
@@ -257,6 +256,7 @@ describe('Test suite for dictionary concepts components', () => {
           public_collections: 0,
         },
       },
+      organizations: organizationsDefaultState,
     };
     expect(mapStateToProps(initialState).user).toEqual({
       name: '',


### PR DESCRIPTION
# JIRA TICKET NAME:
[A user should be able to view and manage collections belonging to organizations they are part of- 1](https://issues.openmrs.org/browse/OCLOMRS-654)

# Summary:
- The view dictionaries page does not display dictionaries belonging to a user's organizations.
- The check for whether or not to display the edit button is coded to show up only when a logged in user created a collection. This also needs to show up if they are a part of the organization that created the collection.