### PR TITLE
OCLOMRS-698: A user should be able to bring a newer concept version into their collection to replace the older version

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -72,7 +72,7 @@ export class DictionaryOverview extends Component {
       fetchUsersMembershipStatus(checkMembershipUrl);
     }
 
-    const conceptsUrl = `/${ownerType}/${owner}/collections/${name}/concepts/?includeRetired=true&q=&limit=0&page=1&verbose=true&is_latest_version=true`;
+    const conceptsUrl = `/${ownerType}/${owner}/collections/${name}/concepts/?includeRetired=true&q=&limit=0&page=1&verbose=true`;
     this.props.fetchDictionaryConcepts(conceptsUrl);
   }
 

--- a/src/components/dictionaryConcepts/components/ActionButtons.jsx
+++ b/src/components/dictionaryConcepts/components/ActionButtons.jsx
@@ -12,7 +12,9 @@ const ActionButtons = ({
   version_url,
   retired,
   retireConcept,
+  updateConcept,
   url,
+  is_latest_version: isLatestVersion,
 }) => {
   const dictionaryPathName = localStorage.getItem('dictionaryPathName');
   let showExtra;
@@ -69,6 +71,16 @@ const ActionButtons = ({
       >
         Unretire
       </button>}
+      {!isLatestVersion && showExtra ? (
+        <button
+          className="btn btn-sm mb-1 actionButtons"
+          type="button"
+          id="update"
+          onClick={() => updateConcept(version_url, url)}
+        >
+          Update
+        </button>
+      ) : ''}
     </React.Fragment>
   );
 };
