### PR TITLE
OCLOMRS-728:Concept description should not be required when creating a new concept

### DIFF
--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -105,7 +105,7 @@ class DescriptionRow extends Component {
             name="description"
             value={this.state.description}
             id="concept-description"
-            required
+            
           />
         </td>
         <td className="concept-language">

--- a/src/components/dictionaryConcepts/components/DescriptionRow.jsx
+++ b/src/components/dictionaryConcepts/components/DescriptionRow.jsx
@@ -105,7 +105,6 @@ class DescriptionRow extends Component {
             name="description"
             value={this.state.description}
             id="concept-description"
-            
           />
         </td>
         <td className="concept-language">


### PR DESCRIPTION
i dropped the required key word under the text area of  Concept description in the DescriptionRow component,and after testing,i could now  create a new Concept without the concept Description being a required field.

Ticket ID:  https://issues.openmrs.org/browse/OCLOMRS-728