### PR TITLE
OCLOMRS-821: As an organization member, I want to see the list of dictionaries created in OCL web so that I can use them in the new UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@types/shortid": "0.0.29",
     "@types/uuid": "^3.4.7",
     "@types/yup": "^0.26.30",
-    "cypress": "^4.8.0",
+    "cypress": "^4.9.0",
     "jest-junit": "^10.0.0",
     "prettier": "^1.19.1",
     "ts-loader": "^6.2.1"

--- a/src/apps/concepts/components/ConceptsTable.tsx
+++ b/src/apps/concepts/components/ConceptsTable.tsx
@@ -482,9 +482,7 @@ const ConceptsTable: React.FC<Props> = ({
                         onClick={e => e.stopPropagation()}
                         to={`${
                           row.version_url
-                        }?linkedDictionary=${linkedDictionary}${
-                          linkedSource ? `&linkedSource=${linkedSource}` : ""
-                        }`}
+                        }?linkedDictionary=${linkedDictionary}`}
                       >
                         {row.display_name}
                       </Link>

--- a/src/apps/concepts/components/ConceptsTable.tsx
+++ b/src/apps/concepts/components/ConceptsTable.tsx
@@ -480,9 +480,7 @@ const ConceptsTable: React.FC<Props> = ({
                     >
                       <Link
                         onClick={e => e.stopPropagation()}
-                        to={`${
-                          row.version_url
-                        }?linkedDictionary=${linkedDictionary}`}
+                        to={`${row.version_url}?linkedDictionary=${linkedDictionary}`}
                       >
                         {row.display_name}
                       </Link>

--- a/src/apps/concepts/pages/CreateOrEditConceptPage.tsx
+++ b/src/apps/concepts/pages/CreateOrEditConceptPage.tsx
@@ -126,7 +126,7 @@ const CreateOrEditConceptPage: React.FC<Props> = ({
       <Redirect
         to={`${concept.version_url}${
           linkedDictionaryUrl ? `?linkedDictionary=${linkedDictionaryUrl}` : ""
-        }&linkedSource=${sourceUrl}`}
+        }`}
       />
     );
 
