### PR TITLE
Oclomrs-690: The 'coded' datatype is missing when creating a concept

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -195,6 +195,7 @@ const CreateConceptForm = (props) => {
             <option>Rule</option>
             <option>Structured-Numeric</option>
             <option>Complex</option>
+            <option>Coded</option>
           </select>
             </div>
           </div>


### PR DESCRIPTION
# JIRA TICKET NAME:
[The 'coded' datatype is missing when creating a concept](https://issues.openmrs.org/browse/OCLOMRS-690)

# Summary:
The 'coded' concept is missing as a data type option when creating a concept. This PR rectifies that.