### PR TITLE
OCLOMRS-691: Set the number of levels to check for to-concepts in mappings to 10

### DIFF
--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -80,7 +80,7 @@ export const ATTRIBUTE_NAME_SOURCE = 'source';
 export const KEY_CODE_FOR_ENTER = 13;
 export const KEY_CODE_FOR_ESCAPE = 27;
 export const KEY_CODE_FOR_SPACE = 32;
-export const MAPPINGS_RECURSION_DEPTH = 2;
+export const MAPPINGS_RECURSION_DEPTH = 10;
 export const isSetConcept = conceptClass => conceptClass.toLowerCase().indexOf('set') > -1;
 export const removeDuplicates = items => union(items);
 export const isExternalSource = source => source && includes(['External', 'externalDictionary'], source.source_type);


### PR DESCRIPTION
# JIRA TICKET NAME:
[Set the number of levels to check for to-concepts in mappings to 10](https://issues.openmrs.org/browse/OCLOMRS-691)

# Summary:
This number is arbitrary and is currently set to 2. Set this number to 10 to reduce the chance that mappings imported at the last level don't have their concepts brought in as well. Details on this are contained in ticket OCLOMRS-688.