### PR TITLE
Rakesh | OCLOMRS-859 | MOBN-1410 | Page retains the information from previously opened pages and causes confusion

### DIFF
--- a/src/apps/concepts/components/ConceptsTable.tsx
+++ b/src/apps/concepts/components/ConceptsTable.tsx
@@ -96,8 +96,8 @@ function EnhancedTableHead(props: EnhancedTableProps) {
     <TableHead data-testid="conceptsTableHeader">
       <TableRow>
         {numSelected <= 0 ? (
-          ""
-        ) : (
+            null
+        )  : (
           <TableCell padding="checkbox">
             <Checkbox
               indeterminate={numSelected > 0 && numSelected < rowCount}
@@ -237,8 +237,8 @@ const EnhancedTableToolbar = (props: EnhancedTableToolbarProps) => {
         </>
       ) : (
         <Tooltip title="Filter list">
-          <IconButton aria-label="filter list">
-            <FilterListIcon onClick={() => toggleShowOptions()} />
+          <IconButton aria-label="filter list" onClick={() => toggleShowOptions()} >
+            <FilterListIcon />
           </IconButton>
         </Tooltip>
       )}
@@ -453,15 +453,15 @@ const ConceptsTable: React.FC<Props> = ({
                 return (
                   <TableRow
                     hover
-                    data-testRowClass="conceptRow"
+                    data-testrowclass="conceptRow"
                     role="checkbox"
                     aria-checked={isItemSelected}
                     tabIndex={-1}
-                    key={row.id}
+                    key={`${row.id}-${index}`}
                     selected={isItemSelected}
                   >
                     {selected.length <= 0 ? (
-                      ""
+                        null
                     ) : (
                       <TableCell padding="checkbox">
                         <Checkbox
@@ -475,7 +475,7 @@ const ConceptsTable: React.FC<Props> = ({
                     )}
                     <TableCell
                       onClick={event => toggleSelect(event, row.id)}
-                      data-testClass="name"
+                      data-testclass="name"
                       className={row.retired ? classes.retired : ""}
                     >
                       <Link
@@ -487,13 +487,13 @@ const ConceptsTable: React.FC<Props> = ({
                     </TableCell>
                     <TableCell
                       onClick={event => toggleSelect(event, row.id)}
-                      data-testClass="conceptClass"
+                      data-testclass="conceptClass"
                     >
                       {row.concept_class}
                     </TableCell>
                     <TableCell
                       onClick={event => toggleSelect(event, row.id)}
-                      data-testClass="datatype"
+                      data-testclass="datatype"
                     >
                       {row.datatype}
                     </TableCell>

--- a/src/apps/concepts/pages/CreateOrEditConceptPage.tsx
+++ b/src/apps/concepts/pages/CreateOrEditConceptPage.tsx
@@ -92,7 +92,7 @@ const CreateOrEditConceptPage: React.FC<Props> = ({
   const [menuAnchor, handleMenuClick, handleMenuClose] = useAnchor();
 
   const sourceUrl = url.substring(0, url.indexOf("concepts/"));
-  const conceptUrl = concept?.version_url || url.replace("/edit", "");
+  const conceptUrl = url.replace("/edit", "");
   const anyMappingsErrors =
     !!allMappingErrors.length && allMappingErrors.some(value => value);
 

--- a/src/apps/concepts/pages/ViewConceptsPage.tsx
+++ b/src/apps/concepts/pages/ViewConceptsPage.tsx
@@ -423,8 +423,8 @@ const ViewConceptsPage: React.FC<Props> = ({
         open={Boolean(customAnchor)}
         onClose={handleCustomClose}
       >
-        {CONCEPT_CLASSES.slice(0, 9).map(conceptClass => (
-          <MenuItem onClick={handleCustomClose}>
+        {CONCEPT_CLASSES.slice(0, 9).map((conceptClass, index) => (
+          <MenuItem onClick={handleCustomClose} key={index}>
             <Link
               className={classes.link}
               to={`${linkedSource}concepts/new/?conceptClass=${conceptClass}&linkedDictionary=${containerUrl}`}

--- a/src/apps/concepts/pages/tests/e2e/ViewConceptsPage.test.ts
+++ b/src/apps/concepts/pages/tests/e2e/ViewConceptsPage.test.ts
@@ -12,10 +12,10 @@ describe("View Concepts Page", () => {
     PICK_CONCEPTS: "Pick concepts"
   };
 
-  const conceptSelector = "[data-testRowClass='conceptRow']";
-  const nameSelector = "[data-testClass='name']";
-  const classSelector = "[data-testClass='conceptClass']";
-  const datatypeSelector = "[data-testClass='datatype']";
+  const conceptSelector = "[data-testrowclass='conceptRow']";
+  const nameSelector = "[data-testclass='name']";
+  const classSelector = "[data-testclass='conceptClass']";
+  const datatypeSelector = "[data-testclass='datatype']";
   let dictionary: TestDictionary, dictionaryUrl: string;
 
   function applyFilters() {

--- a/src/apps/concepts/redux/reducer.ts
+++ b/src/apps/concepts/redux/reducer.ts
@@ -8,6 +8,7 @@ import {
   UPSERT_MAPPING_ACTION
 } from "./actionTypes";
 import { REMOVE_REFERENCES_FROM_DICTIONARY } from "../../dictionaries/redux/actionTypes";
+import {LOGOUT_ACTION} from "../../authentication/redux/actionTypes";
 
 const initialState: ConceptsState = {
   mappings: [],
@@ -58,6 +59,8 @@ export const reducer = createReducer<ConceptsState>(initialState, {
     state.concepts.items = state.concepts.items.filter(
       (concept: APIConcept) => !meta[1].includes(concept.version_url)
     );
+  },[LOGOUT_ACTION]: () =>{
+    return initialState;
   }
 });
 export { reducer as default };

--- a/src/apps/dictionaries/redux/reducer.ts
+++ b/src/apps/dictionaries/redux/reducer.ts
@@ -13,6 +13,7 @@ import {
   RETRIEVE_DICTIONARY_ACTION,
   RETRIEVE_DICTIONARY_VERSIONS_ACTION
 } from "./actionTypes";
+import {LOGOUT_ACTION} from "../../authentication/redux/actionTypes";
 
 const initialState: DictionaryState = {
   dictionaries: [],
@@ -65,6 +66,9 @@ export const reducer = createReducer(initialState, {
     { actionIndex, payload, meta }
   ) => {
     state.versions = [payload, ...state.versions];
-  }
+  },
+  [LOGOUT_ACTION]: () =>{
+    return initialState;
+  },
 });
 export { reducer as default };

--- a/src/apps/sources/redux/reducer.ts
+++ b/src/apps/sources/redux/reducer.ts
@@ -2,6 +2,7 @@ import {createReducer} from "@reduxjs/toolkit";
 import {Action} from "../../../redux";
 import {SourceState} from "../types";
 import {RETRIEVE_SOURCE_ACTION, RETRIEVE_SOURCES_ACTION} from "./actionTypes";
+import {LOGOUT_ACTION} from "../../authentication/redux/actionTypes";
 
 const initialState: SourceState = {
     sources: []
@@ -18,5 +19,8 @@ export const reducer = createReducer(initialState, {
         ...state,
         source: action.payload
     }),
+    [LOGOUT_ACTION]: () =>{
+        return initialState;
+    },
 });
 export {reducer as default};


### PR DESCRIPTION
* Rakesh | OCLOMRS-859 | MOBN-1410 | Flush Dictionaries from store on logout

* Rakesh | OCLOMRS-859 | MOBN-1410 | Load concept from browser url on edit concept page

* Rakesh | OCLOMRS-859 | MOBN-1410 | Fixed console errors on viewconceptspage

* Rakesh | OCLOMRS-859 | MOBN-1410 | Flush Sources & Concepts from store on logout

# JIRA TICKET NAME:
[OCLOMRS_859](https://issues.openmrs.org/browse/OCLOMRS-859)

# Summary:
Users face issues with respect to seeing the right information on certain pages, which retains the information from previously opened pages which causes confusion and ends up with wrong/undesired actions from the users.

For ex: Edit screen of custom concepts shows the Edit screen of another custom concept which was opened earlier, Similarly the list of dictionaries under Your Dictionaries page also retains information from another user who logged in before the current user.