### PR TITLE
OCLOMRS-673: Improve notification message to user when a long running import is ongoing

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -8,3 +8,6 @@ export const FILTER_TYPES = {
 };
 
 export const ORGANIZATIONS = 'orgs';
+
+export const ADDING_CONCEPTS_WARNING_MESSAGE = '\nThis may take several minutes.\n'
+  + 'DO NOT NAVIGATE AWAY FROM THE APPLICATION UNTIL THIS IS COMPLETE.';

--- a/src/redux/actions/bulkConcepts/index.js
+++ b/src/redux/actions/bulkConcepts/index.js
@@ -16,6 +16,7 @@ import {
 import { recursivelyFetchConceptMappings } from '../concepts/addBulkConcepts';
 import { MAPPINGS_RECURSION_DEPTH } from '../../../components/dictionaryConcepts/components/helperFunction';
 import { deleteNotification, upsertNotification } from '../notifications';
+import { ADDING_CONCEPTS_WARNING_MESSAGE } from '../../../constants';
 
 const fetchSourceConcepts = url => async (dispatch) => {
   dispatch(clear(CLEAR_SOURCE_CONCEPTS));
@@ -34,7 +35,7 @@ export default fetchSourceConcepts;
 export const addExistingBulkConcepts = conceptData => async (dispatch) => {
   const { url, data, conceptIdList: fromConceptIds } = conceptData;
   const updateNotification = message => dispatch(upsertNotification(
-    `adding-${fromConceptIds}`, `Adding ${fromConceptIds}\n${message}`,
+    `adding-${fromConceptIds}`, `Adding ${fromConceptIds}\n\n${message}${ADDING_CONCEPTS_WARNING_MESSAGE}`,
   ));
 
   try {
@@ -43,7 +44,9 @@ export const addExistingBulkConcepts = conceptData => async (dispatch) => {
     );
     data.data.expressions.push(...referencesToAdd);
 
-    updateNotification('Finalizing...');
+    updateNotification(
+      `Adding these and ${referencesToAdd.length} dependent concepts...`,
+    );
 
     const payload = await instance.put(url, data);
     dispatch(isSuccess(payload.data, ADD_EXISTING_BULK_CONCEPTS));

--- a/src/styles/notifications.scss
+++ b/src/styles/notifications.scss
@@ -22,7 +22,7 @@
         min-height: 56px;
         padding: 8px 12px;
         justify-content: space-between;
-        white-space: pre;
+        white-space: pre-line;
         text-align: left;
     }
 

--- a/src/tests/bulkConcepts/actions/bulkConcept.test.js
+++ b/src/tests/bulkConcepts/actions/bulkConcept.test.js
@@ -30,6 +30,7 @@ import concepts, { mockConceptStore } from '../../__mocks__/concepts';
 import mappings from '../../__mocks__/mappings';
 import api from '../../../redux/api';
 import { DELETE_NOTIFICATION, UPSERT_NOTIFICATION } from '../../../redux/actions/notifications';
+import { ADDING_CONCEPTS_WARNING_MESSAGE } from '../../../constants';
 
 jest.mock('react-notify-toast');
 const mockStore = configureStore([thunk]);
@@ -60,21 +61,21 @@ describe('Test suite for addBulkConcepts async actions', () => {
         type: UPSERT_NOTIFICATION,
         payload: {
           id: notificationId,
-          message: `Adding ${concepts.display_name}\nFinding dependent concepts...`,
+          message: `Adding ${concepts.display_name}\n\nFinding dependent concepts...${ADDING_CONCEPTS_WARNING_MESSAGE}`,
         },
       },
       {
         type: UPSERT_NOTIFICATION,
         payload: {
           id: notificationId,
-          message: `Adding ${concepts.display_name}\nFound 0 dependent concepts...`,
+          message: `Adding ${concepts.display_name}\n\nFound 0 dependent concepts to add...${ADDING_CONCEPTS_WARNING_MESSAGE}`,
         },
       },
       {
         type: UPSERT_NOTIFICATION,
         payload: {
           id: notificationId,
-          message: `Adding ${concepts.display_name}\nFinalizing...`,
+          message: `Adding ${concepts.display_name}\n\nAdding concept...${ADDING_CONCEPTS_WARNING_MESSAGE}`,
         },
       },
       {
@@ -154,21 +155,21 @@ describe('Test suite for addBulkConcepts async actions', () => {
         type: UPSERT_NOTIFICATION,
         payload: {
           id: notificationId,
-          message: `Adding ${concepts.display_name}\nFinding dependent concepts...`,
+          message: `Adding ${concepts.display_name}\n\nFinding dependent concepts...${ADDING_CONCEPTS_WARNING_MESSAGE}`,
         },
       },
       {
         type: UPSERT_NOTIFICATION,
         payload: {
           id: notificationId,
-          message: `Adding ${concepts.display_name}\nFound 0 dependent concepts...`,
+          message: `Adding ${concepts.display_name}\n\nFound 0 dependent concepts to add...${ADDING_CONCEPTS_WARNING_MESSAGE}`,
         },
       },
       {
         type: UPSERT_NOTIFICATION,
         payload: {
           id: notificationId,
-          message: `Adding ${concepts.display_name}\nFinalizing...`,
+          message: `Adding ${concepts.display_name}\n\nAdding concept...${ADDING_CONCEPTS_WARNING_MESSAGE}`,
         },
       },
       {

--- a/src/tests/bulkConcepts/actions/index.test.js
+++ b/src/tests/bulkConcepts/actions/index.test.js
@@ -18,6 +18,7 @@ fetchCielConcepts,
 import cielConcepts from '../../__mocks__/concepts';
 import api from '../../../redux/api';
 import { DELETE_NOTIFICATION, UPSERT_NOTIFICATION } from '../../../redux/actions/notifications';
+import { ADDING_CONCEPTS_WARNING_MESSAGE } from '../../../constants';
 
 const mockStore = configureStore([thunk]);
 jest.mock('react-notify-toast');
@@ -88,21 +89,21 @@ describe('Test suite for source concepts actions', () => {
         type: UPSERT_NOTIFICATION,
         payload: {
           id: notificationId,
-          message: `Adding ${conceptIdList}\nFinding dependent concepts...`,
+          message: `Adding ${conceptIdList}\n\nFinding dependent concepts...${ADDING_CONCEPTS_WARNING_MESSAGE}`,
         },
       },
       {
         type: UPSERT_NOTIFICATION,
         payload: {
           id: notificationId,
-          message: `Adding ${conceptIdList}\nFound 0 dependent concepts...`,
+          message: `Adding ${conceptIdList}\n\nFound 0 dependent concepts to add...${ADDING_CONCEPTS_WARNING_MESSAGE}`,
         },
       },
       {
         type: UPSERT_NOTIFICATION,
         payload: {
           id: notificationId,
-          message: `Adding ${conceptIdList}\nFinalizing...`,
+          message: `Adding ${conceptIdList}\n\nAdding these and 0 dependent concepts...${ADDING_CONCEPTS_WARNING_MESSAGE}`,
         },
       },
       {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Improve notification message to user when a long running import is ongoing](https://issues.openmrs.org/browse/OCLOMRS-673)

# Summary:
From talk(https://talk.openmrs.org/t/ocl-for-openmrs-user-feedback-discussion/21070/44);
 
I added “Reasons for Referral” to my dictionary. First it does a nice-looking thing where it shows that it’s going to add 39 dependent concepts, then the number goes up to 42. But then it just says “Finalizing” and it waits there for a long time.

That text is not helpful. I would change the initial text to say “Found X dependent concepts to add” and then “Adding and dependent concepts. This may take several minutes. DO NOT NAVIGATE AWAY FROM THE APPLICATION UNTIL THIS IS COMPLETE.”