### PR TITLE
OCLOMRS-715: Updating a dictionary should update both the source and collection

### DIFF
--- a/src/redux/actions/dictionaries/dictionaryActionCreators.js
+++ b/src/redux/actions/dictionaries/dictionaryActionCreators.js
@@ -216,20 +216,33 @@ export const releaseHead = (url, data) => (dispatch) => {
       notify.show("Network Error. Please try again later!", 'error', 6000);
       });
 };
-  export const editDictionary = (url, data) => dispatch => {
-    return api.dictionaries
-      .editDictionary(url, data)
-      .then(payload => {
-        notify.show(
-          'Successfully updated dictionary',
-          'success', 6000,
-        );
-        return dispatch(editDictionarySuccess(payload));
-      })
-      .catch(error => {
-        error.response ? notify.show(`${error.response.data.__all__[0]}`, 'error', 6000) :
+  export const editDictionary = (url, data) => async dispatch => {
+    const editSource = async (url, data) =>  {
+      try {
+        await api.sources.edit(url, data);
+        return true;
+      } catch (error) {
+        notify.hide();
+        notify.show('An error occurred while updating the source. Please retry', 'error', 3000);
+        return false;
+      }
+    };
+    try {
+      const updateSourceResult = await editSource(url.replace('collections', 'sources', data));
+      if (!updateSourceResult) {
+        return
+      }
+
+      const payload =  await api.dictionaries.editDictionary(url, data);
+      notify.show(
+        'Successfully updated dictionary',
+        'success', 6000,
+      );
+      return dispatch(editDictionarySuccess(payload));
+    } catch (error) {
+      error.response ? notify.show(`${error.response.data.__all__[0]}`, 'error', 6000) :
         showNetworkError();
-      })
+    }
 };
 
 export const editMapping = (url, data, source) => dispatch => {

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -1,6 +1,9 @@
 import instance from '../config/axiosConfig';
 
 export default {
+  sources: {
+    edit: (url, data) => instance.put(url, data),
+  },
   dictionaries: {
     list: {
       fromAnOrganization: organizationUrl => instance.get(`${organizationUrl}collections/?limit=0&verbose=true`),

--- a/src/tests/Dashboard/action/api.test.js
+++ b/src/tests/Dashboard/action/api.test.js
@@ -374,6 +374,38 @@ describe('mappings', () => {
   });
 });
 
+describe('sources', () => {
+  describe('edit', () => {
+    beforeEach(() => {
+      moxios.install(instance);
+    });
+
+    afterEach(() => {
+      moxios.uninstall(instance);
+    });
+
+    it('should call the edit source endpoint with the right data', async () => {
+      const sourceUrl = '/test/source/url/';
+      const data = {};
+      let requestUrl;
+      let requestData;
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        requestUrl = request.url;
+        requestData = request.config.data;
+        request.respondWith({
+          status: 200,
+        });
+      });
+
+      await api.sources.edit(sourceUrl, data);
+      expect(requestUrl).toContain(`${sourceUrl}`);
+      expect(requestData).toEqual(JSON.stringify(data));
+    });
+  });
+});
+
 describe('dictionaries', () => {
   describe('addReferencesToCollection', () => {
     beforeEach(() => {

--- a/src/tests/Dashboard/action/dictionaryAction.test.js
+++ b/src/tests/Dashboard/action/dictionaryAction.test.js
@@ -47,6 +47,7 @@ import dictionaries, { sampleDictionaries } from '../../__mocks__/dictionaries';
 import versions, { HeadVersion } from '../../__mocks__/versions';
 import concepts, { sampleConcept, sampleRetiredConcept } from '../../__mocks__/concepts';
 import { notify } from 'react-notify-toast';
+import api from '../../../redux/api';
 
 jest.mock('react-notify-toast');
 
@@ -370,6 +371,7 @@ describe('Test suite for dictionary actions', () => {
   });
 
   it('should dispatch EDIT_DICTIONARY_SUCCESS on success response', () => {
+    api.sources.edit = jest.fn().mockResolvedValueOnce(true);
     const dictionary = dictionaries;
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();
@@ -387,6 +389,7 @@ describe('Test suite for dictionary actions', () => {
     });
   });
   it('should dispatch nothing on edit dictionary failure response', () => {
+    api.sources.edit = jest.fn().mockResolvedValueOnce(true);
     const dictionary = dictionaries;
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();
@@ -407,6 +410,7 @@ describe('Test suite for dictionary actions', () => {
   });
 
   it('should display error message when offline', () => {
+    api.sources.edit = jest.fn().mockResolvedValueOnce(true);
     const dictionary = dictionaries;
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();
@@ -418,6 +422,21 @@ describe('Test suite for dictionary actions', () => {
     const store = mockStore({ payload: {} });
     return store.dispatch(editDictionary('/dictionary-url', dictionary)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('editDictionary should notify a user when an error occurs while editing the source', () => {
+    const dictionary = dictionaries;
+    const notifyMock = jest.fn();
+    const editDictionaryMock = jest.fn();
+    api.dictionaries.editDictionary = editDictionaryMock;
+    api.sources.edit = jest.fn().mockRejectedValueOnce(false);
+    notify.show = notifyMock;
+
+    const store = mockStore({ payload: {} });
+    return store.dispatch(editDictionary('/dictionary-url', dictionary)).then(() => {
+      expect(notifyMock).toHaveBeenCalledWith('An error occurred while updating the source. Please retry', 'error', 3000);
+      expect(editDictionaryMock).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[Updating a dictionary should update both the source and collection](https://issues.openmrs.org/browse/OCLOMRS-715)

# Summary:
Updating a dictionary currently only updates the collection and not the source as well. This creates a situation where the two repositories are out of sync.
