### PR TITLE
OCLOMRS-696: When you try to add a CIEL concept, even if the concept is there, it should recursively add the dependencies and give a better message

### DIFF
--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -114,3 +114,16 @@ export const convertToFrontendNameType = (nameType) => {
     default: return nameType;
   }
 };
+export const buildAddConceptToCollectionMessage = (conceptName, results) => {
+  const conceptResult = results[0];
+  const otherResults = results.slice(1);
+
+  const addedCount = otherResults.filter(result => result.added).length;
+  const alreadyInCollectionCount = otherResults.length - addedCount;
+
+  const conceptMessage = conceptResult.added ? `Added ${conceptName}.` : `${conceptName} already in collection.`;
+  const addedConceptsMessage = addedCount > 0 ? ` ${addedCount} dependent concepts were added.` : '';
+  const alreadyAddedMessage = alreadyInCollectionCount > 0 ? ` ${alreadyInCollectionCount} already added concepts were skipped` : '';
+
+  return conceptMessage + addedConceptsMessage + alreadyAddedMessage;
+};

--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -14,7 +14,11 @@ import {
   CLEAR_BULK_FILTERS,
 } from '../../types';
 import api from '../../../api';
-import { MAPPINGS_RECURSION_DEPTH, removeDuplicates } from '../../../../components/dictionaryConcepts/components/helperFunction';
+import {
+  buildAddConceptToCollectionMessage,
+  MAPPINGS_RECURSION_DEPTH,
+  removeDuplicates
+} from '../../../../components/dictionaryConcepts/components/helperFunction';
 import { ADDING_CONCEPTS_WARNING_MESSAGE, FILTER_TYPES } from '../../../../constants';
 import { deleteNotification, upsertNotification } from '../../notifications';
 import { buildPartialSearchQuery } from '../../../../helperFunctions';
@@ -120,16 +124,7 @@ export const addConcept = (params, data, conceptName, id) => async (dispatch) =>
 
     const payload = await instance.put(url, data);
     dispatch(isSuccess(payload.data, ADD_EXISTING_CONCEPTS));
-    if (payload.data[0].added === true) {
-      const dependentConceptCount = data.data.expressions.length - 1;
-      if (dependentConceptCount) {
-        notify.show(`Just Added - ${conceptName} and ${dependentConceptCount} dependent concepts`, 'success', 3000);
-      } else {
-        notify.show(`Just Added - ${conceptName}`, 'success', 3000);
-      }
-    } else {
-      notify.show(`${conceptName} already added`, 'error', 3000);
-    }
+    notify.show(buildAddConceptToCollectionMessage(conceptName, payload.data), 'success', 5000);
   } catch (e) {
     notify.show(`Failed to add ${conceptName}. Please Retry`, 'error', 3000);
   } finally {

--- a/src/tests/bulkConcepts/actions/bulkConcept.test.js
+++ b/src/tests/bulkConcepts/actions/bulkConcept.test.js
@@ -102,7 +102,7 @@ describe('Test suite for addBulkConcepts async actions', () => {
     store.dispatch(action).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
       expect(notifyMock).toHaveBeenCalledTimes(1);
-      expect(notifyMock).toHaveBeenCalledWith(`Just Added - ${concepts.display_name}`, 'success', 3000);
+      expect(notifyMock).toHaveBeenCalledWith(`Added ${concepts.display_name}.`, 'success', 5000);
       done();
     });
   });
@@ -118,7 +118,7 @@ describe('Test suite for addBulkConcepts async actions', () => {
       const request = moxios.requests.mostRecent();
       request.respondWith({
         status: 200,
-        response: [{ concepts, ...{ added: true } }],
+        response: [{ concepts, ...{ added: true } }, { added: true }],
       });
     });
 
@@ -133,7 +133,7 @@ describe('Test suite for addBulkConcepts async actions', () => {
 
     store.dispatch(action).then(() => {
       expect(notifyMock).toHaveBeenCalledTimes(1);
-      expect(notifyMock).toHaveBeenCalledWith(`Just Added - ${concepts.display_name} and 1 dependent concepts`, 'success', 3000);
+      expect(notifyMock).toHaveBeenCalledWith(`Added ${concepts.display_name}. 1 dependent concepts were added.`, 'success', 5000);
       done();
     });
   });
@@ -196,7 +196,7 @@ describe('Test suite for addBulkConcepts async actions', () => {
     store.dispatch(action).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
       expect(notifyMock).toHaveBeenCalledTimes(1);
-      expect(notifyMock).toHaveBeenCalledWith(`${concepts.display_name} already added`, 'error', 3000);
+      expect(notifyMock).toHaveBeenCalledWith(`${concepts.display_name} already in collection.`, 'success', 5000);
       done();
     });
   });

--- a/src/tests/dictionaryConcepts/components/helperFunction.test.js
+++ b/src/tests/dictionaryConcepts/components/helperFunction.test.js
@@ -1,5 +1,7 @@
 import {
-  compareConceptsByUpdateDate, convertToFrontendNameType,
+  compareConceptsByUpdateDate,
+  convertToFrontendNameType,
+  buildAddConceptToCollectionMessage,
   KEY_CODE_FOR_ENTER,
   KEY_CODE_FOR_SPACE,
   preventFormSubmit, removeBlankMappings, removeBlankSetsOrAnswers,
@@ -87,5 +89,48 @@ describe('convertToFrontendNameType', () => {
 
   it('should return the same name if a match is not found', () => {
     expect(convertToFrontendNameType('Not Known')).toEqual('Not Known');
+  });
+});
+
+describe('buildAddConceptToCollectionMessage', () => {
+  const conceptName = 'testConceptName';
+
+  it('should build the right message for whether or not a concept was added', () => {
+    expect(buildAddConceptToCollectionMessage(conceptName, [{ added: true }])).toEqual(`Added ${conceptName}.`);
+    expect(buildAddConceptToCollectionMessage(conceptName, [{ added: false }])).toEqual(`${conceptName} already in collection.`);
+  });
+
+  it('should return a message with the right count for added and already added concepts', () => {
+    const results = [
+      { added: true },
+      { added: false },
+      { added: true },
+    ];
+
+    expect(buildAddConceptToCollectionMessage(conceptName, results)).toEqual(
+      `Added ${conceptName}. 1 dependent concepts were added. 1 already added concepts were skipped`,
+    );
+  });
+
+  it('should not include added concepts if there are none', () => {
+    const results = [
+      { added: true },
+      { added: false },
+    ];
+
+    expect(buildAddConceptToCollectionMessage(conceptName, results)).toEqual(
+      `Added ${conceptName}. 1 already added concepts were skipped`,
+    );
+  });
+
+  it('should not include skipped concepts if there are none', () => {
+    const results = [
+      { added: true },
+      { added: true },
+    ];
+
+    expect(buildAddConceptToCollectionMessage(conceptName, results)).toEqual(
+      `Added ${conceptName}. 1 dependent concepts were added.`,
+    );
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[When you try to add a CIEL concept, even if the concept is there, it should recursively add the dependencies and give a better message](https://issues.openmrs.org/browse/OCLOMRS-696)

# Summary:
When you try to add a CIEL concept, even if the concept is there, it should recursively add the dependencies(this seems to already be working okay), and give a better(more informative) message(if the amount of work is justified for MVP). It currently simply says the concept was already added