### PR TITLE
OCLOMRS-678: Rename ‘All Dictionaries’ field to ‘Public Dictionaries' in the NavBar

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -73,7 +73,7 @@ export class Navbar extends Component {
                   <Link className="nav-link text-white" to="/home">Home</Link>
                 </NavItem>
                 <NavItem>
-                  <Link className="nav-link text-white" to="/dashboard/dictionaries">All Dictionaries</Link>
+                  <Link className="nav-link text-white" to="/dashboard/dictionaries">Public Dictionaries</Link>
                 </NavItem>
                 <UncontrolledDropdown nav inNavbar>
                   <DropdownToggle nav caret className="text-white">


### PR DESCRIPTION


# JIRA TICKET NAME:
[Rename ‘All Dictionaries’ field to ‘Public Dictionaries' in the NavBar](https://issues.openmrs.org/browse/OCLOMRS-678)

# Summary:

Rename ‘All Dictionaries’ field to ‘Public Dictionaries’ in the NavBar
