### PR TITLE
OCLOMRS-694: When creating a collection, the owner field says the field is required even after selecting it

### DIFF
--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -6,22 +6,21 @@ import {
 import Select from 'react-select';
 import PropTypes from 'prop-types';
 import ReactTooltip from 'react-tooltip';
-import {
-  fetchingOrganizations,
-} from '../../../../../redux/actions/dictionaries/dictionaryActionCreators';
 import InlineError from '../messages/InlineError';
 import languages from './Languages';
+import { getLoggedInUsername } from '../../../../../helperFunctions';
 
 export class DictionaryModal extends React.Component {
   constructor(props) {
     super(props);
+    const { organizations } = this.props;
     this.state = {
       data: {
         id: '',
         preferred_source: 'CIEL',
         public_access: 'View',
         name: '',
-        owner: '',
+        owner: (organizations && organizations.length) ? '' : getLoggedInUsername(),
         custom_validation_schema: 'OpenMRS',
         description: '',
         default_locale: 'en',
@@ -37,7 +36,6 @@ export class DictionaryModal extends React.Component {
   }
 
   componentDidMount() {
-    this.props.fetchingOrganizations();
     const { isEditingDictionary } = this.props;
     if (isEditingDictionary) {
       this.populateFields();
@@ -411,7 +409,6 @@ DictionaryModal.propTypes = {
   title: PropTypes.string,
   show: PropTypes.bool,
   buttonname: PropTypes.string,
-  fetchingOrganizations: PropTypes.func.isRequired,
   submit: PropTypes.func.isRequired,
   organizations: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string,
@@ -434,10 +431,9 @@ DictionaryModal.defaultProps = {
 
 function mapStateToProps(state) {
   return {
-    organizations: state.organizations.organizations,
+    organizations: state.user.userOrganization,
   };
 }
 export default connect(
   mapStateToProps,
-  { fetchingOrganizations },
 )(DictionaryModal);

--- a/src/components/userDasboard/container/UserDashboard.jsx
+++ b/src/components/userDasboard/container/UserDashboard.jsx
@@ -65,7 +65,9 @@ export class UserDashboard extends Component {
     return (
       <div className="container custom-max-width">
         <Title title="Home" />
-        <AddDictionary show={this.state.show} handleHide={this.handleHide} />
+        {this.state.show ? (
+          <AddDictionary show={this.state.show} handleHide={this.handleHide} />
+        ) : ''}
         <div className="row justify-content-center">
           <div className="col-12 user-info">
             <div className="row">
@@ -101,6 +103,7 @@ Your
                     className="btn btn-outline-primary btn-sm"
                     id="add-dictionary"
                     onClick={this.handleShow}
+                    disabled={loading}
                   >
                     <i className="fas fa-plus fa-fw" />
                     {' '}

--- a/src/tests/Dictionary/DictionaryModal.test.jsx
+++ b/src/tests/Dictionary/DictionaryModal.test.jsx
@@ -104,6 +104,7 @@ describe('Test suite for dictionary modal', () => {
         default_locale: '',
         supported_locales: '',
         public_access: '',
+        owner: '',
       },
     });
     const submitButtonWrapper = wrapper.find('#addDictionary');
@@ -112,6 +113,7 @@ describe('Test suite for dictionary modal', () => {
     expect(wrapper.state().errors.preferred_source).toEqual('Required');
     expect(wrapper.state().errors.default_locale).toEqual('Required');
     expect(wrapper.state().errors.public_access).toEqual('Required');
+    expect(wrapper.state().errors.owner).toEqual('Required');
     expect(wrapper.state().errors.supported_locales).toEqual(
       'Preferred language must not be included in other languages',
     );
@@ -265,5 +267,19 @@ describe('Test suite for dictionary modal', () => {
     const submitButtonWrapper = wrapper.find('#addDictionary');
     submitButtonWrapper.simulate('click', preventDefault);
     expect(wrapper.state().disableButton).toBeTruthy();
+  });
+
+  it('should set the owner value to an empty string when a user is a part of organizations', () => {
+    const newProps = { ...props, organizations: [organizations], isEditingDictionary: false };
+    wrapper = shallow(<DictionaryModal {...newProps} />);
+    expect(wrapper.instance().state.data.owner).toEqual('');
+  });
+
+  it('should set the owner value to the username when a user is not a part of any organization', () => {
+    const username = 'test_username';
+    localStorage.setItem('username', username);
+    const newProps = { ...props, organizations: [], isEditingDictionary: false };
+    wrapper = shallow(<DictionaryModal {...newProps} />);
+    expect(wrapper.instance().state.data.owner).toEqual(username);
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[When creating a collection, the owner field says the field is required even after selecting it](https://issues.openmrs.org/browse/OCLOMRS-694)

# Summary:
From OCLOMRS-133, this field should automatically select the currently logged in user as the owner if they are not part of any organizations