### PR TITLE
OCLOMRS-665: Remove verbose call while fetching collections on the home page

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryCard.jsx
@@ -7,8 +7,6 @@ const DictionaryCard = (dictionary) => {
       name,
       owner,
       owner_type,
-      active_concepts,
-      created_by,
       url,
     },
     gotoDictionary,
@@ -40,21 +38,6 @@ const DictionaryCard = (dictionary) => {
                 </small>
               </a>
             </div>
-          </div>
-          <div className="description col-12 text-left">
-            <p>
-              <span className="source-type">
-Active Concepts:
-                {' '}
-                {active_concepts}
-              </span>
-              <br />
-              <a className="source-type" id="cardCapitalize">
-                Created By:
-                {' '}
-                {created_by}
-              </a>
-            </p>
           </div>
         </div>
         <div className="source-card-footer">

--- a/src/redux/actions/user/index.js
+++ b/src/redux/actions/user/index.js
@@ -52,12 +52,11 @@ export const fetchUserOrganizations = (username, props) => async (dispatch) => {
 };
 
 export const fetchsUserDictionaries = (username, props) => async (dispatch) => {
-  const url = `/users/${username}/collections/?q=${''}&limit=${0}&page=${1}&verbose=true`;
+  const url = `/users/${username}/collections/?q=${''}&limit=${0}`;
   dispatch(isFetching(true));
   try {
     const response = await instance.get(url);
-    const result = filterUserPayload(username, response.data);
-    dispatch(isSuccess(result, FETCH_USER_DICTIONARY));
+    dispatch(isSuccess(response.data, FETCH_USER_DICTIONARY));
   } catch (error) {
     if (error.message === REQUEST_DENIED_MESSAGE) {
       dispatch(logout());

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -3,7 +3,7 @@ import instance from '../config/axiosConfig';
 export default {
   dictionaries: {
     list: {
-      fromAnOrganization: organizationUrl => instance.get(`${organizationUrl}collections/?limit=0&verbose=true`),
+      fromAnOrganization: organizationUrl => instance.get(`${organizationUrl}collections/?limit=0`),
     },
     createDictionary: data => instance
       .post(`orgs/${data.owner}/collections/`, data)

--- a/src/redux/reducers/util.js
+++ b/src/redux/reducers/util.js
@@ -59,17 +59,6 @@ export const filterPayload = (payload) => {
   return filteredDictionaries;
 };
 
-export const filterUserPayload = (user, payload) => {
-  const filteredDictionaries = [];
-  payload.map((dictionary) => {
-    if (dictionary.created_by === user) {
-      return filteredDictionaries.push(dictionary);
-    }
-    return filteredDictionaries;
-  });
-  return filteredDictionaries;
-};
-
 export const removeItem = (item, list) => {
   const newList = list ? list.filter(listItem => listItem.uuid !== item) : [];
   return newList;

--- a/src/styles/dashboard.scss
+++ b/src/styles/dashboard.scss
@@ -344,7 +344,7 @@ nav {
 }
 
 #dictionary {
-  min-height: 8rem;
+  height: 8rem;
 }
 
 #dictionaryHeader {

--- a/src/tests/Dashboard/action/api.test.js
+++ b/src/tests/Dashboard/action/api.test.js
@@ -71,7 +71,7 @@ describe('Test suite for dictionary actions', () => {
 
         const orgUrl = '/test/url/';
         await api.dictionaries.list.fromAnOrganization(orgUrl);
-        expect(url).toContain(`${orgUrl}collections/?limit=0&verbose=true`);
+        expect(url).toContain(`${orgUrl}collections/?limit=0`);
       });
     });
   });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Remove verbose call while fetching collections on the home page](https://issues.openmrs.org/browse/OCLOMRS-665)

# Summary:
We currently retrieve the list of collections with a collection's entire details.

As users use the application more, it is possible that they could have a number of collections to manage (>20)

We currently do not(for the user's collections- can be implemented and ticket is up)and cannot(for public dictionaries- because we do some frontend filtering necessitating a back end improvement) have pagination implemented for when we fetch these collections.

This ticket therefore eliminates this verbose calls to prevent this performance degradation.
