### PR TITLE
OCLOMRS-531: Search results on the Add CIEL concepts page should be consistent, with the best match by name and ID appearing first

### DIFF
--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -33,7 +33,7 @@ export const fetchFilteredConcepts = (source = 'CIEL', query = '', currentPage =
   } = getState();
 
   const searchQuery = buildPartialSearchQuery(query);
-  let url = `orgs/${source}/sources/${source}/concepts/?${searchQuery}&limit=${conceptLimit}&page=${currentPage}&verbose=true&includeMappings=1`;
+  let url = `orgs/${source}/sources/${source}/concepts/?${searchQuery}&limit=${conceptLimit}&page=${currentPage}&verbose=true&includeMappings=1&sortAsc=name`;
 
   if (datatypeList.length > 0) {
     url = `${url}&datatype=${datatypeList.join(',')}`;


### PR DESCRIPTION
# JIRA TICKET NAME:
[Search results on the Add CIEL concepts page should be consistent, with the best match by name and ID appearing first](https://issues.openmrs.org/browse/OCLOMRS-531)

# Summary:
- I searched for 1268 (which I actually already added to my dictionary, and the first results are 126800
- This is bad behaviour, but I don’t know which it is:
- If something is already in the dictionary, we should still show it in the search results. (Okay to grey it out, or disable the add button.)
- Exact match on concept ID should show be the first result. This may be a back-end fix, but if this is the scenario, please create a ticket to track it. Make it an MVP ticket for now, though we could punt it.