### PR TITLE
OCLOMRS-684: Remove the initial load on the Public Dictionaries Page

### DIFF
--- a/src/components/dashboard/components/dictionary/ListDictionaries.jsx
+++ b/src/components/dashboard/components/dictionary/ListDictionaries.jsx
@@ -4,7 +4,7 @@ import Card from './DictionaryCard';
 import Loader from '../../../Loader';
 
 const ListDictionaries = (props) => {
-  const { dictionaries, fetching } = props;
+  const { dictionaries, fetching, searchHasBeenDone } = props;
   if (fetching) {
     return (
       <div className="row jusify-content-center">
@@ -28,14 +28,7 @@ const ListDictionaries = (props) => {
   return (
     <div className="text-center mt-3">
       <h5>
-        No Dictionaries Found
-        {' '}
-        <span aria-label="sad-emoji" role="img">
-          {' '}
-          😞
-          {' '}
-        </span>
-        {' '}
+        {searchHasBeenDone ? 'No Dictionaries Found' : 'Search to find Public Dictionaries'}
       </h5>
     </div>
   );
@@ -46,5 +39,11 @@ ListDictionaries.propTypes = {
   dictionaries: PropTypes.arrayOf(PropTypes.shape({
     dictionaryName: PropTypes.string,
   })).isRequired,
+  searchHasBeenDone: PropTypes.bool,
 };
+
+ListDictionaries.defaultProps = {
+  searchHasBeenDone: true,
+};
+
 export default ListDictionaries;

--- a/src/components/dashboard/container/DictionariesDisplay.jsx
+++ b/src/components/dashboard/container/DictionariesDisplay.jsx
@@ -4,10 +4,10 @@ import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { notify } from 'react-notify-toast';
 import {
+  clearDictionariesAction,
   fetchDictionaries,
   searchDictionaries,
 } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
-import { clearDictionaries } from '../../../redux/actions/dictionaries/dictionaryActions';
 import ListDictionaries from '../components/dictionary/ListDictionaries';
 import SearchDictionaries from '../components/dictionary/DictionariesSearch';
 import Paginations from '../components/DictionariesPaginations';
@@ -34,12 +34,13 @@ export class DictionaryDisplay extends Component {
       searchInput: '',
       currentPage: 1,
       limit: 24,
+      searchHasBeenDone: false,
     };
     autoBind(this);
   }
 
   componentDidMount() {
-    this.props.fetchDictionaries();
+    this.props.clearDictionaries();
   }
 
   onSubmit = (event) => {
@@ -48,6 +49,9 @@ export class DictionaryDisplay extends Component {
     const { searchInput } = this.state;
     if (searchInput && searchInput.trim().length > 2) {
       this.props.searchDictionaries(`${searchInput}*`); // asterisk added to allow partial search
+      this.setState({
+        searchHasBeenDone: true,
+      });
     } else notify.show(MIN_CHARACTERS_WARNING, 'error', MILLISECONDS_TO_SHOW_WARNING);
   }
 
@@ -57,7 +61,9 @@ export class DictionaryDisplay extends Component {
     this.setState({ [name]: trueValue });
     if (name === 'searchInput' && value.length <= 0) {
       this.props.clearDictionaries();
-      this.props.fetchDictionaries(value);
+      this.setState({
+        searchHasBeenDone: false,
+      });
     }
   }
 
@@ -72,7 +78,7 @@ export class DictionaryDisplay extends Component {
   };
 
   render() {
-    const { currentPage, searchInput } = this.state;
+    const { currentPage, searchInput, searchHasBeenDone } = this.state;
     const { dictionaries, isFetching } = this.props;
     const dictionariesPerPage = this.state.limit;
     const indexOfLastDictionary = currentPage * dictionariesPerPage;
@@ -110,6 +116,7 @@ export class DictionaryDisplay extends Component {
           dictionaries={currentDictionaries}
           fetching={isFetching}
           gotoDictionary={this.gotoDictionary}
+          searchHasBeenDone={searchHasBeenDone}
         />
       </Fragment>
     );
@@ -127,6 +134,6 @@ export default connect(
   {
     fetchDictionaries,
     searchDictionaries,
-    clearDictionaries,
+    clearDictionaries: clearDictionariesAction,
   },
 )(DictionaryDisplay);

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -16,6 +16,7 @@ import {
   creatingVersionsError,
   replaceConcept,
   toggleDictionaryFetching,
+  clearDictionaries,
 } from './dictionaryActions';
 import { filterPayload } from '../../reducers/util';
 import { addDictionaryReference } from '../bulkConcepts';
@@ -99,6 +100,10 @@ export const searchDictionaries = searchItem => async (dispatch) => {
     error.response ? dispatch(isErrored(error.response.data)):
     showNetworkError();
   }
+};
+
+export const clearDictionariesAction = () => (dispatch) => {
+  dispatch(clearDictionaries());
 };
 
 export const fetchDictionary = data => (dispatch) => {

--- a/src/redux/reducers/dictionaryReducers.js
+++ b/src/redux/reducers/dictionaryReducers.js
@@ -9,6 +9,7 @@ import {
   CREATING_RELEASED_VERSION_FAILED,
   RELEASING_HEAD_VERSION,
   TOGGLE_DICTIONARY_FETCHING,
+  CLEAR_DICTIONARIES,
 } from '../actions/types';
 
 const initalState = {
@@ -27,6 +28,11 @@ export default (state = initalState, action) => {
       return {
         ...state,
         dictionaries: [...action.payload],
+      };
+    case CLEAR_DICTIONARIES:
+      return {
+        ...state,
+        dictionaries: [],
       };
     case IS_FETCHING:
       return {

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -38,7 +38,10 @@ import {
   editDictionary,
   createVersion,
   editMapping,
-  retireConcept, addReferenceToCollectionAction, deleteReferenceFromCollectionAction,
+  retireConcept,
+  addReferenceToCollectionAction,
+  deleteReferenceFromCollectionAction,
+  clearDictionariesAction,
 } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import dictionaries, { sampleDictionaries } from '../../__mocks__/dictionaries';
 import versions, { HeadVersion } from '../../__mocks__/versions';
@@ -103,6 +106,15 @@ describe('Test suite for dictionary actions', () => {
     type: CLEAR_DICTIONARY,
     payload: {},
   };
+
+  describe('clearDictionariesAction', () => {
+    it('should dispatch the clearDictionaries action', () => {
+      const dispatchMock = jest.fn();
+
+      clearDictionariesAction()(dispatchMock);
+      expect(dispatchMock).toHaveBeenCalledWith(clearDictionaries());
+    });
+  });
 
   it('should return an array of dictionaries', () => {
     moxios.wait(() => {

--- a/src/tests/Dashboard/container/DictionaryDisplay.test.jsx
+++ b/src/tests/Dashboard/container/DictionaryDisplay.test.jsx
@@ -16,6 +16,22 @@ import DictionaryCard from '../../../components/dashboard/components/dictionary/
 jest.mock('react-notify-toast');
 
 describe('DictionaryDisplay', () => {
+  let initialProps;
+
+  beforeEach(() => {
+    initialProps = {
+      fetchDictionaries: jest.fn(),
+      dictionaries: [],
+      isFetching: true,
+      clearDictionaries: jest.fn(),
+      searchDictionaries: jest.fn(),
+      onSearch: jest.fn(),
+      onSubmit: jest.fn(),
+      organizations: [organizations],
+      history: { push: jest.fn() },
+    };
+  });
+
   it('should render without any dictionary data', () => {
     const props = {
       fetchDictionaries: jest.fn(),
@@ -139,6 +155,35 @@ describe('DictionaryDisplay', () => {
     expect(wrapper.state().searchInput).toEqual('test');
     expect(searchDictionaries).toHaveBeenCalledWith(`${wrapper.state().searchInput}*`);
   });
+
+  it('should set searchHasBeenDone to true when a search is triggered', (done) => {
+    const wrapper = mount(<DictionaryDisplay {...initialProps} />);
+    wrapper.setState({ searchInput: 'test' }, () => {
+      expect(wrapper.state().searchHasBeenDone).toBeFalsy();
+      wrapper.instance().onSubmit({ preventDefault: jest.fn() });
+      setImmediate(() => {
+        expect(wrapper.state().searchHasBeenDone).toBeTruthy();
+        done();
+      });
+    });
+  });
+
+  it('should clearDictionaries and set searchHasBeenDone to false when the search box is reset', (done) => {
+    const wrapper = mount(<DictionaryDisplay {...initialProps} />);
+    const event = { target: { name: 'searchInput', value: '' } };
+
+    wrapper.setState({ searchHasBeenDone: true }, () => {
+      expect(wrapper.state().searchHasBeenDone).toBeTruthy();
+      expect(initialProps.clearDictionaries).toHaveBeenCalledTimes(1);
+      wrapper.instance().onSearch(event);
+      setImmediate(() => {
+        expect(wrapper.state().searchHasBeenDone).toBeFalsy();
+        expect(initialProps.clearDictionaries).toHaveBeenCalledTimes(2);
+        done();
+      });
+    });
+  });
+
   it('should render the Dictionary search component', () => {
     const properties = {
       onSearch: jest.fn(),

--- a/src/tests/Dashboard/reducer/dictionaryReducers.test.js
+++ b/src/tests/Dashboard/reducer/dictionaryReducers.test.js
@@ -13,9 +13,11 @@ import {
   CREATING_RELEASED_VERSION,
   CREATING_RELEASED_VERSION_FAILED,
   TOGGLE_DICTIONARY_FETCHING,
+  CLEAR_DICTIONARIES,
 } from '../../../redux/actions/types';
 import dictionaries from '../../__mocks__/dictionaries';
 import versions from '../../__mocks__/versions';
+import { clearDictionaries } from '../../../redux/actions/dictionaries/dictionaryActions';
 
 describe('Test suite for vote reducer', () => {
   it('should return the initial state', () => {
@@ -49,6 +51,15 @@ const dictionary = dictionaries;
 describe('Test suite for dictionaries reducers', () => {
   it('should return initial state', () => {
     expect(dictionaryreducer(undefined, {})).toEqual(state);
+  });
+
+  describe(CLEAR_DICTIONARIES, () => {
+    it('should clear all dictionaries in state', () => {
+      expect(dictionaryreducer(
+        { dictionaries: [dictionaries] },
+        clearDictionaries(),
+      )).toEqual({ dictionaries: [] });
+    });
   });
 
   it('should handle FETCH_DICTIONARIES', () => {

--- a/src/tests/Dictionary/ListDictionaries.test.jsx
+++ b/src/tests/Dictionary/ListDictionaries.test.jsx
@@ -33,4 +33,15 @@ describe('Test ListDictionary component', () => {
     const wrapper = mount(<ListDictionaries {...props} />);
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should display "Search to find Public Dictionaries" if a user has not yet started a search', () => {
+    const props = {
+      dictionaries: [],
+      fetching: false,
+      searchHasBeenDone: false,
+    };
+
+    const wrapper = mount(<ListDictionaries {...props} />);
+    expect(wrapper.find('div.mt-3 h5').text()).toEqual('Search to find Public Dictionaries');
+  });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Remove the initial load on the Public Dictionaries Page](https://issues.openmrs.org/browse/OCLOMRS-684)

# Summary:
This initial load is slow and following this discussion(https://talk.openmrs.org/t/developing-the-ocl-for-openmrs-application/17771/1090) and the preceding thread, the decision was to have users search before fetching any data