### PR TITLE
OCLOMRS-724: Fix Broken OCL Client Build

### DIFF
--- a/src/tests/bulkConcepts/components/PreviewCard.test.js
+++ b/src/tests/bulkConcepts/components/PreviewCard.test.js
@@ -48,7 +48,8 @@ describe('Test suite for ActionButton in BulkConceptsPage component', () => {
       <PreviewCard {...newProps} />
     </Router>);
     expect(wrapper.length).toEqual(1);
-    expect(wrapper.find('Cell').getElement(0).props.original).toEqual(newProps.concept.mappings[0]);
+    expect(wrapper.find('MappingPreview TrComponent.-odd TdComponent').at(1).text()).toEqual(newProps.concept.mappings[0].to_concept_name);
+    expect(wrapper.find('MappingPreview TrComponent.-odd TdComponent').at(3).text()).toEqual(newProps.concept.mappings[0].to_concept_code);
   });
 
   it('should render with mappings containing set members', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Fix Broken OCL Client Build](https://issues.openmrs.org/browse/OCLOMRS-724)

# Summary:
A test in one of the suites uses an implementation detail in one of the dependencies, causing inconsistent behaviour when testing in different environments. This eliminates that dependency while maintaining the test.