### PR TITLE
OCLOMRS-653: The edit dictionary modal is not prepopulated sometimes when editting

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -286,7 +286,7 @@ export class DictionaryOverview extends Component {
 export const mapStateToProps = state => ({
   dictionary: state.dictionaries.dictionary,
   dictionaryConcepts: state.concepts.dictionaryConcepts,
-  loader: state.dictionaries.loading,
+  loader: state.dictionaries.loading || state.dictionaries.fetchingDictionary,
   versions: state.dictionaries.versions,
   error: state.dictionaries.error,
   isReleased: state.dictionaries.isReleased,

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -13,7 +13,9 @@ import {
   realisingHeadSuccess,
   editDictionarySuccess,
   creatingVersionsSuccess,
-  creatingVersionsError, replaceConcept,
+  creatingVersionsError,
+  replaceConcept,
+  toggleDictionaryFetching,
 } from './dictionaryActions';
 import { filterPayload } from '../../reducers/util';
 import { addDictionaryReference } from '../bulkConcepts';
@@ -36,7 +38,7 @@ export const createDictionary = data => async dispatch =>
         notify.show(
           'Successfully added dictionary to your organization',
           'success', 6000,
-        ), 
+        ),
       )})
     .catch(error => {
       error.response ? notify.show(`${error.response.data.__all__[0]}`, 'error', 6000):
@@ -58,7 +60,7 @@ export const createDictionaryUser = data => dispatch =>
         ),
       )})
     .catch(error => {
-      error.response ? notify.show(`${error.response.data.__all__[0]}`, 'error', 6000) : 
+      error.response ? notify.show(`${error.response.data.__all__[0]}`, 'error', 6000) :
       showNetworkError();
     });
 
@@ -100,13 +102,13 @@ export const searchDictionaries = searchItem => async (dispatch) => {
 };
 
 export const fetchDictionary = data => (dispatch) => {
-  dispatch(isFetching(true));
+  dispatch(toggleDictionaryFetching(true));
   return api.dictionaries
     .fetchDictionary(data)
     .then(
       (payload) => {
       dispatch(dictionaryIsSuccess(payload));
-      dispatch(isFetching(false));
+      dispatch(toggleDictionaryFetching(false));
     });
   };
 

--- a/src/redux/actions/dictionaries/dictionaryActions.js
+++ b/src/redux/actions/dictionaries/dictionaryActions.js
@@ -14,7 +14,7 @@ import {
   REMOVE_MAPPING,
   CREATING_RELEASED_VERSION,
   CREATING_RELEASED_VERSION_FAILED,
-  RELEASING_HEAD_VERSION, REPLACE_CONCEPT,
+  RELEASING_HEAD_VERSION, REPLACE_CONCEPT, TOGGLE_DICTIONARY_FETCHING,
 } from '../types';
 
 export const addDictionary = response => ({
@@ -104,5 +104,10 @@ export const creatingVersionsSuccess = payload => ({
 
 export const creatingVersionsError = payload => ({
   type: CREATING_RELEASED_VERSION_FAILED,
+  payload,
+});
+
+export const toggleDictionaryFetching = payload => ({
+  type: TOGGLE_DICTIONARY_FETCHING,
   payload,
 });

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -4,6 +4,7 @@ export const AUTHENTICATION_IN_PROGRESS = '[auth] login progess';
 export const LOGGED_OUT = '[auth] logout';
 export const LOGOUT_FAILED = '[auth] logout failed';
 export const IS_FETCHING = '[ui] toggle spinner';
+export const TOGGLE_DICTIONARY_FETCHING = '[dictionary] toggle dictionary fetching';
 export const FETCH_CONCEPTS = '[concepts] fetch concepts';
 export const SEARCH_CONCEPTS = '[concepts] search concepts';
 export const CLEAR_CONCEPTS = '[concepts] clear concepts';

--- a/src/redux/reducers/dictionaryReducers.js
+++ b/src/redux/reducers/dictionaryReducers.js
@@ -8,10 +8,17 @@ import {
   CREATING_RELEASED_VERSION,
   CREATING_RELEASED_VERSION_FAILED,
   RELEASING_HEAD_VERSION,
+  TOGGLE_DICTIONARY_FETCHING,
 } from '../actions/types';
 
 const initalState = {
-  versions: [], dictionaries: [], loading: false, dictionary: {}, isReleased: false, error: [],
+  versions: [],
+  dictionaries: [],
+  loading: false,
+  dictionary: {},
+  isReleased: false,
+  error: [],
+  fetchingDictionary: false,
 };
 
 export default (state = initalState, action) => {
@@ -60,6 +67,11 @@ export default (state = initalState, action) => {
       return {
         ...state,
         error: action.payload,
+      };
+    case TOGGLE_DICTIONARY_FETCHING:
+      return {
+        ...state,
+        fetchingDictionary: action.payload,
       };
     default:
       return state;

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -17,6 +17,7 @@ import {
   REMOVE_CONCEPT,
   CREATING_RELEASED_VERSION,
   CREATING_RELEASED_VERSION_FAILED, REPLACE_CONCEPT,
+  TOGGLE_DICTIONARY_FETCHING,
 } from '../../../redux/actions/types';
 import {
   fetchOrganizations,
@@ -177,9 +178,9 @@ describe('Test suite for dictionary actions', () => {
       });
     });
     const expectedActions = [
-      { type: IS_FETCHING, payload: true },
+      { type: TOGGLE_DICTIONARY_FETCHING, payload: true },
       { type: FETCHING_DICTIONARY, payload: [dictionaries] },
-      { type: IS_FETCHING, payload: false },
+      { type: TOGGLE_DICTIONARY_FETCHING, payload: false },
     ];
     const store = mockStore({ payload: {} });
     return store.dispatch(fetchDictionary('/users/chriskala/collections/over/')).then(() => {

--- a/src/tests/Dashboard/reducer/dictionaryReducers.test.js
+++ b/src/tests/Dashboard/reducer/dictionaryReducers.test.js
@@ -12,6 +12,7 @@ import {
   RELEASING_HEAD_VERSION,
   CREATING_RELEASED_VERSION,
   CREATING_RELEASED_VERSION_FAILED,
+  TOGGLE_DICTIONARY_FETCHING,
 } from '../../../redux/actions/types';
 import dictionaries from '../../__mocks__/dictionaries';
 import versions from '../../__mocks__/versions';
@@ -41,6 +42,7 @@ const state = {
   error: [],
   loading: false,
   isReleased: false,
+  fetchingDictionary: false,
 };
 const dictionary = dictionaries;
 
@@ -67,6 +69,19 @@ describe('Test suite for dictionaries reducers', () => {
       },
     )).toEqual({
       loading: false,
+    });
+  });
+  describe('TOGGLE_DICTIONARY_FETCHING', () => {
+    it('should correctly set the fetchingDictionary to the payload value', () => {
+      expect(dictionaryreducer(
+        {},
+        {
+          type: TOGGLE_DICTIONARY_FETCHING,
+          payload: false,
+        },
+      )).toEqual({
+        fetchingDictionary: false,
+      });
     });
   });
   it('should fetch a dictionary', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[The edit dictionary modal is not pre-populated sometimes when editting](https://issues.openmrs.org/browse/OCLOMRS-653)

# Summary:
This page dispatched multiple actions on mount, all of which use the same action type in state to track loading status. The result is that the loading stops when the first action is complete, hence displaying the page and edit button before the data is ready.
The solution is to have each of these actions have a separate loading value in state

The workaround in such situations is to refresh the page

This is a larger problem though, and a larger ticket- OCLOMRS-670 has been created to deal with the other aspects