@@ -88,6 +100,8 @@ ActionButtons.propTypes = {
   mappingLimit: PropTypes.number,
   retired: PropTypes.bool,
   retireConcept: PropTypes.func,
+  updateConcept: PropTypes.func,
+  is_latest_version: PropTypes.bool,
 };
 
 ActionButtons.defaultProps = {
@@ -96,6 +110,8 @@ ActionButtons.defaultProps = {
   mappingLimit: null,
   retired: false,
   retireConcept: () => {},
+  updateConcept: () => {},
+  is_latest_version: true,
 };
 
 export default ActionButtons;

--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -25,6 +25,7 @@ const ConceptTable = ({
   showDeleteMappingModal,
   handleDeleteMapping,
   retireConcept,
+  updateConcept,
   isOwner,
   page,
   onPageChange,
@@ -80,6 +81,7 @@ const ConceptTable = ({
               mappingLimit: conceptLimit,
               showDeleteMappingModal,
               retireConcept,
+              updateConcept,
             };
             const username = getUsername();
             const renderButtons = username === concept.owner || (
@@ -109,6 +111,7 @@ ConceptTable.propTypes = {
   handleDeleteMapping: PropTypes.func.isRequired,
   showDeleteMappingModal: PropTypes.func.isRequired,
   retireConcept: PropTypes.func,
+  updateConcept: PropTypes.func,
   isOwner: PropTypes.bool,
   page: PropTypes.number.isRequired,
   onPageChange: PropTypes.func.isRequired,
@@ -118,6 +121,7 @@ ConceptTable.defaultProps = {
   url: '',
   original: {},
   retireConcept: () => {},
+  updateConcept: () => {},
   isOwner: false,
 };
 

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -16,12 +16,14 @@ import {
   paginateConcepts,
   fetchExistingConcept,
   clearAllFilters,
+  updateConceptInCollectionAction,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import {
   removeDictionaryConcept,
   removeConceptMapping,
   retireConcept,
-  addReferenceToCollectionAction, deleteReferenceFromCollectionAction,
+  addReferenceToCollectionAction,
+  deleteReferenceFromCollectionAction,
 } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import { fetchMemberStatus } from '../../../redux/actions/user/index';
 
@@ -57,6 +59,7 @@ export class DictionaryConcepts extends Component {
     addReferenceToCollection: PropTypes.func.isRequired,
     deleteReferenceFromCollection: PropTypes.func.isRequired,
     clearAllFilters: PropTypes.func,
+    updateConceptInCollection: PropTypes.func,
   };
 
   constructor(props) {
@@ -266,6 +269,17 @@ export class DictionaryConcepts extends Component {
     return true;
   };
 
+  updateConcept = (versionUrl, conceptUrl) => {
+    const {
+      updateConceptInCollection,
+      match: {
+        params: { collectionName, type, typeName },
+      },
+    } = this.props;
+
+    updateConceptInCollection(versionUrl, conceptUrl, type, typeName, collectionName);
+  };
+
   setPage = (index) => {
     this.setState({
       page: index,
@@ -351,6 +365,7 @@ export class DictionaryConcepts extends Component {
               openDeleteModal={openDeleteModal}
               closeDeleteModal={this.closeDeleteModal}
               retireConcept={this.handleRetireConcept}
+              updateConcept={this.updateConcept}
               isOwner={this.state.isOwner}
               page={page}
               onPageChange={this.setPage}
@@ -366,6 +381,7 @@ DictionaryConcepts.defaultProps = {
   filteredByClass: [],
   filteredBySource: [],
   clearAllFilters: () => {},
+  updateConceptInCollection: () => {},
 };
 
 export const mapStateToProps = state => ({
@@ -397,5 +413,7 @@ export default connect(
     retireCurrentConcept: retireConcept,
     getOriginalConcept: fetchExistingConcept,
     clearAllFilters,
+    fetchExistingConcept,
+    updateConceptInCollection: updateConceptInCollectionAction,
   },
 )(DictionaryConcepts);

--- a/src/tests/dictionaryConcepts/components/ActionButtons.test.jsx
+++ b/src/tests/dictionaryConcepts/components/ActionButtons.test.jsx
@@ -50,4 +50,33 @@ describe('Test suite for ActionButton', () => {
     wrapper.find('#retireConcept').simulate('click');
     expect(props.showDeleteModal).toBeCalled();
   });
+
+  describe('Update Concept Button', () => {
+    it('should be displayed if the concept we are viewing is not the latest version', () => {
+      wrapper = shallow(<ActionButtons {...props} is_latest_version={false} />);
+      expect(wrapper.exists('#update')).toBeTruthy();
+    });
+
+    it('should not be displayed if the concept we are viewing is the latest version', () => {
+      wrapper = shallow(<ActionButtons {...props} is_latest_version />);
+      expect(wrapper.exists('#update')).toBeFalsy();
+    });
+
+    it('should not be displayed if actionsButtons should not be shown', () => {
+      wrapper = shallow(
+        <ActionButtons {...props} is_latest_version={false} actionButtons={false} />,
+      );
+      expect(wrapper.exists('#update')).toBeFalsy();
+    });
+
+    it('should call updateConcept when clicked', () => {
+      const updateConceptMock = jest.fn();
+      wrapper = shallow(
+        <ActionButtons {...props} is_latest_version={false} updateConcept={updateConceptMock} />,
+      );
+      expect(updateConceptMock).not.toHaveBeenCalled();
+      wrapper.find('#update').simulate('click');
+      expect(updateConceptMock).toHaveBeenCalledWith(props.version_url, props.url);
+    });
+  });
 });

--- a/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
+++ b/src/tests/dictionaryConcepts/container/DictionaryConcepts.test.jsx
@@ -692,6 +692,7 @@ describe('Test suite for dictionary concepts components', () => {
         removeDictionaryConcept: jest.fn(),
         removeConceptMappingAction: jest.fn(),
         searchByName: jest.fn(),
+        updateConceptInCollection: jest.fn(),
         ...retireMockProps,
       };
       wrapper = mount(<Provider store={store}>
@@ -699,6 +700,18 @@ describe('Test suite for dictionary concepts components', () => {
           <DictionaryConcepts {...props} />
         </Router>
       </Provider>);
+    });
+
+    it('should call the updateConceptInCollection prop when updateConcept is called', () => {
+      const versionUrl = '/test/version/url/';
+      const url = '/test/url/';
+      const { type, typeName, collectionName } = props.match.params;
+
+      const instance = wrapper.find('DictionaryConcepts').instance();
+      instance.updateConcept(versionUrl, url);
+      expect(props.updateConceptInCollection).toHaveBeenCalledWith(
+        versionUrl, url, type, typeName, collectionName,
+      );
     });
 
     it('should call the handleRetireConcept method when retiring', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[A user should be able to bring a newer concept version into their collection to replace the older version](https://issues.openmrs.org/browse/OCLOMRS-698)

# Summary:
Currently, the application does not provide a way for users to update concepts in their collections that may not be the latest version.
