### PR TITLE
OCLOMRS-677: Modify Search Queries to allow for partial search

### DIFF
--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -1,1 +1,2 @@
 export const getLoggedInUsername = () => localStorage.getItem('username');
+export const buildPartialSearchQuery = query => query.replace(new RegExp(' ', 'g'), '* ');

--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -17,6 +17,7 @@ import api from '../../../api';
 import { MAPPINGS_RECURSION_DEPTH, removeDuplicates } from '../../../../components/dictionaryConcepts/components/helperFunction';
 import { ADDING_CONCEPTS_WARNING_MESSAGE, FILTER_TYPES } from '../../../../constants';
 import { deleteNotification, upsertNotification } from '../../notifications';
+import { buildPartialSearchQuery } from '../../../../helperFunctions';
 
 export const fetchFilteredConcepts = (source = 'CIEL', query = '', currentPage = 1, conceptLimit = 10) => async (
   dispatch,
@@ -26,7 +27,9 @@ export const fetchFilteredConcepts = (source = 'CIEL', query = '', currentPage =
   const {
     bulkConcepts: { datatypeList, classList },
   } = getState();
-  let url = `orgs/${source}/sources/${source}/concepts/?${query}&limit=${conceptLimit}&page=${currentPage}&verbose=true&includeMappings=1`;
+
+  const searchQuery = buildPartialSearchQuery(query);
+  let url = `orgs/${source}/sources/${source}/concepts/?${searchQuery}&limit=${conceptLimit}&page=${currentPage}&verbose=true&includeMappings=1`;
 
   if (datatypeList.length > 0) {
     url = `${url}&datatype=${datatypeList.join(',')}`;

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -55,6 +55,7 @@ import {
 import instance from '../../../config/axiosConfig';
 import api from '../../api';
 import { recursivelyFetchConceptMappings } from './addBulkConcepts';
+import { buildPartialSearchQuery } from '../../../helperFunctions';
 
 export const paginateConcepts = (concepts, limit = 10, offset = 0) => (dispatch, getState) => {
   let conceptList = concepts;
@@ -127,18 +128,18 @@ export const fetchDictionaryConcepts = (
   page = 1,
 ) => async (dispatch, getState) => {
   dispatch(isFetching(true));
-  let url = `${conceptType}/${conceptOwner}/collections/${conceptName}/concepts/?includeMappings=true&q=${query}&limit=${limit}&page=${page}&verbose=true`;
+
+  const searchQuery = buildPartialSearchQuery(query);
+  let url = `${conceptType}/${conceptOwner}/collections/${conceptName}/concepts/?q=${searchQuery}&limit=${limit}&page=${page}&verbose=true&includeMappings=1`;
   const filterBySource = getState().concepts.filteredBySource;
   const filterByClass = getState().concepts.filteredByClass;
 
-  if (filterBySource.length > 0 && filterByClass.length > 0) {
-    url = `${conceptType}/${conceptOwner}/collections/${conceptName}/concepts/?q=${query}&limit=${limit}&page=${page}&verbose=true&source=${filterBySource.join(',')}&conceptClass=${filterByClass.join(',')}`;
+  if (filterBySource.length > 0) {
+    url = `${url}&source=${filterBySource.join(',')}`;
   }
-  if (filterBySource.length > 0 && filterByClass.length === 0) {
-    url = `${conceptType}/${conceptOwner}/collections/${conceptName}/concepts/?q=${query}&limit=${limit}&page=${page}&verbose=true&source=${filterBySource.join(',')}`;
-  }
-  if (filterBySource.length === 0 && filterByClass.length > 0) {
-    url = `${conceptType}/${conceptOwner}/collections/${conceptName}/concepts/?q=${query}&limit=${limit}&page=${page}&verbose=true&conceptClass=${filterByClass.join(',')}`;
+
+  if (filterByClass.length > 0) {
+    url = `${url}&conceptClass=${filterByClass.join(',')}`;
   }
   try {
     const response = await instance.get(`${url}&includeRetired=1`);

--- a/src/tests/helperFunctions.test.js
+++ b/src/tests/helperFunctions.test.js
@@ -1,0 +1,8 @@
+import { buildPartialSearchQuery } from '../helperFunctions';
+
+describe('buildPartialSearchQuery', () => {
+  it('adds wildcards before all spaces', () => {
+    expect(buildPartialSearchQuery(' ')).toEqual('* ');
+    expect(buildPartialSearchQuery('search query')).toEqual('search* query');
+  });
+});


### PR DESCRIPTION
# JIRA TICKET NAME:
[Modify Search Queries to allow for partial search](https://issues.openmrs.org/browse/OCLOMRS-677)

# Summary:
As per this([https://talk.openmrs.org/t/developing-the-ocl-for-openmrs-application/17771/1095)]

Search queries must be explicitly formatted with '*'s if we would like to perform partial token base search, i.e

When searching for "The Day"

This: ?q=th*+da*(search for things that match both 'th' and 'da' partially)

Instead of what we are currently doing: ?q=th+da*(search for things that match 'th da' partially)

 