### PR TITLE
OCLOMRS-674: Dictionary description doesn't wrap

### DIFF
--- a/src/styles/dictionary_modal.scss
+++ b/src/styles/dictionary_modal.scss
@@ -71,6 +71,7 @@
 #desc {
     text-align: left;
     font-weight: 400;
+    word-wrap: break-word;
 }
 #editLink {
     margin-top: 2%;


### PR DESCRIPTION
# JIRA TICKET NAME:
[Dictionary description doesn't wrap](https://issues.openmrs.org/browse/OCLOMRS-674)

# Summary:
When on the dictionary summary page, the description of the dictionary does not wrap. This should be fixed to prevent the description text from overflowing if it is too long