@@ -181,7 +181,7 @@ const CreateOrEditConceptPage: React.FC<Props> = ({
                 <Link
                   replace
                   className="link"
-                  to={`${conceptUrl}?linkedDictionary=${linkedDictionaryUrl}&linkedSource=${sourceUrl}`}
+                  to={`${conceptUrl}?linkedDictionary=${linkedDictionaryUrl}`}
                 >
                   Discard changes and view
                 </Link>

--- a/src/apps/concepts/pages/ViewConceptPage.tsx
+++ b/src/apps/concepts/pages/ViewConceptPage.tsx
@@ -48,12 +48,14 @@ const ViewConceptPage: React.FC<Props> = ({
     ownerType: string;
     owner: string;
   }>();
-  const { linkedDictionary, linkedSource } = useQueryParams();
+  const { linkedDictionary } = useQueryParams();
+  const conceptSource = concept?.source_url;
 
   // we can modify the concept and it lives in our dictionary's linked source
   const showEditButton =
     canModifyContainer(ownerType, owner, profile, usersOrgs) &&
-    concept?.url.includes(linkedSource);
+    conceptSource &&
+    concept?.url.includes(conceptSource);
 
   useEffect(() => {
     retrieveConcept(url);

--- a/src/apps/concepts/pages/ViewConceptsPage.tsx
+++ b/src/apps/concepts/pages/ViewConceptsPage.tsx
@@ -96,6 +96,9 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     lightColour: {
       color: theme.palette.background.default
+    },
+    largerTooltip: {
+      fontSize: "larger"
     }
   })
 );
@@ -380,16 +383,37 @@ const ViewConceptsPage: React.FC<Props> = ({
             >
               Import existing concept
             </MenuItem>
-            {!linkedSource ? null : (
-              <MenuItem
-                onClick={e => {
-                  handleCustomClick(e);
-                  handleAddNewClose();
-                }}
-              >
-                Create custom concept
-              </MenuItem>
-            )}
+            <Tooltip
+              interactive
+              title={
+                linkedSource ? (
+                  ""
+                ) : (
+                  <span className={classes.largerTooltip}>
+                    This dictionary doesn't have a linked source attached to it.
+                    You'll need to{" "}
+                    <Link
+                      to={`${containerUrl}edit/?createLinkedSource=true&next=${gimmeAUrl()}`}
+                    >
+                      create one
+                    </Link>{" "}
+                    to keep your custom concepts.
+                  </span>
+                )
+              }
+            >
+              <span>
+                <MenuItem
+                  disabled={!linkedSource}
+                  onClick={e => {
+                    handleCustomClick(e);
+                    handleAddNewClose();
+                  }}
+                >
+                  Create custom concept
+                </MenuItem>
+              </span>
+            </Tooltip>
           </Menu>
         </>
       )}

--- a/src/apps/concepts/types.ts
+++ b/src/apps/concepts/types.ts
@@ -73,6 +73,7 @@ export interface APIConcept extends BaseConcept {
   version_url: string;
   mappings: APIMapping[];
   retired: boolean;
+  source_url: string;
 }
 
 export interface ConceptsState {

--- a/src/apps/dictionaries/api.ts
+++ b/src/apps/dictionaries/api.ts
@@ -6,7 +6,6 @@ import {
 } from "./types";
 import { authenticatedInstance, unAuthenticatedInstance } from "../../api";
 import { AxiosResponse } from "axios";
-import { OCL_DICTIONARY_TYPE } from "./constants";
 import { buildPartialSearchQuery, CUSTOM_VALIDATION_SCHEMA } from "../../utils";
 import { default as containerAPI } from "../containers/api";
 
@@ -35,7 +34,6 @@ const api = {
             limit,
             page,
             q: buildPartialSearchQuery(q),
-            collection_type: OCL_DICTIONARY_TYPE,
             customValidationSchema: CUSTOM_VALIDATION_SCHEMA,
             timestamp: new Date().getTime() // work around seemingly unhelpful caching
           }
@@ -51,7 +49,6 @@ const api = {
             limit,
             page,
             q: buildPartialSearchQuery(q),
-            collection_type: OCL_DICTIONARY_TYPE,
             customValidationSchema: CUSTOM_VALIDATION_SCHEMA,
             timestamp: new Date().getTime() // work around seemingly unhelpful caching
           }

--- a/src/apps/dictionaries/components/DictionaryForm.tsx
+++ b/src/apps/dictionaries/components/DictionaryForm.tsx
@@ -74,7 +74,7 @@ const useStyles = makeStyles({
 const DictionaryForm: React.FC<Props> = ({
   onSubmit,
   loading,
-  status,
+  status, // todo start using this to show action progress
   profile,
   usersOrgs,
   errors,

--- a/src/apps/dictionaries/components/ReleasedVersions.tsx
+++ b/src/apps/dictionaries/components/ReleasedVersions.tsx
@@ -26,7 +26,6 @@ interface Props {
   createVersionLoading: boolean;
   createVersionError?: { detail: string };
   dictionaryUrl: string;
-  linkedSource: string;
 }
 
 const ReleasedVersions: React.FC<Props> = ({
@@ -37,7 +36,6 @@ const ReleasedVersions: React.FC<Props> = ({
   createVersionLoading,
   createVersionError,
   dictionaryUrl,
-  linkedSource
 }) => {
   const versionsToDisplay = versions.filter(row => row.id !== "HEAD");
 
@@ -74,7 +72,7 @@ const ReleasedVersions: React.FC<Props> = ({
                     <TableCell>
                       <Button
                         // not row.url because the response immediately after creating a new version is missing the url attribute for some reason
-                        to={`${dictionaryUrl}${row.id}/concepts/?linkedSource=${linkedSource}`}
+                        to={`${dictionaryUrl}${row.id}/concepts/`}
                         component={Link}
                         size="small"
                         variant="text"

--- a/src/apps/dictionaries/components/ReleasedVersions.tsx
+++ b/src/apps/dictionaries/components/ReleasedVersions.tsx
@@ -35,7 +35,7 @@ const ReleasedVersions: React.FC<Props> = ({
   createDictionaryVersion,
   createVersionLoading,
   createVersionError,
-  dictionaryUrl,
+  dictionaryUrl
 }) => {
   const versionsToDisplay = versions.filter(row => row.id !== "HEAD");
 

--- a/src/apps/dictionaries/constants.ts
+++ b/src/apps/dictionaries/constants.ts
@@ -1,10 +1,5 @@
-const OCL_DICTIONARY_TYPE = "OCLClientDictionary";
-const OCL_SOURCE_TYPE = "OCLClientSource";
-
-const CONTEXT = {
+export const CONTEXT = {
   create: "create",
   view: "view",
   edit: "edit"
 };
-
-export { OCL_DICTIONARY_TYPE, OCL_SOURCE_TYPE, CONTEXT };

--- a/src/apps/dictionaries/pages/EditDictionaryPage.tsx
+++ b/src/apps/dictionaries/pages/EditDictionaryPage.tsx
@@ -32,6 +32,7 @@ interface StateProps {
   errors?: {};
   profile?: APIProfile;
   usersOrgs?: APIOrg[];
+  createAndAddLinkedSourceLoading: boolean;
   loading: boolean;
   editedDictionary?: APIDictionary;
   dictionaryLoading: boolean;
@@ -63,6 +64,7 @@ const EditDictionaryPage: React.FC<Props> = ({
   errors,
   editSourceAndDictionary,
   createAndAddLinkedSource,
+  createAndAddLinkedSourceLoading,
   loading,
   dictionaryLoading,
   dictionary,
@@ -71,9 +73,7 @@ const EditDictionaryPage: React.FC<Props> = ({
 }: Props) => {
   const { pathname: url } = useLocation();
   const dictionaryUrl = url.replace("edit/", "");
-  const { next: nextUrl = editedDictionary?.url } = useQueryParams<
-    URLQueryParams
-  >();
+  const { next: nextUrl } = useQueryParams<URLQueryParams>();
   const createLinkedSource =
     useQueryParams<URLQueryParams>().createLinkedSource === "true";
   const linkedSource = dictionary?.extras?.source;
@@ -85,15 +85,15 @@ const EditDictionaryPage: React.FC<Props> = ({
   }, [dictionaryUrl, retrieveDictionary]);
 
   useEffect(() => {
-    const dictionaryToUpdate = apiDictionaryToDictionary(dictionary);
+    const dictionaryData = apiDictionaryToDictionary(dictionary);
     if (
       !loading &&
       createLinkedSource &&
       dictionary &&
-      dictionaryToUpdate &&
+      dictionaryData &&
       !linkedSource
     ) {
-      createAndAddLinkedSource(dictionary.url, dictionaryToUpdate);
+      createAndAddLinkedSource(dictionary.url, dictionaryData);
     }
   }, [
     loading,
@@ -115,7 +115,13 @@ const EditDictionaryPage: React.FC<Props> = ({
       backUrl={dictionaryUrl}
       backText="Back to dictionary"
     >
-      <ProgressOverlay delayRender loading={dictionaryLoading}>
+      <ProgressOverlay
+        loadingMessage={
+          createAndAddLinkedSourceLoading ? "Creating linked source" : undefined
+        }
+        delayRender={dictionaryLoading}
+        loading={dictionaryLoading || createAndAddLinkedSourceLoading}
+      >
         <Grid id="edit-dictionary-page" item xs={6} component="div">
           <Paper>
             <DictionaryForm
@@ -158,8 +164,7 @@ const EditDictionaryPage: React.FC<Props> = ({
                 <Link
                   replace
                   className="link"
-                  to={`${url}?createLinkedSource=true&next=${nextUrl ||
-                    dictionaryUrl}`}
+                  to={`${url}?createLinkedSource=true`}
                 >
                   Create linked source
                 </Link>
@@ -175,6 +180,9 @@ const EditDictionaryPage: React.FC<Props> = ({
 const mapStateToProps = (state: any) => ({
   profile: profileSelector(state),
   usersOrgs: orgsSelector(state),
+  createAndAddLinkedSourceLoading: createAndAddLinkedSourceLoadingSelector(
+    state
+  ),
   loading:
     editDictionaryLoadingSelector(state) ||
     createAndAddLinkedSourceLoadingSelector(state),

--- a/src/apps/dictionaries/pages/EditDictionaryPage.tsx
+++ b/src/apps/dictionaries/pages/EditDictionaryPage.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect } from "react";
 import { DictionaryForm } from "../components";
-import { Fab, Grid, Paper, Tooltip } from "@material-ui/core";
+import { Fab, Grid, Menu, MenuItem, Paper, Tooltip } from "@material-ui/core";
 import { connect } from "react-redux";
 import { Link, Redirect, useLocation } from "react-router-dom";
 import {
+  createAndAddLinkedSourceAction,
+  createAndAddLinkedSourceLoadingSelector,
+  createAndAddLinkedSourceProgressSelector,
   editDictionaryLoadingSelector,
   editDictionaryProgressSelector,
   editSourceAndDictionaryErrorsSelector,
@@ -15,30 +18,43 @@ import {
   profileSelector
 } from "../../authentication/redux/reducer";
 import { APIOrg, APIProfile } from "../../authentication";
-import { debug, usePrevious } from "../../../utils";
+import { debug, useAnchor, usePrevious, useQueryParams } from "../../../utils";
 import { CONTEXT } from "../constants";
 import { ProgressOverlay } from "../../../utils/components";
 import {
   editSourceAndDictionaryAction,
   makeRetrieveDictionaryAction
-} from "../redux/actions";
-import { Pageview as PageViewIcon } from "@material-ui/icons";
+} from "../redux";
+import { MoreVert as MenuIcon } from "@material-ui/icons";
 import Header from "../../../components/Header";
 
-interface Props {
+interface StateProps {
   errors?: {};
   profile?: APIProfile;
   usersOrgs?: APIOrg[];
+  loading: boolean;
+  editedDictionary?: APIDictionary;
+  dictionaryLoading: boolean;
+  dictionary?: APIDictionary;
+}
+
+interface ActionProps {
   editSourceAndDictionary: (
     ...args: Parameters<typeof editSourceAndDictionaryAction>
   ) => void;
-  loading: boolean;
-  editedDictionary?: APIDictionary;
   retrieveDictionary: (
     ...args: Parameters<ReturnType<typeof makeRetrieveDictionaryAction>>
   ) => void;
-  dictionaryLoading: boolean;
-  dictionary?: APIDictionary;
+  createAndAddLinkedSource: (
+    ...args: Parameters<typeof createAndAddLinkedSourceAction>
+  ) => void;
+}
+
+type Props = StateProps & ActionProps;
+
+interface URLQueryParams {
+  next?: string;
+  createLinkedSource?: string;
 }
 
 const EditDictionaryPage: React.FC<Props> = ({
@@ -46,6 +62,7 @@ const EditDictionaryPage: React.FC<Props> = ({
   usersOrgs,
   errors,
   editSourceAndDictionary,
+  createAndAddLinkedSource,
   loading,
   dictionaryLoading,
   dictionary,
@@ -54,6 +71,12 @@ const EditDictionaryPage: React.FC<Props> = ({
 }: Props) => {
   const { pathname: url } = useLocation();
   const dictionaryUrl = url.replace("edit/", "");
+  const { next: nextUrl = editedDictionary?.url } = useQueryParams<
+    URLQueryParams
+  >();
+  const createLinkedSource =
+    useQueryParams<URLQueryParams>().createLinkedSource === "true";
+  const linkedSource = dictionary?.extras?.source;
 
   const previouslyLoading = usePrevious(loading);
 
@@ -61,8 +84,29 @@ const EditDictionaryPage: React.FC<Props> = ({
     retrieveDictionary(dictionaryUrl);
   }, [dictionaryUrl, retrieveDictionary]);
 
+  useEffect(() => {
+    const dictionaryToUpdate = apiDictionaryToDictionary(dictionary);
+    if (
+      !loading &&
+      createLinkedSource &&
+      dictionary &&
+      dictionaryToUpdate &&
+      !linkedSource
+    ) {
+      createAndAddLinkedSource(dictionary.url, dictionaryToUpdate);
+    }
+  }, [
+    loading,
+    createLinkedSource,
+    dictionary,
+    linkedSource,
+    createAndAddLinkedSource
+  ]);
+
+  const [menuAnchor, handleMenuClick, handleMenuClose] = useAnchor();
+
   if (!loading && previouslyLoading && editedDictionary) {
-    return <Redirect to={editedDictionary.url} />;
+    return <Redirect to={nextUrl || editedDictionary.url} />;
   }
 
   return (
@@ -83,24 +127,46 @@ const EditDictionaryPage: React.FC<Props> = ({
               savedValues={apiDictionaryToDictionary(dictionary)}
               onSubmit={(values: Dictionary) => {
                 if (dictionary)
-                  editSourceAndDictionary(
-                    dictionary?.url,
-                    values,
-                    dictionary?.extras
-                  );
+                  editSourceAndDictionary(dictionary.url, values, linkedSource);
                 else
                   debug("Could not edit dictionary. dictionary is undefined");
               }}
             />
           </Paper>
         </Grid>
-        <Link to={dictionaryUrl}>
-          <Tooltip title="Discard changes and view">
-            <Fab color="primary" className="fab">
-              <PageViewIcon />
+        <>
+          <Tooltip title="Menu">
+            <Fab onClick={handleMenuClick} color="primary" className="fab">
+              <MenuIcon />
             </Fab>
           </Tooltip>
-        </Link>
+          <Menu
+            anchorEl={menuAnchor}
+            keepMounted
+            open={Boolean(menuAnchor)}
+            onClose={handleMenuClose}
+          >
+            <MenuItem>
+              <Link replace className="link" to={dictionaryUrl}>
+                Discard changes and view
+              </Link>
+            </MenuItem>
+            {createLinkedSource || linkedSource ? (
+              <span />
+            ) : (
+              <MenuItem>
+                <Link
+                  replace
+                  className="link"
+                  to={`${url}?createLinkedSource=true&next=${nextUrl ||
+                    dictionaryUrl}`}
+                >
+                  Create linked source
+                </Link>
+              </MenuItem>
+            )}
+          </Menu>
+        </>
       </ProgressOverlay>
     </Header>
   );
@@ -109,16 +175,25 @@ const EditDictionaryPage: React.FC<Props> = ({
 const mapStateToProps = (state: any) => ({
   profile: profileSelector(state),
   usersOrgs: orgsSelector(state),
-  loading: editDictionaryLoadingSelector(state),
-  progress: editDictionaryProgressSelector(state),
+  loading:
+    editDictionaryLoadingSelector(state) ||
+    createAndAddLinkedSourceLoadingSelector(state),
+  progress:
+    createAndAddLinkedSourceProgressSelector(state) ||
+    editDictionaryProgressSelector(state),
   editedDictionary: state.dictionaries.editedDictionary,
   errors: editSourceAndDictionaryErrorsSelector(state),
   dictionaryLoading: retrieveDictionaryLoadingSelector(state),
   dictionary: state.dictionaries.dictionary
 });
+
 const mapActionsToProps = {
   editSourceAndDictionary: editSourceAndDictionaryAction,
-  retrieveDictionary: makeRetrieveDictionaryAction(false)
+  retrieveDictionary: makeRetrieveDictionaryAction(false),
+  createAndAddLinkedSource: createAndAddLinkedSourceAction
 };
 
-export default connect(mapStateToProps, mapActionsToProps)(EditDictionaryPage);
+export default connect<StateProps, ActionProps, unknown>(
+  mapStateToProps,
+  mapActionsToProps
+)(EditDictionaryPage);

--- a/src/apps/dictionaries/pages/ViewDictionaryPage.tsx
+++ b/src/apps/dictionaries/pages/ViewDictionaryPage.tsx
@@ -80,9 +80,7 @@ const ViewDictionaryPage: React.FC<Props> = ({
     profile,
     usersOrgs
   );
-  const showEditButton = canEditDictionary;
-
-  const linkedSource = dictionary?.extras?.source || "";
+  const showEditButton = canEditDictionary; // redundant, yes, but we don't want to couple them
 
   return (
     <ProgressOverlay
@@ -132,7 +130,6 @@ const ViewDictionaryPage: React.FC<Props> = ({
               createVersionLoading={createVersionLoading}
               createVersionError={createVersionError}
               dictionaryUrl={url}
-              linkedSource={linkedSource}
             />
           )}
         </Grid>

--- a/src/apps/dictionaries/pages/tests/e2e/EditDictionaryPage.test.ts
+++ b/src/apps/dictionaries/pages/tests/e2e/EditDictionaryPage.test.ts
@@ -53,7 +53,7 @@ describe("Edit Dictionary", () => {
     dictionary.otherLanguages.forEach(language => {
       select("Other Languages", language);
       cy.get("body").type("{esc}");
-    })
+    });
 
     cy.findByText("Submit").click();
     // redirects to view page

--- a/src/apps/dictionaries/redux/actionTypes.ts
+++ b/src/apps/dictionaries/redux/actionTypes.ts
@@ -5,6 +5,8 @@ export const RETRIEVE_DICTIONARY_ACTION = "dictionaries/retrieveDictionary";
 export const RETRIEVE_DICTIONARIES_ACTION = "dictionaries/retrieveDictionaries";
 export const EDIT_SOURCE_AND_DICTIONARY_ACTION =
   "dictionaries/editSourceAndDictionary";
+export const CREATE_AND_ADD_LINKED_SOURCE_ACTION =
+  "dictionaries/createAndAddLinkedSource";
 export const EDIT_DICTIONARY_ACTION = "dictionaries/edit";
 export const RETRIEVE_DICTIONARY_VERSIONS_ACTION =
   "dictionaries/retrieveVersions";

--- a/src/apps/dictionaries/redux/actions.ts
+++ b/src/apps/dictionaries/redux/actions.ts
@@ -135,7 +135,7 @@ export const retrieveDictionaryAndDetailsAction = (dictionaryUrl: string) => {
     const retrieveDictionaryResult = await dispatch(
       makeRetrieveDictionaryAction(false)<APIDictionary>(dictionaryUrl)
     );
-    if (!retrieveDictionaryResult || !retrieveDictionaryResult.extras) return;
+    if (!retrieveDictionaryResult) return;
 
     dispatch(retrieveDictionaryVersionsAction(dictionaryUrl));
   };

--- a/src/apps/dictionaries/redux/actions.ts
+++ b/src/apps/dictionaries/redux/actions.ts
@@ -19,7 +19,6 @@ import {
   EditableConceptContainerFields
 } from "../../../utils";
 import uuid from "uuid/v4";
-import { OCL_DICTIONARY_TYPE, OCL_SOURCE_TYPE } from "../constants";
 import {
   ORG_DICTIONARIES_ACTION_INDEX,
   PERSONAL_DICTIONARIES_ACTION_INDEX
@@ -29,6 +28,7 @@ import { recursivelyFetchToConcepts } from "../logic";
 import { addConceptsToDictionaryProgressListSelector } from "./selectors";
 import {
   ADD_CONCEPTS_TO_DICTIONARY,
+  CREATE_AND_ADD_LINKED_SOURCE_ACTION,
   CREATE_DICTIONARY_ACTION,
   CREATE_DICTIONARY_VERSION_ACTION,
   CREATE_SOURCE_AND_DICTIONARY_ACTION,
@@ -39,6 +39,7 @@ import {
   RETRIEVE_DICTIONARY_ACTION,
   RETRIEVE_DICTIONARY_VERSIONS_ACTION
 } from "./actionTypes";
+import { invalidateCache } from "../../../redux/utils";
 
 const createDictionaryAction = createActionThunk(
   CREATE_DICTIONARY_ACTION,
@@ -75,7 +76,6 @@ export const createSourceAndDictionaryAction = (dictionaryData: Dictionary) => {
       public_access: "None",
       short_code: short_code,
       id: short_code,
-      source_type: OCL_SOURCE_TYPE,
       supported_locales: supported_locales.join(","),
       website: ""
     };
@@ -99,7 +99,6 @@ export const createSourceAndDictionaryAction = (dictionaryData: Dictionary) => {
       )
     );
     const dictionary: NewAPIDictionary = {
-      collection_type: OCL_DICTIONARY_TYPE,
       custom_validation_schema: CUSTOM_VALIDATION_SCHEMA,
       default_locale,
       description,
@@ -159,7 +158,7 @@ export const retrieveOrgDictionariesAction = createActionThunk(
 export const editSourceAndDictionaryAction = (
   dictionaryUrl: string,
   dictionaryData: Dictionary,
-  extras: { source: string }
+  linkedSource?: string
 ) => {
   return async (dispatch: Function) => {
     dispatch(startAction(EDIT_SOURCE_AND_DICTIONARY_ACTION));
@@ -182,17 +181,22 @@ export const editSourceAndDictionaryAction = (
       preferred_source
     };
 
-    let sourceResponse: APISource | boolean;
-    let dictionaryResponse: APIDictionary | boolean;
+    if (linkedSource) {
+      let sourceResponse: APISource | boolean;
 
-    dispatch(
-      progressAction(EDIT_SOURCE_AND_DICTIONARY_ACTION, "Editing source...")
-    );
-    sourceResponse = await dispatch(editSource<APISource>(extras.source, data));
-    if (!sourceResponse) {
-      dispatch(completeAction(EDIT_SOURCE_AND_DICTIONARY_ACTION));
-      return false;
+      dispatch(
+        progressAction(EDIT_SOURCE_AND_DICTIONARY_ACTION, "Editing source...")
+      );
+      sourceResponse = await dispatch(
+        editSource<APISource>(linkedSource, data)
+      );
+      if (!sourceResponse) {
+        dispatch(completeAction(EDIT_SOURCE_AND_DICTIONARY_ACTION));
+        return false;
+      }
     }
+
+    let dictionaryResponse: APIDictionary | boolean;
 
     dispatch(
       progressAction(EDIT_SOURCE_AND_DICTIONARY_ACTION, "Editing dictionary...")
@@ -209,7 +213,73 @@ export const editSourceAndDictionaryAction = (
       return false;
     }
 
+    invalidateCache(RETRIEVE_DICTIONARY_ACTION, dispatch);
     dispatch(completeAction(EDIT_SOURCE_AND_DICTIONARY_ACTION));
+  };
+};
+export const createAndAddLinkedSourceAction = (
+  dictionaryUrl: string,
+  dictionaryData: Dictionary
+) => {
+  return async (dispatch: Function) => {
+    dispatch(startAction(CREATE_AND_ADD_LINKED_SOURCE_ACTION));
+
+    const {
+      description,
+      name,
+      supported_locales,
+      owner_url,
+      default_locale,
+      short_code
+    } = dictionaryData;
+
+    let sourceResponse: APISource | boolean;
+
+    dispatch(
+      progressAction(CREATE_AND_ADD_LINKED_SOURCE_ACTION, "Creating source...")
+    );
+    const source: NewAPISource = {
+      custom_validation_schema: CUSTOM_VALIDATION_SCHEMA,
+      default_locale,
+      description,
+      external_id: uuid(),
+      full_name: name,
+      name: name,
+      public_access: "None",
+      short_code: short_code,
+      id: short_code,
+      supported_locales: supported_locales.join(","),
+      website: ""
+    };
+    sourceResponse = await dispatch(createSource<APISource>(owner_url, source));
+    if (!sourceResponse) {
+      dispatch(completeAction(CREATE_AND_ADD_LINKED_SOURCE_ACTION));
+      return false;
+    }
+    sourceResponse = sourceResponse as APISource;
+
+    let dictionaryResponse: APIDictionary | boolean;
+
+    dispatch(
+      progressAction(
+        CREATE_AND_ADD_LINKED_SOURCE_ACTION,
+        "Updating dictionary..."
+      )
+    );
+
+    dictionaryResponse = await dispatch(
+      editDictionaryAction<APIDictionary>(dictionaryUrl, {
+        extras: { source: sourceResponse.url }
+      })
+    );
+    if (!dictionaryResponse) {
+      // todo handle cleanup
+      dispatch(completeAction(CREATE_AND_ADD_LINKED_SOURCE_ACTION));
+      return false;
+    }
+
+    invalidateCache(RETRIEVE_DICTIONARY_ACTION, dispatch);
+    dispatch(completeAction(CREATE_AND_ADD_LINKED_SOURCE_ACTION));
   };
 };
 const editDictionaryAction = createActionThunk(

--- a/src/apps/dictionaries/redux/selectors.ts
+++ b/src/apps/dictionaries/redux/selectors.ts
@@ -18,6 +18,7 @@ import {
 } from "./constants";
 import {
   ADD_CONCEPTS_TO_DICTIONARY,
+  CREATE_AND_ADD_LINKED_SOURCE_ACTION,
   CREATE_DICTIONARY_ACTION,
   CREATE_DICTIONARY_VERSION_ACTION,
   CREATE_SOURCE_AND_DICTIONARY_ACTION,
@@ -46,6 +47,12 @@ export const editDictionaryLoadingSelector = loadingSelector(
 );
 export const editDictionaryProgressSelector = progressSelector(
   EDIT_SOURCE_AND_DICTIONARY_ACTION
+);
+export const createAndAddLinkedSourceLoadingSelector = loadingSelector(
+  CREATE_AND_ADD_LINKED_SOURCE_ACTION
+);
+export const createAndAddLinkedSourceProgressSelector = progressSelector(
+  CREATE_AND_ADD_LINKED_SOURCE_ACTION
 );
 export const createSourceAndDictionaryErrorsSelector = (
   state: AppState

--- a/src/apps/dictionaries/types.ts
+++ b/src/apps/dictionaries/types.ts
@@ -16,7 +16,6 @@ interface BaseAPIDictionary extends BaseDictionary {
   id: string;
   external_id: string;
   full_name: string;
-  collection_type: string;
   website: string;
   custom_validation_schema: string;
   extras: { source: string };
@@ -49,7 +48,8 @@ export interface DictionaryState {
 
 export interface EditableDictionaryFields
   extends EditableConceptContainerFields {
-  public_access: string;
+  public_access?: string;
+  extras?: { source?: string };
 }
 
 export interface DictionaryVersion {

--- a/src/apps/sources/types.ts
+++ b/src/apps/sources/types.ts
@@ -4,21 +4,20 @@ interface BaseAPISource extends BaseConceptContainer {
   external_id: string;
   id: string;
   full_name: string;
-  source_type: string;
   website: string;
   custom_validation_schema: string;
 }
 
 export interface NewAPISource extends BaseAPISource {
+  // api expects a comma separated string for this in create/ edit data
   supported_locales: string;
 }
 
 export interface APISource extends BaseAPISource {
+  source_type: string;
   url: string;
   active_concepts: number;
   concepts_url: string;
   extras?: {};
   supported_locales: string[];
 }
-
-export {};

--- a/src/redux/selectors.ts
+++ b/src/redux/selectors.ts
@@ -11,13 +11,13 @@ export function loadingSelector(...actions: (IndexedAction | string)[]) {
       (
         previousValue: boolean,
         { actionType, actionIndex }: IndexedAction
-      ): boolean =>
-        previousValue ||
-        Boolean(
-          state.status[loading(actionType)]
-            ? state.status[loading(actionType)][actionIndex]
-            : false
-        ),
+      ): boolean => {
+        const loadingList = loadingListSelector(actionType)(state);
+        return (
+          previousValue ||
+          Boolean(loadingList ? loadingList[actionIndex] : false)
+        );
+      },
       false
     );
 }
@@ -25,19 +25,19 @@ export function loadingSelector(...actions: (IndexedAction | string)[]) {
 export function progressSelector(actionOrActionType: IndexedAction | string) {
   const { actionType, actionIndex } = getIndexedAction(actionOrActionType);
 
-  return (state: AppState): any =>
-    state.status[progress(actionType)]
-      ? state.status[progress(actionType)][actionIndex]
-      : undefined;
+  return (state: AppState): any => {
+    const progressList = progressListSelector(actionType)(state);
+    return progressList ? progressList[actionIndex] : undefined;
+  };
 }
 
 export function errorSelector(actionOrActionType: IndexedAction | string) {
   const { actionType, actionIndex } = getIndexedAction(actionOrActionType);
 
-  return (state: AppState): any =>
-    state.status[errors(actionType)]
-      ? state.status[errors(actionType)][actionIndex]
-      : undefined;
+  return (state: AppState): any => {
+    const errorList = errorListSelector(actionType)(state);
+    return errorList ? errorList[actionIndex] : undefined;
+  };
 }
 
 export function metaSelector(actionOrActionType: IndexedAction | string) {

--- a/src/redux/utils.ts
+++ b/src/redux/utils.ts
@@ -96,6 +96,10 @@ function isCacheable(action: IndexedAction, meta: any[], state: AppState) {
   );
 }
 
+export function invalidateCache(action: string, dispatch: Function) {
+  dispatch(resetAction(action));
+}
+
 export const createActionThunk = <T extends any[]>(
   actionOrActionType: IndexedAction | string,
   task: (...args: T) => Promise<AxiosResponse<any>>,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -18,9 +18,9 @@ export interface BaseConceptContainer {
 }
 
 export interface EditableConceptContainerFields {
-  description: string;
-  name: string;
-  supported_locales: string;
-  default_locale: string;
-  preferred_source: string;
+  description?: string;
+  name?: string;
+  supported_locales?: string;
+  default_locale?: string;
+  preferred_source?: string;
 }


### PR DESCRIPTION
# JIRA TICKET NAME:
[JIRA ticket name](https://issues.openmrs.org/browse/OCLOMRS-821)

# Summary:
*Acceptance criteria*
 * A dictionary created in the OCL web should be listed in the OCL for OpenMRS list of public dictionaries.
 * The user should be able to select the source in the new UI

 

*Tasks*
 * Remove API filter to see dictionaries created in OCL
 * Add a field for the user to select the source in the new UI