### PR TITLE
OCLOMRS-685: to_concept_coded should not appear as a datatype

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -195,7 +195,6 @@ const CreateConceptForm = (props) => {
             <option>Rule</option>
             <option>Structured-Numeric</option>
             <option>Complex</option>
-            <option>to_concept_coded</option>
           </select>
             </div>
           </div>


### PR DESCRIPTION

# JIRA TICKET NAME:
[to_concept_coded should not appear as a datatype](https://issues.openmrs.org/browse/OCLOMRS-685)

# Summary:

When creating a new procedure concept, the  to_concept_coded option appears in the list. This should not be the case
