### PR TITLE
OCLOMRS-705: Search results on the Add CIEL concepts page should be consistent regardless of any action take by the user

### DIFF
--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -33,7 +33,7 @@ export const fetchFilteredConcepts = (source = 'CIEL', query = '', currentPage =
   } = getState();
 
   const searchQuery = buildPartialSearchQuery(query);
-  let url = `orgs/${source}/sources/${source}/concepts/?${searchQuery}&limit=${conceptLimit}&page=${currentPage}&verbose=true&includeMappings=1`;
+  let url = `orgs/${source}/sources/${source}/concepts/?${searchQuery}&limit=${conceptLimit}&page=${currentPage}&verbose=true&includeMappings=1&sortAsc=name`;
 
   if (datatypeList.length > 0) {
     url = `${url}&datatype=${datatypeList.join(',')}`;


### PR DESCRIPTION
# JIRA TICKET NAME:
[Search results on the Add CIEL concepts page should be consistent regardless of any action take by the user](https://issues.openmrs.org/browse/OCLOMRS-705)

# Summary:
Addressing part of [OCLOMRS-705](https://issues.openmrs.org/browse/OCLOMRS-705)
- If something is already in the dictionary, we should still show it in the search results. (Okay to grey it out, or disable the add button.)