### PR TITLE
OCLOMRS-700: Viewing a concept should display the particular concept version, and not merely the latest one

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -69,7 +69,7 @@ const App = () => (
             />
             <Route
               exact
-              path="/:ownerType/:owner/sources/:source/concepts/:conceptId/"
+              path="/:ownerType/:owner/sources/:source/concepts/:conceptId/:version?/"
               component={Authenticate(ViewConcept)}
             />
             <Route

--- a/src/components/dictionaryConcepts/components/ActionButtons.jsx
+++ b/src/components/dictionaryConcepts/components/ActionButtons.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { CUSTOM_SOURCE, TRADITIONAL_OCL_HOST } from './helperFunction';
+import { CUSTOM_SOURCE } from './helperFunction';
 
 const ActionButtons = ({
   actionButtons,
@@ -12,7 +12,6 @@ const ActionButtons = ({
   version_url,
   retired,
   retireConcept,
-  url,
 }) => {
   const dictionaryPathName = localStorage.getItem('dictionaryPathName');
   let showExtra;
@@ -23,7 +22,7 @@ const ActionButtons = ({
   return (
     <React.Fragment>
       <Link
-        to={url}
+        to={version_url}
         className="edit-button-link btn btn-sm mb-1"
       >
         View
@@ -80,7 +79,6 @@ ActionButtons.propTypes = {
   concept_class: PropTypes.string.isRequired,
   showDeleteModal: PropTypes.func.isRequired,
   version_url: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
   handleDeleteMapping: PropTypes.func.isRequired,
   showDeleteMappingModal: PropTypes.func.isRequired,
   display_name: PropTypes.string.isRequired,

--- a/src/components/dictionaryConcepts/components/ViewConcept.jsx
+++ b/src/components/dictionaryConcepts/components/ViewConcept.jsx
@@ -13,6 +13,7 @@ const ViewConcept = (props) => {
       datatype,
       names,
       external_id,
+      uuid,
     },
     qaMappings,
     setMappings,
@@ -28,22 +29,26 @@ const ViewConcept = (props) => {
           </legend>
           <div id="concept-details">
             <div className="row">
-              <div className="col-md-6">
-                <label htmlFor="external-id"><u>OpenMRS UUID (OCL External ID)</u></label>
-                <div id="external-id">{external_id}</div>
-              </div>
-              <div className="col-md-6">
+              <div className="col-md-4">
                 <label htmlFor="id"><u>OCL ID</u></label>
                 <div id="id">{id}</div>
+              </div>
+              <div className="col-md-4">
+                <label htmlFor="version-id"><u>Version ID</u></label>
+                <div id="version-id">{uuid}</div>
+              </div>
+              <div className="col-md-4">
+                <label htmlFor="external-id"><u>OpenMRS UUID (OCL External ID)</u></label>
+                <div id="external-id">{external_id}</div>
               </div>
             </div>
             <br />
             <div className="row">
-              <div className="col-md-6">
+              <div className="col-md-4">
                 <label htmlFor="class"><u>Class</u></label>
                 <div id="class">{concept_class}</div>
               </div>
-              <div className="col-md-6">
+              <div className="col-md-4">
                 <label htmlFor="datatype"><u>Datatype</u></label>
                 <div id="datatype">{datatype}</div>
               </div>

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -6,6 +6,7 @@ import { externalSource, internalSource } from './sources';
 
 export default {
   id: '1468667',
+  uuid: '1234',
   external_id: '146869AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
   concept_class: 'Diagnosis',
   datatype: 'N/A',

--- a/src/tests/dictionaryConcepts/components/ViewConcept.test.jsx
+++ b/src/tests/dictionaryConcepts/components/ViewConcept.test.jsx
@@ -19,6 +19,7 @@ describe('ViewConcept', () => {
     expect(viewConcept.find('#external-id').text()).toEqual(props.concept.external_id);
     expect(viewConcept.find('#id').text()).toEqual(props.concept.id);
     expect(viewConcept.find('#class').text()).toEqual(props.concept.concept_class);
+    expect(viewConcept.find('#version-id').text()).toEqual(props.concept.uuid);
     expect(viewConcept.find('#datatype').text()).toEqual(props.concept.datatype);
     expect(viewConcept.exists('#descriptions')).toBeTruthy();
   });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Viewing a concept should display the particular concept version, and not merely the latest one](https://issues.openmrs.org/browse/OCLOMRS-700)

# Summary:
Currently, viewing a concept displays the latest version of that concept, and not the version in the collection. This is incorrect.
