### PR TITLE
OCLOMRS-765: Return to dictionary after changing source (Confusing navigation between pages)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,26 @@
 language: node_js
 node_js:
   - "10.13.0"
+
+before_cache:
+  # Save tagged docker images: https://github.com/travis-ci/travis-ci/issues/5358#issuecomment-248915326
+  - >
+    mkdir -p $HOME/docker && docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}'
+    | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker/$1.tar.gz'
+
+cache:
+  # caches $HOME/.npm when npm ci is default script command
+  # caches node_modules in all other cases
+  npm: true
+  bundler: true
+  directories:
+    - ~/.cache # folder with Cypress binary
+    - $HOME/docker
+
+before_install:
+  # Load cached docker images: https://github.com/travis-ci/travis-ci/issues/5358#issuecomment-248915326
+  - if [[ -d $HOME/docker ]]; then ls $HOME/docker/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load"; fi
+
 install:
   - npm install
   - npm install coveralls
@@ -9,14 +29,6 @@ script:
   - npm run test:ci
   - bash ./start_local_instance.sh
   - npm run test:integration
-
-cache:
-  # Caches $HOME/.npm when npm ci is default script command
-  # Caches node_modules in all other cases
-  npm: true
-  directories:
-    # we also need to cache folder with Cypress binary
-    - ~/.cache
 
 after_success:
   - coveralls < coverage/lcov.info

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,6 +1,6 @@
 import uuid from 'uuid'
 
