### PR TITLE
OCLOMRS-723: Add a little delay before making the request for concepts on the dictionary concepts page

### DIFF
--- a/src/helperFunctions.js
+++ b/src/helperFunctions.js
@@ -11,3 +11,5 @@ export const checkErrorMessage = (error, message) => {
     notify.show(message, 'error', 3000);
   }
 };
+
+export const delay = ms => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -49,7 +49,7 @@ import {
 import instance from '../../../config/axiosConfig';
 import api from '../../api';
 import { recursivelyFetchConceptMappings } from './addBulkConcepts';
-import { buildPartialSearchQuery, checkErrorMessage } from '../../../helperFunctions';
+import { buildPartialSearchQuery, checkErrorMessage, delay } from '../../../helperFunctions';
 
 export const createNewName = () => (dispatch) => {
   const payload = uuid();
@@ -412,6 +412,7 @@ export const createNewConcept = (data, dataUrl, ownerType = 'users', owner = loc
   } finally {
     if (createdConcept) {
       await dispatch(addConceptToDictionary(createdConcept.id, dataUrl));
+      await delay(1000);
       dispatch(isSuccess(createdConcept, CREATE_NEW_CONCEPT));
     }
   }
@@ -508,6 +509,7 @@ export const updateConcept = (conceptUrl, data, history, source, concept, collec
 
     dispatch(isSuccess(response.data, UPDATE_CONCEPT));
     notify.show('Concept successfully updated', 'success', 3000);
+    await delay(1000);
     dispatch(isFetching(false));
     return response.data;
   } catch (error) {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Add a little delay before making the request for concepts on the dictionary concepts page](https://issues.openmrs.org/browse/OCLOMRS-723)

# Summary:
For context;
Upon updating of a custom concepts in edit screen, returning to view concepts page did not show the concept at all. I had to click and unclick the custom concept filter to show. (MVP)

We noticed this has once again popped up of late. This appears to come from a ~slow update of the search index after a concept is added to the collection(on the backend). We’ll have to add a small delay before making that request to allow the update to complete.

https://talk.openmrs.org/t/developing-the-ocl-for-openmrs-application/17771/1240