### PR TITLE
OCLOMRS-703: Remove isErrored action creator

### DIFF
--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -1,2 +1,13 @@
+import { notify } from 'react-notify-toast';
+
 export const getLoggedInUsername = () => localStorage.getItem('username');
 export const buildPartialSearchQuery = query => query.replace(new RegExp(' ', 'g'), '* ');
+export const checkErrorMessage = (error, message) => {
+  if (error && error.response && error.response.data && error.response.data.detail) {
+    notify.show(error.response.data.detail, 'error', 3000);
+  } else if (error && error.response && error.response.data) {
+    notify.show(error.response.data, 'error', 3000);
+  } else {
+    notify.show(message, 'error', 3000);
+  }
+};

--- a/src/redux/actions/bulkConcepts/index.js
+++ b/src/redux/actions/bulkConcepts/index.js
@@ -2,7 +2,6 @@ import { notify } from 'react-notify-toast';
 import instance from '../../../config/axiosConfig';
 import {
   isSuccess,
-  isErrored,
   isFetching,
   clear,
 } from '../globalActionCreators';
@@ -10,12 +9,12 @@ import {
   ADD_EXISTING_BULK_CONCEPTS,
   FETCH_CONCEPT_SOURCES,
   CLEAR_SOURCE_CONCEPTS,
-  IS_LOADING,
 } from '../types';
 import { recursivelyFetchConceptMappings } from '../concepts/addBulkConcepts';
 import { MAPPINGS_RECURSION_DEPTH } from '../../../components/dictionaryConcepts/components/helperFunction';
 import { deleteNotification, upsertNotification } from '../notifications';
 import { ADDING_CONCEPTS_WARNING_MESSAGE } from '../../../constants';
+import { checkErrorMessage } from '../../../helperFunctions';
 
 export const addExistingBulkConcepts = conceptData => async (dispatch) => {
   const { url, data, conceptIdList: fromConceptIds } = conceptData;
@@ -42,11 +41,8 @@ export const addExistingBulkConcepts = conceptData => async (dispatch) => {
       notify.show(`${payload.data.length} Concept(s) Added`, 'success', 4000);
     }
   } catch (error) {
-    if (error && error.response) {
-      notify.show(error.response.data.detail, 'error', 3000);
-    } else {
-      notify.show('Failed to add concepts. Please retry', 'error', 3000);
-    }
+    const defaultMessage = 'Failed to add concepts. Please retry';
+    checkErrorMessage(error, defaultMessage);
   } finally {
     dispatch(deleteNotification(`adding-${fromConceptIds}`));
   }
@@ -71,9 +67,8 @@ export const addDictionaryReference = (conceptUrl, ownerUrl, dictionaryId) => as
     };
     payload = await instance.put(url, references);
   } catch (error) {
-    return notify.show(
-      'There was an error in referencing concepts in the new dictionary', 'error', 3000,
-    );
+    const defaultMessage = 'There was an error in referencing concepts in the new dictionary';
+    return checkErrorMessage(error, defaultMessage);
   }
   return dispatch(isSuccess(payload, ADD_EXISTING_BULK_CONCEPTS));
 };
@@ -86,7 +81,8 @@ export const fetchConceptSources = () => async (dispatch) => {
     dispatch(isSuccess(response.data, FETCH_CONCEPT_SOURCES));
     dispatch(isFetching(false));
   } catch (error) {
-    dispatch(isErrored(error.response.data, FETCH_CONCEPT_SOURCES));
+    const defaultMessage = 'Failed to fetch source concepts';
+    checkErrorMessage(error, defaultMessage);
     dispatch(isFetching(false));
   }
 };

--- a/src/redux/actions/concepts/ConceptActionCreators.js
+++ b/src/redux/actions/concepts/ConceptActionCreators.js
@@ -6,10 +6,6 @@ const fetchConcepts = payload => ({
   type: FETCH_CONCEPTS,
   payload,
 });
