### PR TITLE
OCLOMRS-719: Allow users to sort concepts on the add ciel concepts page and in their collection

### DIFF
--- a/src/components/bulkConcepts/component/ConceptTable.jsx
+++ b/src/components/bulkConcepts/component/ConceptTable.jsx
@@ -18,7 +18,7 @@ const ConceptTable = ({
     );
   }
   return (
-    <div className="row col-12 custom-concept-list">
+    <div className="row custom-concept-list">
       <ReactTable
         data={concepts}
         currentPage={currentPage}

--- a/src/components/bulkConcepts/component/SearchBar.jsx
+++ b/src/components/bulkConcepts/component/SearchBar.jsx
@@ -4,8 +4,7 @@ import PropTypes from 'prop-types';
 const SearchBar = ({
   handleChange, searchInput, handleSearch,
 }) => (
-  <div className="row search-container">
-    <div className="concept-search-wrapper col-9 col-md-5 col-sm-8">
+    <div className="concept-search-wrapper col-6">
       <i className="fa fa-search search-icons" aria-hidden="true" />
       <form onSubmit={handleSearch} id="submit-search-form">
         <input
@@ -21,7 +20,6 @@ const SearchBar = ({
         <button type="submit" className="search-button"><i className="fas fa-arrow-right" /></button>
       </form>
     </div>
-  </div>
 );
 
 SearchBar.propTypes = {

--- a/src/components/bulkConcepts/component/SortBar.jsx
+++ b/src/components/bulkConcepts/component/SortBar.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SortBar = (
+  {
+    sortCriteria,
+    setSortCriteria,
+    sortDirection,
+    setSortDirection,
+    sortOptions,
+  },
+) => (
+  <div className="col-6" id="sort-bar">
+    <span className="label">Sort by:</span>
+    <select name="sort-bar-criteria" value={sortCriteria} className="custom-select" onChange={event => setSortCriteria(event.target.value)}>
+      {
+        sortOptions.map(([value, text]) => (
+          <option
+            key={value}
+            value={value}
+          >
+            {text}
+          </option>
+        ))
+      }
+    </select>
+    <select name="sort-bar-direction" value={sortDirection} className="custom-select" onChange={event => setSortDirection(event.target.value)}>
+      <option value="sortAsc">Ascending</option>
+      <option value="sortDesc">Descending</option>
+    </select>
+  </div>
+);
+
+SortBar.propTypes = {
+  setSortCriteria: PropTypes.func.isRequired,
+  sortCriteria: PropTypes.string.isRequired,
+  setSortDirection: PropTypes.func.isRequired,
+  sortDirection: PropTypes.string.isRequired,
+  sortOptions: PropTypes.array,
+};
+
+SortBar.defaultProps = {
+  sortOptions: [
+    ['lastUpdate', 'Last update'], ['name', 'Name'], ['id', 'ID'], ['bestMatch', 'Best match'],
+  ],
+};
+
+export default SortBar;

--- a/src/components/bulkConcepts/container/BulkConceptsPage.jsx
+++ b/src/components/bulkConcepts/container/BulkConceptsPage.jsx
@@ -13,10 +13,13 @@ import {
   fetchFilteredConcepts,
   setCurrentPage,
   clearAllBulkFilters,
+  setSortDirectionAction,
+  setSortCriteriaAction,
 } from '../../../redux/actions/concepts/addBulkConcepts';
 import { conceptsProps } from '../../dictionaryConcepts/proptypes';
 import { MIN_CHARACTERS_WARNING, MILLISECONDS_TO_SHOW_WARNING } from '../../../redux/reducers/generalSearchReducer';
 import { INTERNAL_MAPPING_DEFAULT_SOURCE } from '../../dictionaryConcepts/components/helperFunction';
+import SortBar from '../component/SortBar';
 
 export class BulkConceptsPage extends Component {
   static propTypes = {
@@ -44,6 +47,10 @@ export class BulkConceptsPage extends Component {
     datatypeList: PropTypes.array,
     classList: PropTypes.array,
     clearAllBulkFilters: PropTypes.func,
+    sortCriteria: PropTypes.string,
+    sortDirection: PropTypes.string,
+    setSortCriteria: PropTypes.func,
+    setSortDirection: PropTypes.func,
   };
 
   static defaultProps = {
@@ -51,6 +58,10 @@ export class BulkConceptsPage extends Component {
     datatypeList: [],
     classList: [],
     clearAllBulkFilters: () => {},
+    sortCriteria: 'name',
+    sortDirection: 'sortAsc',
+    setSortCriteria: () => {},
+    setSortDirection: () => {},
   };
 
   constructor(props) {
@@ -80,8 +91,9 @@ export class BulkConceptsPage extends Component {
 
   componentDidUpdate(prevProps) {
     const { searchingOn } = this.state;
-    const { currentPage } = this.props;
-    if (currentPage !== prevProps.currentPage) {
+    const { currentPage, sortCriteria, sortDirection } = this.props;
+    // eslint-disable-next-line max-len
+    if (currentPage !== prevProps.currentPage || sortCriteria !== prevProps.sortCriteria || sortDirection !== prevProps.sortDirection) {
       if (searchingOn) {
         return this.searchOption();
       }
@@ -182,6 +194,10 @@ export class BulkConceptsPage extends Component {
       addConcept: addedConcept,
       datatypeList,
       classList,
+      sortCriteria,
+      sortDirection,
+      setSortCriteria,
+      setSortDirection,
     } = this.props;
     const {
       datatypeInput, classInput, searchInput, conceptLimit,
@@ -206,11 +222,19 @@ export class BulkConceptsPage extends Component {
             clearAllBulkFilters={this.clearBulkFilters}
           />
           <div className="col-10 col-md-9 bulk-concept-wrapper custom-full-width">
-            <SearchBar
-              handleSearch={this.handleSearch}
-              handleChange={this.handleChange}
-              searchInput={searchInput}
-            />
+            <div className="row search-container">
+              <SearchBar
+                handleSearch={this.handleSearch}
+                handleChange={this.handleChange}
+                searchInput={searchInput}
+              />
+              <SortBar
+                sortCriteria={sortCriteria}
+                setSortCriteria={setSortCriteria}
+                sortDirection={sortDirection}
+                setSortDirection={setSortDirection}
+              />
+            </div>
             <ConceptTable
               concepts={concepts}
               loading={loading}
@@ -238,6 +262,8 @@ export const mapStateToProps = ({ bulkConcepts, concepts }) => ({
   ...bulkConcepts,
   datatypeList: bulkConcepts.datatypeList,
   classList: bulkConcepts.classList,
+  sortCriteria: bulkConcepts.sortCriteria,
+  sortDirection: bulkConcepts.sortDirection,
 });
 
 export default connect(
@@ -249,5 +275,7 @@ export default connect(
     fetchFilteredConcepts,
     setCurrentPage,
     clearAllBulkFilters,
+    setSortCriteria: setSortCriteriaAction,
+    setSortDirection: setSortDirectionAction,
   },
 )(BulkConceptsPage);

--- a/src/components/dictionaryConcepts/components/ConceptTable.jsx
+++ b/src/components/dictionaryConcepts/components/ConceptTable.jsx
@@ -31,7 +31,7 @@ const ConceptTable = ({
   onPageSizeChange,
   fetchData,
 }) => (
-  <div className="row col-12 custom-concept-list">
+  <div className="row custom-concept-list">
     <RemoveConcept
       collectionName={locationPath.collectionName}
       conceptOwner={locationPath.typeName}

--- a/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
+++ b/src/components/dictionaryConcepts/containers/DictionaryConcepts.jsx
@@ -16,6 +16,8 @@ import {
   filterByClass,
   fetchExistingConcept,
   clearAllFilters,
+  setSortCriteriaAction,
+  setSortDirectionAction,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import {
   removeDictionaryConcept,
@@ -24,6 +26,7 @@ import {
   addReferenceToCollectionAction, deleteReferenceFromCollectionAction,
 } from '../../../redux/actions/dictionaries/dictionaryActionCreators';
 import { fetchMemberStatus } from '../../../redux/actions/user/index';
+import SortBar from '../../bulkConcepts/component/SortBar';
 
 export class DictionaryConcepts extends Component {
   static propTypes = {
@@ -55,6 +58,10 @@ export class DictionaryConcepts extends Component {
     addReferenceToCollection: PropTypes.func.isRequired,
     deleteReferenceFromCollection: PropTypes.func.isRequired,
     clearAllFilters: PropTypes.func,
+    sortCriteria: PropTypes.string,
+    sortDirection: PropTypes.string,
+    setSortCriteria: PropTypes.func,
+    setSortDirection: PropTypes.func,
   };
 
   constructor(props) {
@@ -79,13 +86,22 @@ export class DictionaryConcepts extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     const {
-      filteredByClass: prevFilteredByClass, filteredBySource: prevFilteredBySource,
+      filteredByClass: prevFilteredByClass,
+      filteredBySource: prevFilteredBySource,
+      sortCriteria: prevSortCriteria,
+      sortDirection: prevSortDirection,
     } = prevProps;
-    const { filteredByClass, filteredBySource } = this.props;
+    const {
+      filteredByClass,
+      filteredBySource,
+      sortCriteria,
+      sortDirection,
+    } = this.props;
     const { searchInput: prevSearchTerm } = prevState;
     const { searchInput: searchTerm } = this.state;
 
-    if (prevFilteredByClass !== filteredByClass || prevFilteredBySource !== filteredBySource) {
+    // eslint-disable-next-line max-len
+    if (prevFilteredByClass !== filteredByClass || prevFilteredBySource !== filteredBySource || prevSortCriteria !== sortCriteria || prevSortDirection !== sortDirection) {
       this.setPage(0, true);
     } else if (prevSearchTerm !== searchTerm && searchTerm.length === 0) {
       this.setPage(0, true);
@@ -114,13 +130,15 @@ export class DictionaryConcepts extends Component {
       match: {
         params: { collectionName, type, typeName },
       },
+      sortCriteria,
+      sortDirection,
     } = this.props;
 
     const { searchInput, page, conceptLimit } = this.state;
     const query = `${searchInput.trim()}*`;
 
     this.props.fetchDictionaryConcepts(
-      type, typeName, collectionName, query, conceptLimit, page + 1,
+      type, typeName, collectionName, query, conceptLimit, page + 1, sortCriteria, sortDirection,
     );
   }
 
@@ -297,6 +315,10 @@ export class DictionaryConcepts extends Component {
       userIsMember,
       filteredByClass,
       filteredBySource,
+      sortCriteria,
+      sortDirection,
+      setSortCriteria,
+      setSortDirection,
     } = this.props;
 
     const { page } = this.state;
@@ -342,11 +364,19 @@ export class DictionaryConcepts extends Component {
             clearAllFilters={this.clearAllFilters}
           />
           <div className="col-12 col-md-9 custom-full-width">
-            <SearchBar
-              handleSearch={this.handleSearchByName}
-              handleChange={this.handleChange}
-              searchInput={searchInput}
-            />
+            <div className="row search-container">
+              <SearchBar
+                handleSearch={this.handleSearchByName}
+                handleChange={this.handleChange}
+                searchInput={searchInput}
+              />
+              <SortBar
+                sortCriteria={sortCriteria}
+                setSortCriteria={setSortCriteria}
+                sortDirection={sortDirection}
+                setSortDirection={setSortDirection}
+              />
+            </div>
             <ConceptTable
               concepts={myConcepts}
               loading={loading}
@@ -378,6 +408,10 @@ DictionaryConcepts.defaultProps = {
   filteredByClass: [],
   filteredBySource: [],
   clearAllFilters: () => {},
+  sortCriteria: 'name',
+  sortDirection: 'sortAsc',
+  setSortCriteria: () => {},
+  setSortDirection: () => {},
 };
 
 export const mapStateToProps = state => ({
@@ -389,6 +423,8 @@ export const mapStateToProps = state => ({
   dictionaries: state.dictionaries.dictionary,
   userIsMember: state.user.userIsMember,
   originalConcept: state.concepts.existingConcept,
+  sortCriteria: state.concepts.sortCriteria,
+  sortDirection: state.concepts.sortDirection,
 });
 
 export default connect(
@@ -405,5 +441,7 @@ export default connect(
     retireCurrentConcept: retireConcept,
     getOriginalConcept: fetchExistingConcept,
     clearAllFilters,
+    setSortCriteria: setSortCriteriaAction,
+    setSortDirection: setSortDirectionAction,
   },
 )(DictionaryConcepts);

--- a/src/redux/actions/concepts/addBulkConcepts/index.js
+++ b/src/redux/actions/concepts/addBulkConcepts/index.js
@@ -12,6 +12,8 @@ import {
   SET_NEXT_PAGE,
   SET_CURRENT_PAGE,
   CLEAR_BULK_FILTERS,
+  SET_SORT_CRITERIA,
+  SET_SORT_DIRECTION,
 } from '../../types';
 import api from '../../../api';
 import {
@@ -29,11 +31,11 @@ export const fetchFilteredConcepts = (source = 'CIEL', query = '', currentPage =
 ) => {
   dispatch(isFetching(true));
   const {
-    bulkConcepts: { datatypeList, classList },
+    bulkConcepts: { datatypeList, classList, sortCriteria = 'name', sortDirection = 'sortAsc' },
   } = getState();
 
   const searchQuery = buildPartialSearchQuery(query);
-  let url = `orgs/${source}/sources/${source}/concepts/?${searchQuery}&limit=${conceptLimit}&page=${currentPage}&verbose=true&includeMappings=1`;
+  let url = `orgs/${source}/sources/${source}/concepts/?${searchQuery}&${sortDirection}=${sortCriteria}&limit=${conceptLimit}&page=${currentPage}&verbose=true&includeMappings=1`;
 
   if (datatypeList.length > 0) {
     url = `${url}&datatype=${datatypeList.join(',')}`;
@@ -60,6 +62,14 @@ export const addToFilterList = (item, type) => (dispatch) => {
 
 export const clearAllBulkFilters = (filterType) => (dispatch) => {
   dispatch({ type: CLEAR_BULK_FILTERS, payload: filterType });
+};
+
+export const setSortCriteriaAction = criteria => (dispatch) => {
+  dispatch({ type: SET_SORT_CRITERIA, payload: criteria });
+};
+
+export const setSortDirectionAction = direction => (dispatch) => {
+  dispatch({ type: SET_SORT_DIRECTION, payload: direction });
 };
 
 export const previewConcept = id => (dispatch, getState) => {

--- a/src/redux/actions/concepts/dictionaryConcepts.js
+++ b/src/redux/actions/concepts/dictionaryConcepts.js
@@ -39,6 +39,8 @@ import {
   PRE_POPULATE_SETS,
   UNPOPULATE_PRE_POPULATED_SETS,
   UNPOPULATE_SET, CLEAR_FILTERS,
+  CHANGE_SORT_CRITERIA,
+  CHANGE_SORT_DIRECTION,
 } from '../types';
 import {
   isFetching,
@@ -102,11 +104,13 @@ export const fetchDictionaryConcepts = (
   query = '*',
   limit = 0,
   page = 1,
+  sortCriteria = 'lastUpdate',
+  sortDirection = 'sortDesc',
 ) => async (dispatch, getState) => {
   dispatch(isFetching(true));
 
   const searchQuery = buildPartialSearchQuery(query);
-  let url = `${conceptType}/${conceptOwner}/collections/${conceptName}/concepts/?q=${searchQuery}&limit=${limit}&page=${page}&verbose=true&includeMappings=1&sortDesc=lastUpdate`;
+  let url = `${conceptType}/${conceptOwner}/collections/${conceptName}/concepts/?q=${searchQuery}&limit=${limit}&page=${page}&verbose=true&includeMappings=1&${sortDirection}=${sortCriteria}`;
   const filterBySource = getState().concepts.filteredBySource;
   const filterByClass = getState().concepts.filteredByClass;
 
@@ -545,4 +549,12 @@ export const unretireMapping = url => async (dispatch) => {
     dispatch(isFetching(false));
     return null;
   }
+};
+
+export const setSortCriteriaAction = criteria => (dispatch) => {
+  dispatch({ type: CHANGE_SORT_CRITERIA, payload: criteria });
+};
+
+export const setSortDirectionAction = direction => (dispatch) => {
+  dispatch({ type: CHANGE_SORT_DIRECTION, payload: direction });
 };

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -62,6 +62,8 @@ export const FETCH_BULK_CONCEPTS = '[concept] fetch_bulk_concepts';
 export const ADD_EXISTING_BULK_CONCEPTS = '[concept] add_existing_bulk_concepts';
 export const ADD_TO_DATATYPE_LIST = '[concept] add_to_datatype_list';
 export const CLEAR_BULK_FILTERS = '[bulk concept] clear bulk filters';
+export const SET_SORT_CRITERIA = '[bulk concept] set sort criteria';
+export const SET_SORT_DIRECTION = '[bulk concept] set sort direction';
 export const ADD_TO_CLASS_LIST = '[concept] add_to_class_list';
 export const FETCH_FILTERED_CONCEPTS = '[concept] fetch_filtered_concepts';
 export const PREVIEW_CONCEPT = '[concept] preview_concept';
@@ -79,5 +81,7 @@ export const SET_CURRENT_PAGE = '[page] current_page';
 export const IS_LOADING = '[ui] loader_spinning';
 export const UN_POPULATE_THIS_ANSWER = '[concept] unpopulate an answer';
 export const UNPOPULATE_SET = '[concept] unpopulate a set';
+export const CHANGE_SORT_CRITERIA = '[dictionary concepts] change sort criteria';
+export const CHANGE_SORT_DIRECTION = '[dictionary concepts] change sort direction';
 
 export const SET_DICTIONARIES_OWNED_BY_A_USERS_ORGS = '[dictionaries] set dictionaries owned by a user\'s orgs';

--- a/src/redux/reducers/ConceptReducers.js
+++ b/src/redux/reducers/ConceptReducers.js
@@ -34,6 +34,8 @@ import {
   REPLACE_CONCEPT,
   UNPOPULATE_SET,
   CLEAR_FILTERS,
+  CHANGE_SORT_CRITERIA,
+  CHANGE_SORT_DIRECTION,
 } from '../actions/types';
 import {
   filterList,
@@ -72,6 +74,8 @@ const initialState = {
   selectedSets: [{
     frontEndUniqueKey: 'intialKey',
   }],
+  sortCriteria: 'name',
+  sortDirection: 'sortAsc',
 };
 
 export default (state = initialState, action) => {
@@ -141,6 +145,10 @@ export default (state = initialState, action) => {
         ...state,
         dictionaryConcepts: action.payload,
       };
+    case CHANGE_SORT_CRITERIA:
+      return { ...state, sortCriteria: action.payload };
+    case CHANGE_SORT_DIRECTION:
+      return { ...state, sortDirection: action.payload };
     case CREATE_NEW_NAMES:
       return {
         ...state,

--- a/src/redux/reducers/bulkConceptReducer.js
+++ b/src/redux/reducers/bulkConceptReducer.js
@@ -8,6 +8,8 @@ import {
   SET_NEXT_PAGE,
   SET_CURRENT_PAGE,
   CLEAR_BULK_FILTERS,
+  SET_SORT_CRITERIA,
+  SET_SORT_DIRECTION,
 } from '../actions/types';
 import { normalizeList } from './util';
 import { classes as classList, DATA_TYPES as dataTypesList } from '../../components/dictionaryConcepts/components/helperFunction';
@@ -20,6 +22,8 @@ const userInitialState = {
   datatypeList: [],
   classList: [],
   currentPage: 1,
+  sortCriteria: 'name',
+  sortDirection: 'sortAsc',
 };
 const bulkConcepts = (state = userInitialState, action) => {
   switch (action.type) {
@@ -73,6 +77,10 @@ const bulkConcepts = (state = userInitialState, action) => {
         case FILTER_TYPES.CLASSES: return { ...state, classList: [] };
         default: return state;
       }
+    case SET_SORT_CRITERIA:
+      return { ...state, sortCriteria: action.payload };
+    case SET_SORT_DIRECTION:
+      return { ...state, sortDirection: action.payload };
     default:
       return state;
   }

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -138,3 +138,7 @@
 .no-wrap {
   white-space: nowrap;
 }
+
+.ReactTable {
+  width: 100%;
+}

--- a/src/styles/bulk_concepts.scss
+++ b/src/styles/bulk_concepts.scss
@@ -253,3 +253,19 @@
   max-height: 40rem;
   overflow: auto;
 }
+
+#sort-bar {
+  text-align: end;
+  vertical-align: middle;
+
+  .custom-select {
+    width: unset;
+    background-color: transparent;
+    border-width: .5px;
+    margin-left: .3rem;
+  }
+
+  .label {
+    margin: 0 .8rem;
+  }
+}

--- a/src/tests/Dashboard/reducer/conceptReducer.test.js
+++ b/src/tests/Dashboard/reducer/conceptReducer.test.js
@@ -16,7 +16,9 @@ import {
   PRE_POPULATE_SETS,
   UNPOPULATE_PRE_POPULATED_SETS,
   REPLACE_CONCEPT,
-  UNPOPULATE_SET
+  UNPOPULATE_SET,
+  CHANGE_SORT_CRITERIA,
+  CHANGE_SORT_DIRECTION,
 } from '../../../redux/actions/types';
 import concepts, { multipleConceptsMockStore } from '../../__mocks__/concepts';
 import { replaceConcept } from '../../../redux/actions/dictionaries/dictionaryActions';
@@ -48,6 +50,8 @@ const initialState = {
   selectedSets: [{
     frontEndUniqueKey: 'intialKey',
   }],
+  sortCriteria: 'name',
+  sortDirection: 'sortAsc',
 };
 describe('Test suite for concepts reducer', () => {
   it('should return the initial state', () => {
@@ -334,4 +338,17 @@ describe('Test suite for concepts reducer', () => {
       .toEqual(expected);
   });
 
+  it('should set the right sort criteria', () => {
+    let state = reducer(initialState, { type: 'init' });
+    expect(state.sortCriteria).toEqual(initialState.sortCriteria);
+    state = reducer(state, { type: CHANGE_SORT_CRITERIA, payload: 'id' });
+    expect(state.sortCriteria).toEqual('id');
+  });
+
+  it('should set the right sort direction', () => {
+    let state = reducer(initialState, { type: 'init' });
+    expect(state.sortDirection).toEqual(initialState.sortDirection);
+    state = reducer(state, { type: CHANGE_SORT_DIRECTION, payload: 'sortDesc' });
+    expect(state.sortDirection).toEqual('sortDesc');
+  });
 });

--- a/src/tests/bulkConcepts/actions/bulkConcept.test.js
+++ b/src/tests/bulkConcepts/actions/bulkConcept.test.js
@@ -15,6 +15,8 @@ import {
   SET_NEXT_PAGE,
   SET_PERVIOUS_PAGE,
   CLEAR_BULK_FILTERS,
+  SET_SORT_CRITERIA,
+  SET_SORT_DIRECTION,
 } from '../../../redux/actions/types';
 import {
   addToFilterList,
@@ -24,7 +26,7 @@ import {
   setCurrentPage,
   setNextPage,
   setPreviousPage, recursivelyFetchConceptMappings,
-  clearAllBulkFilters,
+  clearAllBulkFilters, setSortDirectionAction, setSortCriteriaAction,
 } from '../../../redux/actions/concepts/addBulkConcepts';
 import concepts, { mockConceptStore } from '../../__mocks__/concepts';
 import mappings from '../../__mocks__/mappings';
@@ -499,5 +501,17 @@ describe('test suite for addBulkConcepts synchronous action creators', () => {
     const expectedActions = [{ type: PREVIEW_CONCEPT, payload: { id: 123 } }];
     await store.dispatch(previewConcept(123));
     expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it('setSortCriteriaAction should dispatch the correct action type', () => {
+    const mock = jest.fn();
+    setSortCriteriaAction('criteria')(mock);
+    expect(mock).toHaveBeenCalledWith({ type: SET_SORT_CRITERIA, payload: 'criteria' });
+  });
+
+  it('setSortDirectionAction should dispatch the correct action type', () => {
+    const mock = jest.fn();
+    setSortDirectionAction('direction')(mock);
+    expect(mock).toHaveBeenCalledWith({ type: SET_SORT_DIRECTION, payload: 'direction' });
   });
 });

--- a/src/tests/bulkConcepts/components/SortBar.test.jsx
+++ b/src/tests/bulkConcepts/components/SortBar.test.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import SortBar from '../../../components/bulkConcepts/component/SortBar';
+
+describe('SortBar', () => {
+  const setSortCriteria = jest.fn();
+  const setSortDirection = jest.fn();
+  let sortBar;
+
+  beforeEach(() => {
+    sortBar = mount(
+      <SortBar
+        setSortCriteria={setSortCriteria}
+        setSortDirection={setSortDirection}
+        sortCriteria="id"
+        sortDirection="sortAsc"
+      />,
+    );
+
+    setSortCriteria.mockClear();
+    setSortDirection.mockClear();
+  });
+
+  afterEach(() => {
+    sortBar.unmount();
+  });
+
+  it('should call setSortDirection when the sort direction changes', () => {
+    expect(setSortDirection).not.toHaveBeenCalled();
+    sortBar.find('select[name="sort-bar-direction"]').simulate('change', { target: { value: 'sortDesc' } });
+    expect(setSortDirection).toHaveBeenCalledWith('sortDesc');
+  });
+
+  it('should call setSortCriteria when the sort direction changes', () => {
+    expect(setSortCriteria).not.toHaveBeenCalled();
+    sortBar.find('select[name="sort-bar-criteria"]').simulate('change', { target: { value: 'name' } });
+    expect(setSortCriteria).toHaveBeenCalledWith('name');
+  });
+});

--- a/src/tests/bulkConcepts/reducer/index.test.js
+++ b/src/tests/bulkConcepts/reducer/index.test.js
@@ -10,6 +10,8 @@ import {
   SET_NEXT_PAGE,
   SET_PERVIOUS_PAGE,
   CLEAR_BULK_FILTERS,
+  SET_SORT_CRITERIA,
+  SET_SORT_DIRECTION,
 } from '../../../redux/actions/types';
 import concepts, { concept2, multipleConceptsMockStore } from '../../__mocks__/concepts';
 import { classes as classList, DATA_TYPES as dataTypesList } from '../../../components/dictionaryConcepts/components/helperFunction';
@@ -196,5 +198,17 @@ describe('Test suite for bulkConcepts reducer', () => {
       ...state,
       preview: action.payload,
     });
+  });
+
+  it('should set the right sort criteria', () => {
+    let currentState = reducer(undefined, { type: 'init' });
+    currentState = reducer(currentState, { type: SET_SORT_CRITERIA, payload: 'id' });
+    expect(currentState.sortCriteria).toEqual('id');
+  });
+
+  it('should set the right sort direction', () => {
+    let currentState = reducer(undefined, { type: 'init' });
+    currentState = reducer(currentState, { type: SET_SORT_DIRECTION, payload: 'sortDesc' });
+    expect(currentState.sortDirection).toEqual('sortDesc');
   });
 });

--- a/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
+++ b/src/tests/dictionaryConcepts/actions/dictionaryConcept.test.js
@@ -38,6 +38,8 @@ import {
   UNPOPULATE_PRE_POPULATED_SETS,
   UNPOPULATE_SET,
   CLEAR_FILTERS,
+  CHANGE_SORT_CRITERIA,
+  CHANGE_SORT_DIRECTION,
 } from '../../../redux/actions/types';
 import {
   fetchDictionaryConcepts,
@@ -77,6 +79,8 @@ import {
   buildNewMappingData,
   fetchConceptsFromASource, buildUpdateMappingData,
   clearAllFilters,
+  setSortCriteriaAction,
+  setSortDirectionAction,
 } from '../../../redux/actions/concepts/dictionaryConcepts';
 import {
   removeDictionaryConcept,
@@ -1472,5 +1476,17 @@ describe('fetchConceptsFromASource', () => {
     });
     await fetchConceptsFromASource(sourceUrl, query);
     expect(notifyMock).toHaveBeenCalledWith('Could not load concepts: error. Please retry.', 'error', 2000);
+  });
+
+  it('setSortCriteriaAction should dispatch the correct action type', () => {
+    const mock = jest.fn();
+    setSortCriteriaAction('criteria')(mock);
+    expect(mock).toHaveBeenCalledWith({ type: CHANGE_SORT_CRITERIA, payload: 'criteria' });
+  });
+
+  it('setSortDirectionAction should dispatch the correct action type', () => {
+    const mock = jest.fn();
+    setSortDirectionAction('direction')(mock);
+    expect(mock).toHaveBeenCalledWith({ type: CHANGE_SORT_DIRECTION, payload: 'direction' });
   });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
[Allow users to sort concepts on the add ciel concepts page and in their collection](https://issues.openmrs.org/browse/OCLOMRS-719)

# Summary:
Currently, we user a default sort criteria for both of these pages. This allows the user to sort concepts by `bestMatch`, `name` or `id`.