### PR TITLE
OLCOMRS-675: Remove '0' that shows up when there are no concepts on the dictionary concepts and add ciel concepts page

### DIFF
--- a/src/components/bulkConcepts/component/Sidenav.jsx
+++ b/src/components/bulkConcepts/component/Sidenav.jsx
@@ -22,9 +22,9 @@ const Sidenav = (props) => {
         <div className="row">
           <h5 className="sidenav-header">
             Datatypes
-            {datatypes.length && (
+            {datatypes.length > 0 ? (
               <Button id="clear-datatype-filters" onClick={() => clearAllBulkFilters(FILTER_TYPES.DATATYPE)} className="btn btn-sm btn-outline-secondary clear-filter-button">Clear all</Button>
-            )}
+            ) : ('')}
           </h5>
         </div>
         {datatypes.map(datatype => (
@@ -40,9 +40,9 @@ const Sidenav = (props) => {
         <div className="row mt-3">
           <h5 className="sidenav-header">
             Classes
-            {classes.length && (
+            {classes.length > 0 ? (
               <Button id="clear-class-filters" onClick={() => clearAllBulkFilters(FILTER_TYPES.CLASSES)} className="btn btn-sm btn-outline-secondary clear-filter-button">Clear all</Button>
-            )}
+            ) : ('')}
           </h5>
         </div>
         {classes.map(classItem => (

--- a/src/components/dictionaryConcepts/components/Sidenav.jsx
+++ b/src/components/dictionaryConcepts/components/Sidenav.jsx
@@ -12,9 +12,9 @@ const Sidenav = ({
       <div className="row">
         <h5 className="sidenav-header">
           Source
-          {filteredSources.length && (
+          {filteredSources.length > 0 ? (
             <Button id="clear-source-filters" onClick={() => clearAllFilters(FILTER_TYPES.SOURCES)} className="btn btn-sm btn-outline-secondary clear-filter-button">Clear all</Button>
-          )}
+          ) : ('')}
         </h5>
       </div>
       {filteredSources.map(source => (
@@ -29,9 +29,9 @@ const Sidenav = ({
       <div className="row mt-3">
         <h5 className="sidenav-header">
           Class
-          {filteredClass.length && (
+          {filteredClass.length > 0 ? (
             <Button id="clear-class-filters" onClick={() => clearAllFilters(FILTER_TYPES.CLASSES)} className="btn btn-sm btn-outline-secondary clear-filter-button">Clear all</Button>
-          )}
+          ) : ('')}
         </h5>
       </div>
       {filteredClass.map(classItem => (


### PR DESCRIPTION
# JIRA TICKET NAME:
[Remove '0' that shows up when there are no concepts on the dictionary concepts and add ciel concepts page](https://issues.openmrs.org/browse/OCLOMRS-675)

# Summary:
On the dictionary concepts and add Ciel concepts pages, if either of them has no concepts, the side-nav bar  should not show `0` or the clear button if there are no concepts to display