-const isErrored = payload => ({
-  type: FETCH_CONCEPTS,
-  payload,
-});
 const isFetching = payload => ({
   type: IS_FETCHING,
   payload,
@@ -23,5 +19,4 @@ export const clearConcepts = () => ({
 export {
   fetchConcepts,
   isFetching,
-  isErrored,
 };

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -21,7 +21,6 @@ import {
   CREATE_NEW_CONCEPT,
   ADD_CONCEPT_TO_DICTIONARY,
   FETCH_EXISTING_CONCEPT,
-  FETCH_EXISTING_CONCEPT_ERROR,
   UPDATE_CONCEPT,
   EDIT_CONCEPT_ADD_DESCRIPTION,
   EDIT_CONCEPT_REMOVE_ONE_DESCRIPTION,
@@ -44,14 +43,13 @@ import {
 import {
   isFetching,
   getDictionaryConcepts,
-  isErrored,
   isSuccess,
 } from '../globalActionCreators/index';
 
 import instance from '../../../config/axiosConfig';
 import api from '../../api';
 import { recursivelyFetchConceptMappings } from './addBulkConcepts';
-import { buildPartialSearchQuery } from '../../../helperFunctions';
+import { buildPartialSearchQuery, checkErrorMessage } from '../../../helperFunctions';
 
 export const createNewName = () => (dispatch) => {
   const payload = uuid();
@@ -436,10 +434,8 @@ export const fetchExistingConcept = conceptUrl => async (dispatch) => {
     dispatch(prepopulateAnswers(answers));
     dispatch(prePopulateSets(sets));
   } catch (error) {
-    notify.show('Could not retrieve concept details', 'error', 3000);
-    if (error.response) {
-      dispatch(isErrored(error.response.data, FETCH_EXISTING_CONCEPT_ERROR));
-    }
+    const defaultMessage = 'Could not retrieve concept details';
+    checkErrorMessage(error, defaultMessage);
   }
   dispatch(isFetching(false));
 };
@@ -523,7 +519,6 @@ export const updateConcept = (conceptUrl, data, history, source, concept, collec
 } for ${
   Object.keys(error.response.data).toString()
 }`, 'error', 3000);
-      dispatch(isErrored(error.response.data, FETCH_EXISTING_CONCEPT_ERROR));
     } else {
       notify.show('An error occurred when updating the concept. Please retry.', 'error', 2000);
     }

--- a/src/redux/actions/concepts/specificConceptAction.js
+++ b/src/redux/actions/concepts/specificConceptAction.js
@@ -1,6 +1,7 @@
 import instance from '../../../config/axiosConfig';
 
-import { isErrored, fetchConcepts, isFetching } from './ConceptActionCreators';
+import { fetchConcepts, isFetching } from './ConceptActionCreators';
+import { checkErrorMessage } from '../../../helperFunctions';
 
 const fetchConceptsActionTypes = (
   owner,
@@ -21,13 +22,8 @@ const fetchConceptsActionTypes = (
     dispatch(isFetching(false));
   } catch (error) {
     dispatch(isFetching(false));
-    if (error.response) {
-      dispatch(isErrored(error.response.data));
-      dispatch(isFetching(false));
-    } else {
-      dispatch(isErrored("Request can't be made"));
-      dispatch(isFetching(false));
-    }
+    const defaultMessage = "Request can't be made";
+    checkErrorMessage(error, defaultMessage);
   }
 };
 export default fetchConceptsActionTypes;

--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -5,7 +5,6 @@ import {
   isSuccess,
   isFetching,
   dictionaryIsSuccess,
-  isErrored,
   removeConcept,
   removeMapping,
   fetchingVersions,
@@ -21,6 +20,7 @@ import {
 import { filterPayload } from '../../reducers/util';
 import { addDictionaryReference } from '../bulkConcepts';
 import api from '../../api';
+import { checkErrorMessage } from '../../../helperFunctions';
 import axiosInstance from '../../../config/axiosConfig';
 
 export const showNetworkError = () => (
@@ -80,7 +80,8 @@ export const fetchDictionaries = () => (dispatch) => {
       dispatch(isFetching(false));
     })
     .catch((error) => {
-      error.response ? dispatch(isErrored(error.response.data)):
+      const defaultMessage = 'Could not retrieve the dictionaries';
+      checkErrorMessage(error, defaultMessage);
       showNetworkError();
       dispatch(isFetching(false));
     });
@@ -97,8 +98,8 @@ export const searchDictionaries = searchItem => async (dispatch) => {
   }
   catch (error) {
     dispatch(isFetching(false));
-    error.response ? dispatch(isErrored(error.response.data)):
-    showNetworkError();
+    const defaultMessage = 'Could not retrieve the dictionaries';
+    checkErrorMessage(error, defaultMessage);
   }
 };
 
@@ -192,8 +193,11 @@ export const fetchDictionaryConcepts = data => (dispatch) => {
       dispatch(isFetching(false));
       })
       .catch((error) => {
-        error.response ? dispatch(isErrored(error.response.data)):
-        showNetworkError();
+        if (error && error.response) {
+          notify.show('Could not retrieve dictionary concept', 'error', 3000);
+        } else {
+          showNetworkError();
+        }
         dispatch(isFetching(false));
       });
 };
@@ -298,7 +302,6 @@ export const retireConcept = (conceptUrl, retire) => async (dispatch) => {
     notify.show(`Concept successfully ${retiredMessage}`, 'success', 3000);
     return response.data;
   } catch (error) {
-    error && error.response && error.response.data && dispatch(isErrored(error.response.data));
     notify.show(`Failed to ${retiredMessage} the concept`, 'error', 3000);
     return null;
   }

--- a/src/redux/actions/dictionaries/dictionaryActions.js
+++ b/src/redux/actions/dictionaries/dictionaryActions.js
@@ -37,11 +37,6 @@ export const isSuccess = payload => ({
   payload,
 });
 
-export const isErrored = payload => ({
-  type: FETCHING_DICTIONARIES,
-  payload,
-});
-
 export const isFetching = payload => ({
   type: IS_FETCHING,
   payload,

--- a/src/redux/actions/globalActionCreators/index.js
+++ b/src/redux/actions/globalActionCreators/index.js
@@ -10,11 +10,6 @@ export const isSuccess = (payload, type) => ({
   payload,
 });
 
-export const isErrored = (payload, type) => ({
-  type,
-  payload,
-});
-
 export const isFetching = payload => ({
   type: IS_FETCHING,
   payload,

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -66,7 +66,6 @@ export const ADD_TO_CLASS_LIST = '[concept] add_to_class_list';
 export const FETCH_FILTERED_CONCEPTS = '[concept] fetch_filtered_concepts';
 export const PREVIEW_CONCEPT = '[concept] preview_concept';
 export const FETCH_EXISTING_CONCEPT = '[concept] fetch_existing_concept';
-export const FETCH_EXISTING_CONCEPT_ERROR = '[concept] fetch_existing_concept_error';
 export const CLEAR_PREVIOUS_CONCEPT = '[concept] clear_previous_concept';
 export const UPDATE_CONCEPT = '[concept] update_concept';
 export const EDIT_CONCEPT_ADD_DESCRIPTION = '[concept] edit_concept_add_description';

--- a/src/redux/actions/user/index.js
+++ b/src/redux/actions/user/index.js
@@ -1,15 +1,13 @@
 import { notify } from 'react-notify-toast';
 import axios from 'axios';
 import { union } from 'lodash';
-import { isSuccess, isFetching, isErrored } from '../globalActionCreators';
+import { isSuccess, isFetching } from '../globalActionCreators';
 import {
   GET_USER,
   FETCH_USER_DICTIONARY,
   FETCH_USER_ORGANIZATION,
   CLEAR_DICTIONARY,
   USER_IS_MEMBER,
-  USER_IS_NOT_MEMBER,
-  NETWORK_ERROR,
   SET_DICTIONARIES_OWNED_BY_A_USERS_ORGS,
 } from '../types';
 import instance from '../../../config/axiosConfig';
@@ -32,7 +30,6 @@ export const fetchUser = (username, props) => async (dispatch) => {
     }
     const message = 'An error occurred with your internet connection, please fix it and try reloading the page.';
     notify.show(message, 'error', 3000);
-    dispatch(isErrored(message, NETWORK_ERROR));
   }
 };
 
@@ -109,9 +106,12 @@ export const fetchMemberStatus = url => async (dispatch) => {
   try {
     response = await instance.get(url);
   } catch (error) {
-    if (error.response.status === 403 || error.response.status === 404) {
+    if (error.response.status === 404) {
       dispatch(isFetching(false));
-      return dispatch(isErrored(false, USER_IS_NOT_MEMBER));
+      notify.show('User not found', 'error', 3000);
+    } else if (error.response.status === 403) {
+      dispatch(isFetching(false));
+      notify.show('You have no access', 'error', 3000);
     }
   }
   if (response.data === '' && response.status === 204) {

--- a/src/redux/reducers/ConceptReducers.js
+++ b/src/redux/reducers/ConceptReducers.js
@@ -14,7 +14,6 @@ import {
   CREATE_NEW_CONCEPT,
   ADD_CONCEPT_TO_DICTIONARY,
   FETCH_EXISTING_CONCEPT,
-  FETCH_EXISTING_CONCEPT_ERROR,
   EDIT_CONCEPT_ADD_DESCRIPTION,
   EDIT_CONCEPT_REMOVE_ONE_DESCRIPTION,
   CLEAR_PREVIOUS_CONCEPT,
@@ -234,10 +233,6 @@ export default (state = initialState, action) => {
           ...state.existingConcept,
           names: removeItem(action.payload, state.existingConcept.names),
         },
-      };
-    case FETCH_EXISTING_CONCEPT_ERROR:
-      return {
-        ...state,
       };
     case PRE_POPULATE_ANSWERS: {
       return {

--- a/src/tests/Dashboard/action/ConceptsActionCreator.test.js
+++ b/src/tests/Dashboard/action/ConceptsActionCreator.test.js
@@ -1,5 +1,5 @@
 import { FETCH_CONCEPTS } from '../../../redux/actions/types';
-import { isErrored, fetchConcepts } from '../../../redux/actions/concepts/ConceptActionCreators';
+import { fetchConcepts } from '../../../redux/actions/concepts/ConceptActionCreators';
 
 describe('Test for successful concept fetch', () => {
   const response = {
@@ -12,8 +12,5 @@ describe('Test for successful concept fetch', () => {
 
   it('should return action type and payload', () => {
     expect(fetchConcepts(response)).toEqual(responseData);
-  });
-  it('Test for errors while fetching concepts', () => {
-    expect(isErrored(response)).toEqual(responseData);
   });
 });

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -23,7 +23,6 @@ import {
   EDIT_CONCEPT_CREATE_NEW_NAMES,
   EDIT_CONCEPT_REMOVE_ONE_NAME,
   UPDATE_CONCEPT,
-  FETCH_EXISTING_CONCEPT_ERROR,
   REMOVE_CONCEPT,
   REMOVE_MAPPING,
   ADD_SELECTED_ANSWERS,
@@ -787,7 +786,7 @@ describe('Testing Edit concept actions ', () => {
     expect(result).toEqual(existingConcept);
   });
 
-  it('should handle error in FETCH_EXISTING_CONCEPT_ERROR for update concept', () => {
+  it('should handle error for update concept', () => {
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();
       request.respondWith({
@@ -802,7 +801,6 @@ describe('Testing Edit concept actions ', () => {
 
     const expectedActions = [
       { type: IS_FETCHING, payload: true },
-      { type: FETCH_EXISTING_CONCEPT_ERROR, payload: 'bad request' },
       { type: IS_FETCHING, payload: false },
     ];
 
@@ -873,18 +871,16 @@ describe('Testing Edit concept actions ', () => {
     });
   });
 
-  it('should handle error in FETCH_EXISTING_CONCEPT_ERROR for fetching exing concepts', () => {
+  it('should handle error for fetching exing concepts', () => {
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();
       request.respondWith({
         status: 400,
-        response: 'bad request',
       });
     });
 
     const expectedActions = [
       { type: IS_FETCHING, payload: true },
-      { type: FETCH_EXISTING_CONCEPT_ERROR, payload: 'bad request' },
       { type: IS_FETCHING, payload: false },
     ];
 
@@ -910,6 +906,42 @@ describe('Testing Edit concept actions ', () => {
     const conceptUrl = '/orgs/EthiopiaNHDD/sources/HMIS-Indicators/concepts/C1.1.1.1/';
     return store.dispatch(fetchExistingConcept(conceptUrl)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('fetchExistingConcept should return an notify error from the db data message ', () => {
+    const notifyMock = jest.fn();
+    notify.show = notifyMock;
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        response: { data: 'Request failed' },
+      });
+    });
+
+    const store = mockStore({ payload: {} });
+
+    return store.dispatch(fetchExistingConcept()).catch(() => {
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+      expect(notifyMock).toHaveBeenCalledWith('Request failed', 'error', 3000);
+    });
+  });
+
+  it('fetchExistingConcept should return an notify error from the db data detail message ', () => {
+    const notifyMock = jest.fn();
+    notify.show = notifyMock;
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.reject({
+        response: { data: { detail: 'Request failed' } },
+      });
+    });
+
+    const store = mockStore({ payload: {} });
+
+    return store.dispatch(fetchExistingConcept()).catch(() => {
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+      expect(notifyMock).toHaveBeenCalledWith('Request failed', 'error', 3000);
     });
   });
 

--- a/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/reducer/dictionaryConcept.test.js
@@ -18,7 +18,6 @@ import {
   FETCH_NEXT_CONCEPTS,
   TOTAL_CONCEPT_COUNT,
   FETCH_EXISTING_CONCEPT,
-  FETCH_EXISTING_CONCEPT_ERROR,
   EDIT_CONCEPT_ADD_DESCRIPTION,
   EDIT_CONCEPT_REMOVE_ONE_DESCRIPTION,
   CLEAR_PREVIOUS_CONCEPT,
@@ -339,18 +338,6 @@ describe('Test suite for single dictionary concepts', () => {
           { uuid: action.payload },
         ],
       },
-    });
-  });
-  it('should handle FETCH_EXISTING_CONCEPT_ERROR', () => {
-    action = {
-      type: FETCH_EXISTING_CONCEPT_ERROR,
-    };
-
-    deepFreeze(state);
-    deepFreeze(action);
-
-    expect(reducer(state, action)).toEqual({
-      ...state,
     });
   });
   it('should handle EDIT_CONCEPT_REMOVE_ONE_DESCRIPTION', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Remove isErrored action creator](https://issues.openmrs.org/browse/OCLOMRS-703)

# Summary:
Some parts of the code use isErrored to dispatch an error response into state, causing unexpected crashes. These parts should be refactored to notify the user of the error, but not add it to state.

Dispatching a zero value(eg. empty list) would make sense.