### PR TITLE
OCLOMRS-718: Update README link to wiki to point to the actual wiki a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ npm run watch:css
 
 ## How to contribute to this project?
  - Please read [OpenMRS wiki](https://wiki.openmrs.org/) for awareness on the code of conduct used in OpenMRS organization 
- - And to get you started with the project please use the OpenMRS-OCL [documentation](https://docs.google.com/document/d/1R_Fgr5SBl4xFNJgj6yMJNVY63b5H_OUqM55o1GFqFKs/edit#heading=h.rc908wooykzg)
+ - And to get you started with the project please use the OpenMRS-OCL [documentation](https://wiki.openmrs.org/x/1gJiDQ)
 
 ## Support
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[Update README link to wiki to point to the actual wiki and not the Roadmap document](https://issues.openmrs.org/browse/OCLOMRS-718)

# Summary:
This PR update README link to wiki to point to the actual wiki and not the Roadmap document