### PR TITLE
OCLOMRS-666: Searching or filtering on the add CIEL concepts pages should set the page back to page 1

### DIFF
--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -90,25 +90,38 @@ export class BulkConceptsPage extends Component {
     return null;
   }
 
+  returnToFirstPageAndSearch = () => {
+    const { searchingOn } = this.state;
+    const { currentPage, setCurrentPage: setPage } = this.props;
+
+    if (currentPage === 1) {
+      if (searchingOn) return this.searchOption();
+      return this.getBulkConcepts();
+    }
+    // search is triggered in componentDidUpdate
+    return setPage(1);
+  };
+
   handleFilter = (event) => {
     const {
       target: { name },
     } = event;
     const targetName = name.split(',');
-    const query = `q=${this.state.searchInput}`;
     this.setState({ searchingOn: true });
-    const { currentPage } = this.props;
     if ((targetName[1]).trim() === 'datatype') {
-      this.props.addToFilterList(targetName[0], 'datatype', query, currentPage);
+      this.props.addToFilterList(targetName[0], 'datatype');
     } else {
-      this.props.addToFilterList(targetName[0], 'classes', query, currentPage);
+      this.props.addToFilterList(targetName[0], 'classes');
     }
+
+    this.returnToFirstPageAndSearch();
   };
 
   clearBulkFilters = (filterType) => {
-    const { clearAllBulkFilters: clearFilters, currentPage } = this.props;
-    const query = `q=${this.state.searchInput}`;
-    clearFilters(filterType, query, currentPage);
+    const { clearAllBulkFilters: clearFilters } = this.props;
+    clearFilters(filterType);
+
+    this.returnToFirstPageAndSearch();
   };
 
   getBulkConcepts = () => {

--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -46,18 +46,13 @@ export const fetchFilteredConcepts = (source = 'CIEL', query = '', currentPage =
   }
 };
 
-export const addToFilterList = (item, type, query, currentPage) => (dispatch) => {
-  if (type === FILTER_TYPES.DATATYPE) {
-    dispatch(isSuccess(item, ADD_TO_DATATYPE_LIST));
-    return dispatch(fetchFilteredConcepts('CIEL', query, currentPage));
-  }
-  dispatch(isSuccess(item, ADD_TO_CLASS_LIST));
-  return dispatch(fetchFilteredConcepts('CIEL', query, currentPage));
+export const addToFilterList = (item, type) => (dispatch) => {
+  if (type === FILTER_TYPES.DATATYPE) dispatch(isSuccess(item, ADD_TO_DATATYPE_LIST));
+  else dispatch(isSuccess(item, ADD_TO_CLASS_LIST));
 };
 
-export const clearAllBulkFilters = (filterType, query, currentPage) => (dispatch) => {
+export const clearAllBulkFilters = (filterType) => (dispatch) => {
   dispatch({ type: CLEAR_BULK_FILTERS, payload: filterType });
-  dispatch(fetchFilteredConcepts('CIEL', query, currentPage));
 };
 
 export const previewConcept = id => (dispatch, getState) => {

--- a/src/tests/bulkConcepts/actions/bulkConcept.test.js
+++ b/src/tests/bulkConcepts/actions/bulkConcept.test.js
@@ -442,21 +442,17 @@ describe('test suite for addBulkConcepts synchronous action creators', () => {
     const store = mockStore(mockConceptStore);
     const expectedActions = [
       { type: ADD_TO_DATATYPE_LIST, payload: 'text' },
-      { payload: true, type: '[ui] toggle spinner' },
     ];
     await store.dispatch(addToFilterList('text', 'datatype'));
     expect(store.getActions()[0]).toEqual(expectedActions[0]);
-    expect(store.getActions()[1]).toEqual(expectedActions[1]);
   });
   it('should handle ADD_TO_CLASS_LIST', async () => {
     const store = mockStore(mockConceptStore);
     const expectedActions = [
       { type: ADD_TO_CLASS_LIST, payload: 'drug' },
-      { payload: true, type: '[ui] toggle spinner' },
     ];
     await store.dispatch(addToFilterList('drug', 'class'));
     expect(store.getActions()[0]).toEqual(expectedActions[0]);
-    expect(store.getActions()[1]).toEqual(expectedActions[1]);
   });
 
   describe('clearAllBulkFilters', () => {
@@ -480,11 +476,9 @@ describe('test suite for addBulkConcepts synchronous action creators', () => {
       const store = mockStore(mockConceptStore);
       const expectedActions = [
         { type: CLEAR_BULK_FILTERS, payload: filterType },
-        { payload: true, type: '[ui] toggle spinner' },
       ];
       await store.dispatch(clearAllBulkFilters(filterType));
       expect(store.getActions()[0]).toEqual(expectedActions[0]);
-      expect(store.getActions()[1]).toEqual(expectedActions[1]);
     });
   });
 

--- a/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
+++ b/src/tests/bulkConcepts/containers/BulkConceptsPage.test.js
@@ -177,6 +177,36 @@ describe('Test suite for BulkConceptsPage component', () => {
     expect(instance.componentDidUpdate(2)).toEqual(undefined);
   });
 
+  describe('returnToFirstPageAndSearch', () => {
+    it('it should set the currentPage to the first page if it is not', () => {
+      const nextProps = {
+        ...props,
+        currentPage: 2,
+        setCurrentPage: jest.fn(),
+      };
+      const wrapper = shallow(<BulkConceptsPage {...nextProps} />);
+      const instance = wrapper.instance();
+
+      expect(nextProps.setCurrentPage).not.toHaveBeenCalled();
+      instance.returnToFirstPageAndSearch();
+      expect(nextProps.setCurrentPage).toHaveBeenCalledWith(1);
+    });
+
+    it('it should call getBulkConcepts if the currentPage is already page 1', () => {
+      const nextProps = {
+        ...props,
+        currentPage: 1,
+      };
+      const wrapper = shallow(<BulkConceptsPage {...nextProps} />);
+      const instance = wrapper.instance();
+      instance.getBulkConcepts = jest.fn();
+
+      expect(instance.getBulkConcepts).not.toHaveBeenCalled();
+      instance.returnToFirstPageAndSearch();
+      expect(instance.getBulkConcepts).toHaveBeenCalled();
+    });
+  });
+
   it('should refresh page when search input is empty', () => {
     const nextProps = {
       ...props,


### PR DESCRIPTION
# JIRA TICKET NAME:
[Searching or filtering on the add CIEL concepts pages should set the page back to page 1](https://issues.openmrs.org/browse/OCLOMRS-666)

# Summary:
The current functionality fetches whatever page the user was already on. This is a problem because the user may not realize the best match to their search was on a previous page