### PR TITLE
OCLOMRS-702: The view dictionary page should not fetch all of a dictionary's concepts

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryContainer.jsx
@@ -4,11 +4,11 @@ import { connect } from 'react-redux';
 import DictionaryDetailCard from './DictionaryDetailCard';
 import Loader from '../../../Loader';
 import {
-  fetchDictionary, fetchVersions, fetchDictionaryConcepts, releaseHead, createVersion,
+  fetchDictionary, fetchVersions, releaseHead, createVersion,
 } from '../../../../redux/actions/dictionaries/dictionaryActionCreators';
 import EditDictionary from './EditDictionary';
 import GeneralModel from './common/GeneralModal';
-import { DIAGNOSIS_CLASS, ORGANIZATIONS, PROCEDURE_CLASS } from '../../../../constants';
+import { ORGANIZATIONS } from '../../../../constants';
 import { getLoggedInUsername } from '../../../../helperFunctions';
 import { fetchMemberStatus } from '../../../../redux/actions/user';
 
@@ -20,7 +20,6 @@ export class DictionaryOverview extends Component {
       }),
     }).isRequired,
     dictionary: propTypes.object.isRequired,
-    dictionaryConcepts: propTypes.array.isRequired,
     versions: propTypes.array.isRequired,
     fetchDictionary: propTypes.func.isRequired,
     loader: propTypes.bool.isRequired,
@@ -71,9 +70,6 @@ export class DictionaryOverview extends Component {
       const checkMembershipUrl = `/orgs/${owner}/members/${getLoggedInUsername()}/`;
       fetchUsersMembershipStatus(checkMembershipUrl);
     }
