### PR TITLE
OCLOMRS-712: The coded datatype should only be an option on pages where we can add answers to a concept

### DIFF
--- a/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
+++ b/src/components/dictionaryConcepts/components/CreateConceptForm.jsx
@@ -41,6 +41,7 @@ const CreateConceptForm = (props) => {
         && map.map_type !== MAP_TYPE.conceptSet,
   );
   const descriptions = props.existingConcept.descriptions || props.description;
+  const showCodedOption = concept === CONCEPT_CLASS.question || concept === '' || isEditConcept;
 
   return (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
@@ -205,7 +206,7 @@ const CreateConceptForm = (props) => {
             <option>Rule</option>
             <option>Structured-Numeric</option>
             <option>Complex</option>
-            <option>Coded</option>
+            {showCodedOption && <option>Coded</option>}
           </select>
             </div>
           </div>


### PR DESCRIPTION
# JIRA TICKET NAME:
[The coded datatype should only be an option on pages where we can add answers to a concept](https://issues.openmrs.org/browse/OCLOMRS-712)

# Summary:
Concepts with this datatype should be able to have answers. For MVP, we will only make this option available on the Add Q-A concepts and add another type of concept pages.