### PR TITLE
OCLOMRS-727: Remove paginatedConcepts from dictionary concepts state

### DIFF
--- a/src/redux/reducers/ConceptReducers.js
+++ b/src/redux/reducers/ConceptReducers.js
@@ -104,16 +104,12 @@ export default (state = initialState, action) => {
     case REMOVE_CONCEPT:
       return {
         ...state,
-        paginatedConcepts: state.paginatedConcepts
-          .filter(concept => concept.version_url !== action.payload),
         dictionaryConcepts: state.dictionaryConcepts
           .filter(concept => concept.version_url !== action.payload),
       };
     case REPLACE_CONCEPT:
       return {
         ...state,
-        paginatedConcepts: state.paginatedConcepts
-          .map(concept => (concept.id === action.payload.id ? action.payload : concept)),
         dictionaryConcepts: state.dictionaryConcepts
           .map(concept => (concept.id === action.payload.id ? action.payload : concept)),
       };

--- a/src/tests/Dashboard/reducer/conceptReducer.test.js
+++ b/src/tests/Dashboard/reducer/conceptReducer.test.js
@@ -290,7 +290,7 @@ describe('Test suite for concepts reducer', () => {
   });
 
   describe(REPLACE_CONCEPT, () => {
-    it('should replace a concept in dictionaryConcepts and paginatedConcepts', () => {
+    it('should replace a concept in dictionaryConcepts', () => {
       let state = reducer(multipleConceptsMockStore.concepts, 'init');
       const conceptToReplace = state.dictionaryConcepts[0];
       const newConcept = concepts;
@@ -298,7 +298,6 @@ describe('Test suite for concepts reducer', () => {
       expect(conceptToReplace).not.toEqual(newConcept);
       state = reducer(state, replaceConcept(newConcept));
       expect(state.dictionaryConcepts[0]).toEqual(newConcept);
-      expect(state.paginatedConcepts[0]).toEqual(newConcept);
     });
   });
 

--- a/src/tests/__mocks__/concepts.js
+++ b/src/tests/__mocks__/concepts.js
@@ -154,7 +154,6 @@ export const multipleConceptsMockStore = {
   concepts: {
     concepts: [],
     loading: false,
-    paginatedConcepts: mockConcepts.slice(0, 10),
     dictionaryConcepts: mockConcepts,
     filteredSources: ['dev-col', 'MapTypes', 'Classes'],
     filteredClass: ['Diagnosis', 'MapType', 'Concept Class'],


### PR DESCRIPTION
# JIRA TICKET NAME:
[Remove paginatedConcepts from dictionary concepts state](https://issues.openmrs.org/browse/OCLOMRS-727)

# Summary:
Remove unused state field