### PR TITLE
OCLOMRS-601: Improved error validation

### DIFF
--- a/src/components/dictionaryConcepts/containers/CreateConcept.jsx
+++ b/src/components/dictionaryConcepts/containers/CreateConcept.jsx
@@ -136,6 +136,8 @@ export class CreateConcept extends Component {
         nextProps.history.push(`/concepts/${type}/${typeName}/${collectionName}/${dictionaryName}/${language}`);
         notify.show('concept successfully created', 'success', 3000);
       }, 10);
+    } else {
+      notify.show('Failed to create concept', 'error', 3000);
     }
   }
 


### PR DESCRIPTION
# OCLOMRS-601:  Improve error message validation when a user fails to create a concept.

[Issue: Improve error message validation when a user fails to create a concept.](https://issues.openmrs.org/browse/OCLOMRS-601)

# Summary:
In this commit I've improved error validation, when user fails to create a Concept.

### UI Changes
Now an Toast pops up telling users that they have failed to create a concept

![Screenshot from 2020-01-23 02-19-20](https://user-images.githubusercontent.com/28570857/72933391-a79a2d80-3d87-11ea-9081-0406a5bce45e.png)

### Steps to see new changes
1. Open form to create new Test concept
2. Add some dummy data
3. Refresh the page

Previously, all the data used to get cleared up with no error message, now we have a toast for that
