### PR TITLE
OCLOMRS-683: Creating collections belonging to a user fails

### DIFF
--- a/src/components/dashboard/components/dictionary/AddDictionary.jsx
+++ b/src/components/dashboard/components/dictionary/AddDictionary.jsx
@@ -7,10 +7,12 @@ import {
   createDictionaryUser,
   fetchingOrganizations,
 } from '../../../../redux/actions/dictionaries/dictionaryActionCreators';
+import { getLoggedInUsername } from '../../../../helperFunctions';
 
 export class AddDictionary extends React.Component {
   submit = data => (
-    data.owner === 'Individual' ? this.props.createDictionaryUser(data).then(this.props.handleHide)
+    data.owner === getLoggedInUsername()
+      ? this.props.createDictionaryUser(data).then(this.props.handleHide)
       : this.props.createDictionary(data).then(this.props.handleHide))
 
   render() {

--- a/src/tests/Dictionary/AddDictionary.test.js
+++ b/src/tests/Dictionary/AddDictionary.test.js
@@ -35,17 +35,21 @@ describe('Test suite for Edit Dictionary', () => {
     expect(wrapper.length).toEqual(1);
   });
 
-  it('should handle submit from an individual', async (done) => {
+  it('should correctly create a collection belonging to a user', () => {
+    const username = 'Individual';
+    localStorage.setItem('username', username);
+
+    props.createDictionaryUser.mockClear();
     const data = {
-      owner: 'Individual',
+      owner: username,
     };
     const wrapper = mount(<Provider store={store}><AddDictionary {...props} /></Provider>);
 
+    expect(props.createDictionaryUser).not.toHaveBeenCalled();
+
     wrapper.find(AddDictionary).instance().submit(data);
 
-    await expect(props.createDictionaryUser).toHaveBeenCalled();
-    expect(props.handleHide).toHaveBeenCalled();
-    done();
+    expect(props.createDictionaryUser).toHaveBeenCalled();
   });
 
   it('should handle submit from anywhere', async (done) => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Creating collections belonging to a user fails](https://issues.openmrs.org/browse/OCLOMRS-683)

# Summary:
OCLOMRS-671 makes a change that breaks this. This ticket updates the check that was previously checking for an owner called 'Individual' to check for the username instead in order to decide who the collection belongs to