### PR TITLE
OCLOMRS-646: Added support for multiple preferred sources

### DIFF
--- a/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
+++ b/src/components/dashboard/components/dictionary/DictionaryDetailCard.jsx
@@ -6,6 +6,8 @@ import ReleaseVersionModal from './common/ReleaseVersionModal';
 import SubscriptionModal from './common/SubscriptionModal';
 import {
   CIEL_SOURCE_URL,
+  AMPATH_SOURCE_URL,
+  PIH_SOURCE_URL,
   TRADITIONAL_OCL_HOST,
 } from '../../../dictionaryConcepts/components/helperFunction';
 import { findLocale } from './common/Languages';
@@ -26,6 +28,7 @@ const DictionaryDetailCard = (props) => {
       supported_locales,
       url,
       references,
+      preferred_source,
     },
     versions,
     showEditModal,
@@ -62,7 +65,16 @@ const DictionaryDetailCard = (props) => {
   const cielConceptCount = conceptReferences.filter(
     ({ expression }) => expression.includes(CIEL_SOURCE_URL),
   ).length;
-  const otherConceptCount = conceptReferences.length - cielConceptCount;
+
+  const ampathConceptCount = conceptReferences.filter(
+    ({ expression }) => expression.includes(AMPATH_SOURCE_URL),
+  ).length;
+
+  const pihConceptCount = conceptReferences.filter(
+    ({ expression }) => expression.includes(PIH_SOURCE_URL),
+  ).length;
+
+  const otherConceptCount = conceptReferences.length - cielConceptCount - ampathConceptCount - pihConceptCount;
 
   return (
     <div className="dictionaryDetails">
@@ -89,7 +101,7 @@ Dictionary
             <legend>General Details</legend>
             <p>
               <b>Preferred Source</b>
-: CIEL
+: {preferred_source}
             </p>
             <p className="paragraph">
               <b>Public Access</b>
@@ -166,6 +178,18 @@ Dictionary
 :
               {' '}
               {cielConceptCount}
+            </p>
+            <p className="points">
+              <b>From AMPATH</b>
+:
+              {' '}
+              {ampathConceptCount}
+            </p>
+            <p className="points">
+              <b>From PIH</b>
+:
+              {' '}
+              {pihConceptCount}
             </p>
             <p className="points">
               <b>Other Concepts</b>

--- a/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
+++ b/src/components/dashboard/components/dictionary/common/DictionaryModal.jsx
@@ -272,11 +272,14 @@ export class DictionaryModal extends React.Component {
                     <Input
                       type="select"
                       id="preferred_source"
+                      placeholder="CIEL"
                       name="preferred_source"
                       onChange={this.onChange}
                       value={data.preferred_source}
                     >
                       <option value="CIEL">CIEL (default source)</option>
+                      <option value="AMPATH">AMPATH</option>
+                      <option value="PIH">PIH</option>
                     </Input>
                   </FormGroup>
                   <FormGroup style={{ marginTop: '12px' }}>

--- a/src/components/dictionaryConcepts/components/helperFunction.js
+++ b/src/components/dictionaryConcepts/components/helperFunction.js
@@ -54,6 +54,8 @@ export const MAP_TYPES_DEFAULTS = ['SAME-AS', 'NARROWER-THAN'];
 
 export const INTERNAL_MAPPING_DEFAULT_SOURCE = 'CIEL';
 export const CIEL_SOURCE_URL = '/orgs/CIEL/sources/CIEL/';
+export const AMPATH_SOURCE_URL = '/orgs/AMPATH/sources/AMPATH/';
+export const PIH_SOURCE_URL = '/orgs/PIH/sources/PIH/';
 
 export const MAP_TYPE = {
   conceptSet: 'CONCEPT-SET',


### PR DESCRIPTION
# Add support for multiple preferred sources
[OCLOMRS-646: Add support for multiple preferred sources](https://issues.openmrs.org/browse/OCLOMRS-646)

# Summary:

Added support for AMPATH and PIH sources

### Edit/Create Dictionary
![Edit/Create Dictionary](https://drive.google.com/uc?export=view&id=10axHDKc9_k1tVmNOV96zrRcPP3Z2Vhdp)

### Dictionary Details
![Dictionary Details](https://drive.google.com/uc?export=view&id=1-XrS_U-MUDMbXvzS83ygkpuwq0xAaCtP)

### Dictionary Concept Details
![Dictionary Concept Details](https://drive.google.com/uc?export=view&id=1RQbDTlVettuFWrKKPLmbdV1CUcQZGrWg)


 - If images don't show up, here's the link to Google Drive folder: [Google Drive](https://drive.google.com/open?id=1Ti299O2s65Bnq2U-NvsugELY21QrW5n3)