-Cypress.Commands.add('runAndAwait', (callable, method='GET') => {
+Cypress.Commands.add('runAndAwait', (callable, method='GET', addArtificialWait=false) => {
     const requestId = `apiRequest-${uuid()}`;
 
     cy.server();
@@ -8,6 +8,8 @@ Cypress.Commands.add('runAndAwait', (callable, method='GET') => {
     callable();
     cy.wait(`@${requestId}`);
     cy.route(method, '**').as('untrackedRequest'); // stop recording requests
+
+    if (addArtificialWait) cy.wait(5000);
   }
 );
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "ocl-client",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=10.13.0",
+    "npm": ">=6.4.1"
+  },
   "dependencies": {
     "@material-ui/core": "^4.9.1",
     "@material-ui/icons": "^4.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Route,
+  Switch,
+  Redirect
+} from "react-router-dom";
 import { AuthenticationRequired, LoginPage } from "./apps/authentication";
 import { Provider } from "react-redux";
 import store from "./redux";
@@ -11,7 +16,7 @@ import DictionaryRoutes, {
 } from "./apps/dictionaries";
 import ConceptRoutes, {
   DICTIONARY_CONTAINER,
-  DICTIONARY_VERSION_CONTAINER,
+  DICTIONARY_VERSION_CONTAINER
 } from "./apps/concepts";
 import { SOURCE_CONTAINER } from "./apps/concepts/constants";
 
@@ -56,17 +61,14 @@ const AuthenticatedRoutes: React.FC = () => {
         />
       </Route>
       <Route path="/concepts">
-        <ConceptRoutes
-          containerType={SOURCE_CONTAINER}
-          viewConcepts={true}
-        />
+        <ConceptRoutes containerType={SOURCE_CONTAINER} viewConcepts={true} />
       </Route>
       <Route
         path="/:ownerType/:owner/collections"
         component={DictionaryRoutes}
       />
       <Route exact path="/">
-        Home
+        <Redirect to="/user/collections/" />
       </Route>
     </Switch>
   );

--- a/src/apps/authentication/LoginPage.tsx
+++ b/src/apps/authentication/LoginPage.tsx
@@ -39,7 +39,7 @@ const LoginPage: React.FC<Props> = ({
     };
   }, []);
 
-  if (isLoggedIn) return <Redirect to="/user/collections/" />;
+  if (isLoggedIn) return <Redirect to="/" />;
   else
     return (
       <Grid

--- a/src/apps/authentication/components/AuthenticationRequired.tsx
+++ b/src/apps/authentication/components/AuthenticationRequired.tsx
@@ -1,9 +1,13 @@
-import React, { useEffect } from 'react'
-import { connect } from 'react-redux'
-import { Redirect } from 'react-router-dom'
-import { getUserDetailsAction, getUserDetailsLoadingSelector, profileSelector } from '../redux'
-import { APIProfile } from '../types'
-import { ProgressOverlay } from '../../../utils/components'
+import React, { useEffect } from "react";
+import { connect } from "react-redux";
+import { Redirect } from "react-router-dom";
+import {
+  getUserDetailsAction,
+  getUserDetailsLoadingSelector,
+  profileSelector
+} from "../redux";
+import { APIProfile } from "../types";
+import { ProgressOverlay } from "../../../utils/components";
 
 interface Props {
   children: any;

--- a/src/apps/concepts/Routes.tsx
+++ b/src/apps/concepts/Routes.tsx
@@ -28,7 +28,7 @@ const Routes: React.FC<Props> = ({
     <Switch>
       {!viewConcepts ? null : (
         <Route exact path={`${path}/`}>
-          <ViewConceptsPage containerType={containerType} />
+          <ViewConceptsPage key={containerType} containerType={containerType} />
         </Route>
       )}
       {!newConcept ? null : (

--- a/src/apps/concepts/components/FilterOptions.tsx
+++ b/src/apps/concepts/components/FilterOptions.tsx
@@ -165,7 +165,7 @@ const FilterOptions: React.FC<FilterOptionsProps> = ({
         <div className={classes.center}>
           <ButtonGroup size="small" variant="text" fullWidth>
             <Button className={classes.applyFilters} color="primary">
-              <Link className={classes.applyFiltersLink} to={url}>
+              <Link replace className={classes.applyFiltersLink} to={url}>
                 Apply Filters
               </Link>
             </Button>

--- a/src/apps/concepts/pages/CreateOrEditConceptPage.tsx
+++ b/src/apps/concepts/pages/CreateOrEditConceptPage.tsx
@@ -102,6 +102,7 @@ const CreateOrEditConceptPage: React.FC<Props> = ({
 
   return (
     <Header
+      allowImplicitNavigation
       title={
         context === CONTEXT.edit
           ? "Edit " +
@@ -146,6 +147,7 @@ const CreateOrEditConceptPage: React.FC<Props> = ({
               <MenuItem>
                 <PageViewIcon />
                 <Link
+                  replace
                   className="link"
                   to={`${conceptUrl}?linkedDictionary=${linkedDictionary}&linkedSource=${sourceUrl}`}
                 >

--- a/src/apps/concepts/pages/ViewConceptPage.tsx
+++ b/src/apps/concepts/pages/ViewConceptPage.tsx
@@ -61,6 +61,7 @@ const ViewConceptPage: React.FC<Props> = ({
 
   return (
     <Header
+      allowImplicitNavigation
       title={startCase(
         toLower(concept ? concept.display_name : "View concept")
       )}
@@ -82,7 +83,7 @@ const ViewConceptPage: React.FC<Props> = ({
           />
         </Grid>
         {!showEditButton ? null : (
-          <Link to={`${url}edit/?linkedDictionary=${linkedDictionary}`}>
+          <Link replace to={`${url}edit/?linkedDictionary=${linkedDictionary}`}>
             <Tooltip title="Edit this concept">
               <Fab color="primary" className="fab">
                 <EditIcon />

--- a/src/apps/concepts/tests/e2e/ViewConceptsPage.test.ts
+++ b/src/apps/concepts/tests/e2e/ViewConceptsPage.test.ts
@@ -202,7 +202,7 @@ describe("View Concepts Page", () => {
       cy.runAndAwait(() => {
         cy.findByText(TEXT.ADD_TO_DICTIONARY).click();
         cy.findByTitle("In progress").should("exist");
-      });
+      }, "PUT", true);
 
       cy.findByTitle("Go back").click();
 
@@ -220,9 +220,7 @@ describe("View Concepts Page", () => {
     cy.findByPlaceholderText(
       "1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007"
     ).type("1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007");
-    cy.runAndAwait(() => cy.findByText(TEXT.ADD_CONCEPTS).click(), "PUT");
-
-    cy.wait(5000); // index update takes a while
+    cy.runAndAwait(() => cy.findByText(TEXT.ADD_CONCEPTS).click(), "PUT", true);
 
     cy.findByTitle("Go back").click();
     cy.get(conceptSelector).should("have.length.gte", 3); // account for possible recursively added concepts

--- a/src/apps/concepts/utils.ts
+++ b/src/apps/concepts/utils.ts
@@ -3,8 +3,9 @@ import { USER_TYPE } from "../../utils";
 // @ts-ignore
 import { getParams } from "url-matcher";
 
-export function getSourceIdFromUrl(sourceUrl?: string) {
+export function getContainerIdFromUrl(sourceUrl?: string) {
   // /orgs/FOO/sources/FOO/ => FOO
+  // /orgs/FOO/collections/FOO/ => FOO
   // / => Public Sources
 
   if (!sourceUrl) return undefined;

--- a/src/apps/dictionaries/Routes.tsx
+++ b/src/apps/dictionaries/Routes.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { Route, Switch, useRouteMatch } from "react-router-dom";
 import Header from "../../components/Header";
 import { EditDictionaryPage, ViewDictionaryPage } from "./pages";
-import { DICTIONARY_VERSION_CONTAINER, ViewConceptsPage } from "../concepts";
+import { DICTIONARY_VERSION_CONTAINER } from "../concepts";
 import AddBulkConceptsPage from "./pages/AddBulkConceptsPage";
+import ConceptRoutes from "../concepts/Routes";
 
 const Routes: React.FC = () => {
   // @ts-ignore
@@ -17,12 +18,13 @@ const Routes: React.FC = () => {
         </Header>
       </Route>
       <Route exact path={`${path}/:collection/edit/`}>
-        <Header title="Edit Dictionary">
-          <EditDictionaryPage />
-        </Header>
+        <EditDictionaryPage />
       </Route>
       <Route path={`${path}/:collection/:version/concepts/`}>
-        <ViewConceptsPage containerType={DICTIONARY_VERSION_CONTAINER} />
+        <ConceptRoutes
+          containerType={DICTIONARY_VERSION_CONTAINER}
+          viewConcepts={true}
+        />
       </Route>
       <Route exact path={`${path}/:collection/add/`}>
         <AddBulkConceptsPage />

--- a/src/apps/dictionaries/pages/AddBulkConceptsPage.tsx
+++ b/src/apps/dictionaries/pages/AddBulkConceptsPage.tsx
@@ -51,6 +51,7 @@ const AddBulkConceptsPage: React.FC<Props> = ({ addConceptsToDictionary }) => {
 
   return (
     <Header
+      allowImplicitNavigation
       title={`Add concepts in bulk from ${fromSource}`}
       headerComponent={
         <>
@@ -72,7 +73,11 @@ const AddBulkConceptsPage: React.FC<Props> = ({ addConceptsToDictionary }) => {
             {Object.entries(PREFERRED_SOURCES).map(
               ([sourceName, sourceUrl]) => (
                 <MenuItem onClick={handleSwitchSourceClose}>
-                  <Link className="link" to={`${url}?fromSource=${sourceName}`}>
+                  <Link
+                    replace
+                    className="link"
+                    to={`${url}?fromSource=${sourceName}`}
+                  >
                     {sourceName}
                   </Link>
                 </MenuItem>

--- a/src/apps/dictionaries/pages/EditDictionaryPage.tsx
+++ b/src/apps/dictionaries/pages/EditDictionaryPage.tsx
@@ -23,6 +23,7 @@ import {
   retrieveDictionaryAction
 } from "../redux/actions";
 import { Pageview as PageViewIcon } from "@material-ui/icons";
+import Header from '../../../components/Header'
 
 interface Props {
   errors?: {};
@@ -65,36 +66,38 @@ const EditDictionaryPage: React.FC<Props> = ({
   }
 
   return (
-    <ProgressOverlay delayRender loading={dictionaryLoading}>
-      <Grid id="edit-dictionary-page" item xs={6} component="div">
-        <Paper>
-          <DictionaryForm
-            context={CONTEXT.edit}
-            errors={errors}
-            profile={profile}
-            usersOrgs={usersOrgs ? usersOrgs : []}
-            loading={loading}
-            savedValues={apiDictionaryToDictionary(dictionary)}
-            onSubmit={(values: Dictionary) => {
-              if (dictionary)
-                editSourceAndDictionary(
-                  dictionary?.url,
-                  values,
-                  dictionary?.extras
-                );
-              else debug("Could not edit dictionary. dictionary is undefined");
-            }}
-          />
-        </Paper>
-      </Grid>
-      <Link to={dictionaryUrl}>
-        <Tooltip title="Discard changes and view">
-          <Fab color="primary" className="fab">
-            <PageViewIcon />
-          </Fab>
-        </Tooltip>
-      </Link>
-    </ProgressOverlay>
+    <Header title="Edit Dictionary" backUrl={dictionaryUrl} backText="Back to dictionary">
+      <ProgressOverlay delayRender loading={dictionaryLoading}>
+        <Grid id="edit-dictionary-page" item xs={6} component="div">
+          <Paper>
+            <DictionaryForm
+              context={CONTEXT.edit}
+              errors={errors}
+              profile={profile}
+              usersOrgs={usersOrgs ? usersOrgs : []}
+              loading={loading}
+              savedValues={apiDictionaryToDictionary(dictionary)}
+              onSubmit={(values: Dictionary) => {
+                if (dictionary)
+                  editSourceAndDictionary(
+                    dictionary?.url,
+                    values,
+                    dictionary?.extras
+                  );
+                else debug("Could not edit dictionary. dictionary is undefined");
+              }}
+            />
+          </Paper>
+        </Grid>
+        <Link to={dictionaryUrl}>
+          <Tooltip title="Discard changes and view">
+            <Fab color="primary" className="fab">
+              <PageViewIcon />
+            </Fab>
+          </Tooltip>
+        </Link>
+      </ProgressOverlay>
+    </Header>
   );
 };
 

--- a/src/apps/dictionaries/tests/e2e/CreateDictionaryPage.test.ts
+++ b/src/apps/dictionaries/tests/e2e/CreateDictionaryPage.test.ts
@@ -1,7 +1,7 @@
-import { login, logout } from '../../../authentication/tests/e2e/testUtils'
-import { createDictionary, newDictionary } from './testUtils'
+import { login, logout } from "../../../authentication/tests/e2e/testUtils";
+import { createDictionary, newDictionary } from "./testUtils";
 
-describe('Create Dictionary', () => {
+describe("Create Dictionary", () => {
   beforeEach(() => {
     login();
   });
@@ -10,17 +10,21 @@ describe('Create Dictionary', () => {
     logout();
   });
 
-  it('Happy flow: Should create a dictionary', () => {
+  it("Happy flow: Should create a dictionary", () => {
     // todo improve this test to check actual values
     const [dictionary, dictionaryUrl] = newDictionary();
 
     cy.visit(dictionaryUrl);
-    cy.findByText("Could not load dictionary. Refresh the page to retry").should('exist');
+    cy.findByText(
+      "Could not load dictionary. Refresh the page to retry"
+    ).should("exist");
 
     createDictionary([dictionary, dictionaryUrl]);
 
     cy.visit(dictionaryUrl);
-    cy.queryByText("Could not load dictionary. Refresh the page to retry").should('not.exist');
-    cy.findByText('General Details').should('exist');
+    cy.queryByText(
+      "Could not load dictionary. Refresh the page to retry"
+    ).should("not.exist");
+    cy.findByText("General Details").should("exist");
   });
-})
+});

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -44,7 +44,9 @@ interface Props {
   justifyChildren?: string;
   loadingList: boolean[];
   backUrl?: string;
+  backText?: string;
   headerComponent?: any;
+  allowImplicitNavigation?: boolean;
 }
 
 const Header: React.FC<Props> = ({
@@ -53,7 +55,9 @@ const Header: React.FC<Props> = ({
   justifyChildren = "center",
   loadingList = [],
   backUrl,
-  headerComponent
+  backText = "Go back",
+  headerComponent,
+  allowImplicitNavigation = false,
 }) => {
   const loadingItemsLength = loadingList.filter((loading: boolean) => loading)
     .length;
@@ -68,19 +72,21 @@ const Header: React.FC<Props> = ({
     <div>
       <AppBar position="fixed" className={classes.appBar}>
         <Toolbar>
-          <Tooltip title="Go back">
             {backUrl ? (
+              <Tooltip title={backText}>
               <Link to={backUrl}>
                 <IconButton>
                   <BackIcon className={classes.icon} />
                 </IconButton>
               </Link>
-            ) : (
+              </Tooltip>
+            ) : (allowImplicitNavigation ? (
+              <Tooltip title="Go back">
               <IconButton onClick={history.goBack}>
                 <BackIcon className={classes.icon} />
               </IconButton>
-            )}
-          </Tooltip>
+              </Tooltip>
+            ) : <span />)}
           <Typography variant="h5" noWrap>
             {title}
           </Typography>
@@ -98,13 +104,6 @@ const Header: React.FC<Props> = ({
                 </Tooltip>
               </Link>
             )}
-            {/*Until we can properly disable this when it is not necessary, I'm disabling it.*/}
-            {/*We would need some kind of canGoForward()*/}
-            {/*<Tooltip title="Go forward">*/}
-            {/*  <IconButton onClick={history.goForward}>*/}
-            {/*    <ForwardIcon className={classes.icon} />*/}
-            {/*</IconButton>*/}
-            {/*</Tooltip>*/}
           </div>
         </Toolbar>
       </AppBar>

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -1,6 +1,15 @@
 import { cloneDeep } from "lodash";
 
-import { errors, loading, progress, COMPLETE, FAILURE, PROGRESS, RESET, START } from './utils'
+import {
+  errors,
+  loading,
+  progress,
+  COMPLETE,
+  FAILURE,
+  PROGRESS,
+  RESET,
+  START
+} from "./utils";
 import { Action, LoadingAndErroredState } from "./types";
 
 // todo improve these action types args

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -340,9 +340,9 @@ export const MAP_TYPE_Q_AND_A = option("Q-AND-A");
 export const MAP_TYPE_CONCEPT_SET = option("CONCEPT-SET");
 const CIEL_SOURCE_URL = "/orgs/CIEL/sources/CIEL/";
 const PIH_SOURCE_URL = "/orgs/PIH/sources/PIH/";
-export const ALL_PUBLIC_SOURCES_URL = "/"
+export const ALL_PUBLIC_SOURCES_URL = "/";
 
 export const PREFERRED_SOURCES: { [key: string]: string } = {
   CIEL: CIEL_SOURCE_URL,
-  PIH: PIH_SOURCE_URL,
+  PIH: PIH_SOURCE_URL
 };


### PR DESCRIPTION
JIRA TICKET NAME:
[Return to dictionary after changing source (Confusing navigation between pages)](https://issues.openmrs.org/browse/OCLOMRS-765)

# Summary:
When adding new concepts to the dictionary , changed from CIEL to PIH and back again. Doing this changes the behavior of the back arrow at the top, as this now backs up through the changing sources. It needs to ALWAYS go back to viewing the concepts in the dictionary that are added.