### PR TITLE
OCLOMRS-682: When a dictionary version is released, the download option should produce a file with mappings

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -110,55 +110,6 @@ export class DictionaryOverview extends Component {
     this.setState({ [name]: value });
   }
 
-  objectToCsv = (data) => {
-    const csvRows = [];
-
-    const headers = Object.keys(data[0]);
-    csvRows.push(headers.join(','));
-
-    for (const row of data) {
-      const values = headers.map((header) => {
-        const escaped = (`${row[header]}`).replace(/"/g, '\\"');
-        return `"${escaped}"`;
-      });
-      csvRows.push(values.join(','));
-    }
-    return csvRows.join('\n');
-  }
-
-  downloadConcept = (data) => {
-    const blob = new Blob([data], { type: 'text/csv' });
-    const url = window.URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.setAttribute('hidden', '');
-    a.setAttribute('href', url);
-    a.setAttribute('download', 'dictionaryConcepts.csv');
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-  };
-
-  download = () => {
-    const { dictionaryConcepts } = this.props;
-
-    const data = dictionaryConcepts.map(row => ({
-      owner: row.owner,
-      source: row.source,
-      preferredName: row.display_name,
-      description: row.descriptions ? row.descriptions.map(
-        description => description.description,
-      ).join(' ') : '',
-      conceptClass: row.concept_class,
-      datatype: row.datatype,
-      retired: row.retired,
-      externalId: row.external_id,
-      mappings: row.mappings,
-      url: row.url,
-    }));
-    const csvData = this.objectToCsv(data);
-    this.downloadConcept(csvData);
-  }
-
   confirmRelease = () => {
     const {
       match: {
@@ -259,7 +210,6 @@ export class DictionaryOverview extends Component {
                 versionId={this.state.versionId}
                 versionDescription={this.state.versionDescription}
                 inputLength={inputLength}
-                download={this.download}
                 userCanEditDictionary={this.userCanEditDictionary()}
               />
               <EditDictionary

--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -41,7 +41,6 @@ const DictionaryDetailCard = (props) => {
     versionDescription,
     versionId,
     inputLength,
-    download,
     userCanEditDictionary,
   } = props;
 
@@ -230,7 +229,6 @@ Browse in traditional OCL
                         version={version}
                         key={version.id}
                         showSubModal={showSubModal}
-                        download={download}
                       />
                     ))
                   ) : (
@@ -285,7 +283,6 @@ DictionaryDetailCard.propTypes = {
   handleCreateVersion: PropTypes.func.isRequired,
   handleChange: PropTypes.func.isRequired,
   inputLength: PropTypes.number.isRequired,
-  download: PropTypes.func.isRequired,
   versionDescription: PropTypes.string.isRequired,
   versionId: PropTypes.string.isRequired,
   disableButton: PropTypes.bool.isRequired,

--- a/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryVersionsTable.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { TRADITIONAL_OCL_HOST } from '../../../dictionaryConcepts/components/helperFunction';
+import urlConfig from '../../../../config';
 
 const DictionaryVersionsTable = (version) => {
   const {
@@ -8,7 +9,7 @@ const DictionaryVersionsTable = (version) => {
       id,
       updated_on,
       version_url,
-    }, showSubModal, download,
+    }, showSubModal,
   } = version;
   const DATE_OPTIONS = {
     weekday: 'long', year: 'numeric', month: 'short', day: 'numeric',
@@ -21,7 +22,14 @@ const DictionaryVersionsTable = (version) => {
       <td>
         <a className="btn btn-sm" target="_blank" rel="noopener noreferrer" href={TRADITIONAL_OCL_HOST + version_url}>Browse in OCL</a>
         {' '}
-        <Link className="downloadConcepts btn btn-sm" onClick={download} to="#">Download</Link>
+        <a
+          className="downloadConcepts btn btn-sm"
+          target="_blank"
+          rel="noopener noreferrer"
+          href={`${urlConfig.OCL_API_HOST}${version_url}export/`}
+        >
+          Download
+        </a>
         {' '}
         <Link className="subscription-link btn btn-sm" onClick={() => { showSubModal(version_url); }} to="#">
           Subscription URL

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -353,48 +353,6 @@ describe('DictionaryOverview', () => {
     expect(spyOnHandleHideSub).toHaveBeenCalledTimes(1);
   });
 
-  it('should handle downloading of dictionary concepts', () => {
-    const props = {
-      dictionary: { dictionary },
-      versions: [versions, customVersion],
-      headVersion: [versions],
-      url: '',
-      dictionaryConcepts: [concepts, conceptWithoutDescriptions],
-      showEditModal: jest.fn(),
-      hideSubModal: jest.fn(),
-      showSubModal: jest.fn(),
-      handleRelease: jest.fn(),
-      match: {
-        params: {
-          ownerType: 'testing',
-          owner: 'mochu',
-          type: 'collection',
-          name: 'mochu',
-        },
-      },
-      fetchDictionary: jest.fn(),
-      fetchVersions: jest.fn(),
-      fetchDictionaryConcepts: jest.fn(),
-      download: jest.fn(),
-      createVersion: jest.fn(() => Promise.resolve(true)),
-      error: [],
-      releaseHead: jest.fn(),
-      isReleased: false,
-      loader: false,
-    };
-
-    const wrapper = mount(<Provider store={store}>
-      <MemoryRouter>
-        <DictionaryOverview {...props} />
-      </MemoryRouter>
-    </Provider>);
-    const spy = jest.spyOn(wrapper.find('DictionaryOverview').instance(), 'download');
-    wrapper.instance().forceUpdate();
-    expect(wrapper.find('.downloadConcepts').at(0).exists()).toBe(true);
-    wrapper.find('.downloadConcepts').at(0).simulate('click');
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-
   it('should handle a new version release without error', () => {
     const props = {
       dictionary,


### PR DESCRIPTION
# JIRA TICKET NAME:
[When a dictionary version is released, the download option should produce a file with mappings](https://issues.openmrs.org/browse/OCLOMRS-682)

# Summary:
Mappings should be included in this file. They currently don't seem to be included

- Discussion on [talk](https://talk.openmrs.org/t/developing-the-ocl-for-openmrs-application/17771/1105)
- The download option should not be generating this file on the frontend.
- Find the endpoint that provides this file and simply link to them.
- If they are multiple/ cannot be found, drop this feature from the MVP