-
-    const conceptsUrl = `/${ownerType}/${owner}/collections/${name}/concepts/?includeRetired=true&q=&limit=0&page=1&verbose=true&is_latest_version=true`;
-    this.props.fetchDictionaryConcepts(conceptsUrl);
   }
 
   componentDidUpdate = (prevProps) => {
@@ -158,22 +154,6 @@ export class DictionaryOverview extends Component {
     const {
       url, showSubModal, versionId, openGeneralModal,
     } = this.state;
-    const cielConcepts = this.props.dictionaryConcepts.filter(
-      concept => concept.owner === 'CIEL',
-    ).length.toString();
-    const customConcepts = this.props.dictionaryConcepts.filter(
-      concept => concept.owner !== 'CIEL',
-    ).length.toString();
-    const diagnosisConcepts = this.props.dictionaryConcepts.filter(
-      concept => concept.concept_class === DIAGNOSIS_CLASS,
-    ).length.toString();
-    const procedureConcepts = this.props.dictionaryConcepts.filter(
-      concept => concept.concept_class === PROCEDURE_CLASS,
-    ).length.toString();
-    const otherConcepts = this.props.dictionaryConcepts.filter(
-      concept => concept.concept_class !== DIAGNOSIS_CLASS
-      && concept.concept_class !== PROCEDURE_CLASS,
-    ).length.toString();
     const headVersion = this.props.versions.filter(version => version.id === 'HEAD')[0];
     const headVersionIdObj = Object.assign({}, headVersion);
     const inputLength = versionId.length;
@@ -190,11 +170,6 @@ export class DictionaryOverview extends Component {
               <DictionaryDetailCard
                 dictionary={this.props.dictionary}
                 versions={this.props.versions}
-                cielConcepts={cielConcepts}
-                customConcepts={customConcepts}
-                diagnosisConcepts={diagnosisConcepts}
-                procedureConcepts={procedureConcepts}
-                otherConcepts={otherConcepts}
                 headVersion={headVersionIdObj}
                 showEditModal={this.handleShow}
                 hideSubModal={this.handleHideSub}
@@ -235,7 +210,6 @@ export class DictionaryOverview extends Component {
 }
 export const mapStateToProps = state => ({
   dictionary: state.dictionaries.dictionary,
-  dictionaryConcepts: state.concepts.dictionaryConcepts,
   loader: state.dictionaries.loading || state.dictionaries.fetchingDictionary,
   versions: state.dictionaries.versions,
   error: state.dictionaries.error,
@@ -246,7 +220,6 @@ export const mapStateToProps = state => ({
 export default connect(
   mapStateToProps,
   {
-    fetchDictionaryConcepts,
     fetchDictionary,
     fetchVersions,
     createVersion,

--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -4,7 +4,11 @@ import { Link } from 'react-router-dom';
 import DictionaryVersionsTable from './DictionaryVersionsTable';
 import ReleaseVersionModal from './common/ReleaseVersionModal';
 import SubscriptionModal from './common/SubscriptionModal';
-import { TRADITIONAL_OCL_HOST } from '../../../dictionaryConcepts/components/helperFunction';
+import {
+  CIEL_SOURCE_URL,
+  TRADITIONAL_OCL_HOST,
+} from '../../../dictionaryConcepts/components/helperFunction';
+import { findLocale } from './common/Languages';
 
 const DictionaryDetailCard = (props) => {
   const {
@@ -19,15 +23,12 @@ const DictionaryDetailCard = (props) => {
       owner_url,
       short_code,
       default_locale,
+      supported_locales,
       url,
+      references,
     },
     versions,
     showEditModal,
-    customConcepts,
-    cielConcepts,
-    diagnosisConcepts,
-    procedureConcepts,
-    otherConcepts,
     hideSubModal,
     showSubModal,
     subModal,
@@ -56,6 +57,12 @@ const DictionaryDetailCard = (props) => {
 
   const traditionalUrl = `${TRADITIONAL_OCL_HOST}${url}`;
   const releasedVersions = versions.filter(version => version.released === true);
+
+  const conceptReferences = references ? references.filter(({ reference_type }) => reference_type === 'concepts') : [];
+  const cielConceptCount = conceptReferences.filter(
+    ({ expression }) => expression.includes(CIEL_SOURCE_URL),
+  ).length;
+  const otherConceptCount = conceptReferences.length - cielConceptCount;
 
   return (
     <div className="dictionaryDetails">
@@ -123,6 +130,18 @@ Dictionary
               {' '}
               {new Date(updated_on).toLocaleDateString('en-US', DATE_OPTIONS)}
             </p>
+            <p className="paragraph">
+              <b>Preferred Language</b>
+              :
+              {' '}
+              {findLocale(default_locale).label}
+            </p>
+            <p className="paragraph">
+              <b>Other Languages</b>
+              :
+              {' '}
+              <span>{supported_locales ? supported_locales.map(locale => findLocale(locale).label).join(', ') : 'None'}</span>
+            </p>
             {userCanEditDictionary && (
               <button
                 type="button"
@@ -140,41 +159,19 @@ Dictionary
               <b>Total Concepts</b>
 :
               {' '}
-              {Number(customConcepts) + Number(cielConcepts)}
-            </p>
-            <p className="points">
-              <b>Custom Concepts</b>
-:
-              {' '}
-              {customConcepts}
+              {conceptReferences.length}
             </p>
             <p className="points">
               <b>From CIEL</b>
 :
               {' '}
-              {cielConcepts}
-            </p>
-            <p>
-              <b>By class</b>
-:
+              {cielConceptCount}
             </p>
             <p className="points">
-              <b>Diagnosis</b>
-:
+              <b>Other Concepts</b>
+              :
               {' '}
-              {diagnosisConcepts}
-            </p>
-            <p className="points">
-              <b>Procedure</b>
-:
-              {' '}
-              {procedureConcepts}
-            </p>
-            <p className="points">
-              <b>Others</b>
-:
-              {' '}
-              {otherConcepts}
+              {otherConceptCount}
             </p>
             <Link
               className="btn btn-primary m-3"
@@ -268,11 +265,6 @@ DictionaryDetailCard.propTypes = {
   dictionary: PropTypes.object.isRequired,
   versions: PropTypes.array.isRequired,
   showEditModal: PropTypes.func.isRequired,
-  customConcepts: PropTypes.string.isRequired,
-  cielConcepts: PropTypes.string.isRequired,
-  diagnosisConcepts: PropTypes.string.isRequired,
-  procedureConcepts: PropTypes.string.isRequired,
-  otherConcepts: PropTypes.string.isRequired,
   hideSubModal: PropTypes.func.isRequired,
   showSubModal: PropTypes.func.isRequired,
   subModal: PropTypes.bool.isRequired,

--- a/src/tests/Dictionary/DictionaryContainer.test.jsx
+++ b/src/tests/Dictionary/DictionaryContainer.test.jsx
@@ -33,7 +33,14 @@ describe('DictionaryOverview', () => {
   const defaultProps = {
     dictionary,
     versions: [],
-    match: {},
+    match: {
+      params: {
+        ownerType: 'testing',
+        owner: 'tester',
+        type: 'collection',
+        name: 'chris',
+      },
+    },
     dictionaryConcepts: [],
     fetchDictionary: jest.fn(),
     loader: false,
@@ -150,9 +157,22 @@ describe('DictionaryOverview', () => {
       </MemoryRouter>
     </Provider>);
     expect(wrapper.find('#headingDict')).toHaveLength(1);
-    expect(wrapper.find('.paragraph')).toHaveLength(5);
+    expect(wrapper.find('.paragraph')).toHaveLength(7);
     expect(wrapper.find('tr')).toHaveLength(2);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('it should display none under supported languages of there are no additional supported locales', () => {
+    const props = {
+      ...defaultProps,
+      dictionary: { ...dictionary, description: null, supported_locales: null },
+    };
+    const wrapper = mount(<Provider store={store}>
+      <MemoryRouter>
+        <DictionaryOverview {...props} />
+      </MemoryRouter>
+    </Provider>);
+    expect(wrapper.find('.paragraph').at(5).find('span').text()).toEqual('None');
   });
 
   it('should handle HEAD version release', () => {
@@ -309,7 +329,7 @@ describe('DictionaryOverview', () => {
 
   it('should handle opening/closing of subscription modal', () => {
     const props = {
-      dictionary: { dictionary },
+      dictionary,
       versions: [versions, customVersion],
       headVersion: [versions],
       url: '',
@@ -648,7 +668,6 @@ describe('DictionaryOverview', () => {
   it('should test mapStateToProps', () => {
     const initialState = {
       concepts: {
-        loading: false,
         dictionaryConcepts: [],
         paginatedConcepts: [],
         filteredSources: [],
@@ -656,9 +675,21 @@ describe('DictionaryOverview', () => {
       },
       dictionaries: {
         dictionary,
+        versions: [],
+        error: 'error',
+        isReleased: false,
+        loading: false,
+        fetchingDictionary: true,
       },
       user: { userIsMember: false },
     };
-    expect(mapStateToProps(initialState).dictionaryConcepts).toEqual([]);
+    expect(mapStateToProps(initialState)).toEqual({
+      dictionary,
+      loader: true,
+      versions: [],
+      error: 'error',
+      isReleased: false,
+      userIsOrganizationMember: false,
+    });
   });
 });

--- a/src/tests/__mocks__/dictionaries.js
+++ b/src/tests/__mocks__/dictionaries.js
@@ -29,7 +29,7 @@ const dictionary = {
   created_by: 'chriskala',
   updated_by: 'chriskala',
   extras: null,
-  references: [],
+  references: [{ reference_type: 'concepts', expression: '/orgs/CIEL/sources/CIEL/mappings/5d53f0a52ac7120143e8ea59/1/' }],
   active_concepts: 0,
   active_mappings: 0,
 };


### PR DESCRIPTION
# JIRA TICKET NAME:
[The view dictionary page should not fetch all a dictionary's concepts](https://issues.openmrs.org/browse/OCLOMRS-702)

# Summary:
This page currently fetches the verbose dictionary with all mappings and concepts.
This information is used to display a concept breakdown.

This presents a performance issue for this page if a dictionary contains a large number of concepts.