### PR TITLE
OCLOMRS-709: Remove unnecessary API calls on the add bulk concepts page

### DIFF
--- a/src/components/bulkConcepts/addBulkConcepts.jsx
+++ b/src/components/bulkConcepts/addBulkConcepts.jsx
@@ -8,18 +8,13 @@ import {
   Input,
 } from 'reactstrap';
 import Loader from '../Loader';
-import fetchSourceConcepts, { addExistingBulkConcepts, isConceptValid, fetchConceptSources } from '../../redux/actions/bulkConcepts';
+import { addExistingBulkConcepts, isConceptValid } from '../../redux/actions/bulkConcepts';
 import Header from './container/Header';
 import ResultModal from './component/addBulkConceptResultModal';
 
 export class AddBulkConcepts extends Component {
   static propTypes = {
-    fetchSourceConcepts: PropTypes.func.isRequired,
-    fetchConceptSources: PropTypes.func.isRequired,
     addExistingBulkConcepts: PropTypes.func.isRequired,
-    sourceConcepts: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.string,
-    })).isRequired,
     conceptSources: PropTypes.array.isRequired,
     match: PropTypes.shape({
       params: PropTypes.shape({
@@ -43,11 +38,6 @@ export class AddBulkConcepts extends Component {
     this.sourceUrl = 'orgs/CIEL/sources/CIEL/';
   }
 
-  componentDidMount() {
-    this.props.fetchConceptSources();
-    this.props.fetchSourceConcepts(this.sourceUrl);
-  }
-
   handleSelected = (selected) => {
     const { conceptIds } = this.state;
     this.setState({ conceptIds: conceptIds ? `${conceptIds}, ${selected.id}` : selected.id });
@@ -55,7 +45,6 @@ export class AddBulkConcepts extends Component {
 
   handleCielClick = (e) => {
     this.sourceUrl = e.target.value;
-    this.props.fetchSourceConcepts(this.sourceUrl);
     this.reset();
   };
 
@@ -209,5 +198,5 @@ export const mapStateToProps = state => ({
 });
 export default connect(
   mapStateToProps,
-  { fetchSourceConcepts, addExistingBulkConcepts, fetchConceptSources },
+  { addExistingBulkConcepts },
 )(AddBulkConcepts);

--- a/src/redux/actions/bulkConcepts/index.js
+++ b/src/redux/actions/bulkConcepts/index.js
@@ -7,7 +7,6 @@ import {
   clear,
 } from '../globalActionCreators';
 import {
-  FETCH_SOURCE_CONCEPTS,
   ADD_EXISTING_BULK_CONCEPTS,
   FETCH_CONCEPT_SOURCES,
   CLEAR_SOURCE_CONCEPTS,
@@ -17,20 +16,6 @@ import { recursivelyFetchConceptMappings } from '../concepts/addBulkConcepts';
 import { MAPPINGS_RECURSION_DEPTH } from '../../../components/dictionaryConcepts/components/helperFunction';
 import { deleteNotification, upsertNotification } from '../notifications';
 import { ADDING_CONCEPTS_WARNING_MESSAGE } from '../../../constants';
-
-const fetchSourceConcepts = url => async (dispatch) => {
-  dispatch(clear(CLEAR_SOURCE_CONCEPTS));
-  dispatch(isSuccess(true, IS_LOADING));
-  try {
-    const response = await instance.get(`${url}concepts/?limit=0`);
-    dispatch(isSuccess(response.data, FETCH_SOURCE_CONCEPTS));
-    dispatch(isSuccess(false, IS_LOADING));
-  } catch (error) {
-    dispatch(isErrored(error.response.data, FETCH_SOURCE_CONCEPTS));
-    dispatch(isSuccess(false, IS_LOADING));
-  }
-};
-export default fetchSourceConcepts;
 
 export const addExistingBulkConcepts = conceptData => async (dispatch) => {
   const { url, data, conceptIdList: fromConceptIds } = conceptData;

--- a/src/tests/bulkConcepts/actions/index.test.js
+++ b/src/tests/bulkConcepts/actions/index.test.js
@@ -5,12 +5,10 @@ import thunk from 'redux-thunk';
 
 import instance from '../../../config/axiosConfig';
 import {
-  FETCH_SOURCE_CONCEPTS,
   IS_FETCHING,
   ADD_EXISTING_BULK_CONCEPTS,
   CLEAR_SOURCE_CONCEPTS,
   FETCH_CONCEPT_SOURCES,
-  IS_LOADING,
 } from '../../../redux/actions/types';
 import
 fetchCielConcepts,
@@ -52,25 +50,6 @@ describe('Test suite for source concepts actions', () => {
       .then(() => expect(store.getActions()).toEqual(returnedAction));
   });
 
-  it('should dispatch FETCH_SOURCE_CONCEPTS  action type on response from server', () => {
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent();
-      request.respondWith({
-        status: 200,
-        response: [{ cielConcepts: { cielConcepts } }],
-      });
-    });
-
-    const returnedAction = [
-      { type: CLEAR_SOURCE_CONCEPTS },
-      { type: IS_LOADING, payload: true },
-      { type: FETCH_SOURCE_CONCEPTS, payload: [{ cielConcepts: { cielConcepts } }] },
-      { type: IS_LOADING, payload: false },
-    ];
-    const store = mockStore({});
-    return store.dispatch(fetchCielConcepts())
-      .then(() => expect(store.getActions()).toEqual(returnedAction));
-  });
   it('should dispatch ADD_EXISTING_BULK_CONCEPTS  action type on response from server', () => {
     const notifyMock = jest.fn();
     notify.show = notifyMock;
@@ -122,27 +101,6 @@ describe('Test suite for source concepts actions', () => {
 
     const store = mockStore({});
     return store.dispatch(addExistingBulkConcepts(conceptData))
-      .then(() => {
-        expect(store.getActions()).toEqual(returnedAction);
-      });
-  });
-  it('should dispatch an error message when a response is errored', () => {
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent();
-      request.respondWith({
-        status: 400,
-        response: 'could not complete this request',
-      });
-    });
-
-    const returnedAction = [
-      { type: CLEAR_SOURCE_CONCEPTS },
-      { type: IS_LOADING, payload: true },
-      { type: FETCH_SOURCE_CONCEPTS, payload: 'could not complete this request' },
-      { type: IS_LOADING, payload: false },
-    ];
-    const store = mockStore({});
-    return store.dispatch(fetchCielConcepts())
       .then(() => {
         expect(store.getActions()).toEqual(returnedAction);
       });

--- a/src/tests/bulkConcepts/addBulkConcepts.test.jsx
+++ b/src/tests/bulkConcepts/addBulkConcepts.test.jsx
@@ -23,7 +23,6 @@ describe('Add Bulk Concepts', () => {
   const props = {
     fetchSourceConcepts: jest.fn(),
     addExistingBulkConcepts: jest.fn(),
-    fetchConceptSources: jest.fn(),
     sourceConcepts: mockConcepts,
     conceptSources: [{ id: 1, name: 'testSource', url: '/org/testSource/' },
       { id: 2, name: 'testSource', url: '/org/testSource/' }],


### PR DESCRIPTION
# JIRA TICKET NAME:
[Remove unnecessary API calls on the add bulk concepts page](https://issues.openmrs.org/browse/OCLOMRS-709)

# Summary:
The API call to retrieve the concept sources in the bulk concept page was unnecessary and thus removed.