### PR TITLE
OCLOMRS-692: The collection’s default language should dictate the default language when adding a new name/ description

### DIFF
--- a/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptNameRows.jsx
@@ -24,8 +24,8 @@ class ConceptNameRows extends Component {
     newRow: {
       id: '',
       name: '',
-      locale: 'en',
-      locale_full: { value: 'en', label: 'English [en]' },
+      locale: '',
+      locale_full: {},
       locale_preferred: true,
       name_type: '',
     },
@@ -62,8 +62,8 @@ class ConceptNameRows extends Component {
   }
 
   updateState() {
-    const { newRow } = this.props;
-    const defaultLocale = findLocale(newRow.locale);
+    const { newRow, pathName } = this.props;
+    const defaultLocale = findLocale(newRow.locale || pathName.language);
     this.setState({
       ...this.state,
       uuid: newRow.uuid || '',

--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -22,8 +22,8 @@ class DescriptionRow extends Component {
     newRow: {
       id: '',
       name: '',
-      locale: 'en',
-      locale_full: { value: 'en', label: 'English [en]' },
+      locale: '',
+      locale_full: {},
       locale_preferred: true,
       name_type: '',
     },
@@ -56,8 +56,8 @@ class DescriptionRow extends Component {
   }
 
   updateState() {
-    const { newRow } = this.props;
-    const defaultLocale = findLocale(newRow.locale, 'en');
+    const { newRow, pathName } = this.props;
+    const defaultLocale = findLocale(newRow.locale || pathName.language, 'en');
     this.setState({
       ...this.state,
       uuid: newRow.uuid,

--- a/src/tests/helperFunctions.test.js
+++ b/src/tests/helperFunctions.test.js
@@ -1,8 +1,15 @@
 import { buildPartialSearchQuery } from '../helperFunctions';
+import { findLocale } from '../components/dashboard/components/dictionary/common/Languages';
 
 describe('buildPartialSearchQuery', () => {
   it('adds wildcards before all spaces', () => {
     expect(buildPartialSearchQuery(' ')).toEqual('* ');
     expect(buildPartialSearchQuery('search query')).toEqual('search* query');
+  });
+});
+
+describe('findLocale', () => {
+  it('returns English when it cant find the request locale', () => {
+    expect(findLocale('doesNotExist')).toEqual({ value: 'en', label: 'English [en]' });
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[The collection’s default language should dictate the default language when adding a new name/ description](https://issues.openmrs.org/browse/OCLOMRS-692)

# Summary:
Currently, this language is set to English by default. It should change based on a collection's preferred language.