### PR TITLE
Rakesh | OCLOMRS-860 | MOBN-1411 | [UI] General details section is not wrapped and hence the alignment is affected with lengthy information (#22)

### DIFF
--- a/src/apps/dictionaries/components/DictionaryForm.tsx
+++ b/src/apps/dictionaries/components/DictionaryForm.tsx
@@ -71,6 +71,20 @@ const useStyles = makeStyles({
   }
 });
 
+const supportedLocalesLabel = (values: any) => {
+  const labels: Array<JSX.Element> = [];
+  {LOCALES.filter(
+      ({ value }) => value !== values.default_locale
+  ).map(({ value, label }) => (
+      labels.push(
+        <MenuItem key={value} value={value} style={{whiteSpace: 'normal'}}>
+          { label }
+        </MenuItem>
+      )
+  ))}
+  return labels;
+}
+
 const DictionaryForm: React.FC<Props> = ({
   onSubmit,
   loading,
@@ -143,6 +157,8 @@ const DictionaryForm: React.FC<Props> = ({
               name="name"
               label="Dictionary Name"
               margin="normal"
+              multiline
+              rowsMax={4}
               component={TextField}
             />
             <Field
@@ -154,6 +170,8 @@ const DictionaryForm: React.FC<Props> = ({
               name="short_code"
               label="Short Code"
               margin="normal"
+              multiline
+              rowsMax={4}
               component={TextField}
             />
             <Field
@@ -267,18 +285,16 @@ const DictionaryForm: React.FC<Props> = ({
               </InputLabel>
               <Field
                 multiple
+                fullWidth
+                multiline
+                rowsMax={4}
                 value={[]}
                 name="supported_locales"
                 id="supported_locales"
                 component={Select}
+                style={{whiteSpace: "inherit !important"}}
               >
-                {LOCALES.filter(
-                  ({ value }) => value !== values.default_locale
-                ).map(({ value, label }) => (
-                  <MenuItem key={value} value={value}>
-                    {label}
-                  </MenuItem>
-                ))}
+                {supportedLocalesLabel(values)}
               </Field>
               <Typography color="error" variant="caption" component="div">
                 <ErrorMessage name="supported_locales" component="span" />
@@ -289,6 +305,8 @@ const DictionaryForm: React.FC<Props> = ({
             ) : (
               <Field
                 fullWidth
+                multiline
+                rowsMax={4}
                 defaultValue="None"
                 id="linked_source"
                 name="extras.source"

--- a/src/apps/dictionaries/components/ReleasedVersions.tsx
+++ b/src/apps/dictionaries/components/ReleasedVersions.tsx
@@ -85,7 +85,7 @@ const ReleasedVersions: React.FC<Props> = ({
 
     return (
     <Paper className="fieldsetParent">
-      <fieldset>
+      <fieldset style={{minWidth: "0"}}>
         <Typography component="legend" variant="h5" gutterBottom>
           Releases
         </Typography>
@@ -104,8 +104,8 @@ const ReleasedVersions: React.FC<Props> = ({
               <TableBody>
                 {versionsToDisplay.map((row: APIDictionaryVersion) => (
                   <TableRow key={row.id}>
-                    <TableCell>{row.id}</TableCell>
-                    <TableCell>{row.description || "None"}</TableCell>
+                    <TableCell  style={{wordBreak: 'break-all'}}>{row.id}</TableCell>
+                    <TableCell style={{wordBreak: 'break-all'}}>{row.description || "None"}</TableCell>
                     <TableCell>
                       <Button
                         // not row.url because the response immediately after creating a new version is missing the url attribute for some reason

--- a/src/apps/dictionaries/pages/ViewDictionaryPage.tsx
+++ b/src/apps/dictionaries/pages/ViewDictionaryPage.tsx
@@ -99,7 +99,7 @@ const ViewDictionaryPage: React.FC<Props> = ({
     >
       <Grid id="viewDictionaryPage" item xs={5} component="div">
         <Paper className="fieldsetParent">
-          <fieldset>
+          <fieldset style={{minWidth: "0"}} >
             <Typography component="legend" variant="h5" gutterBottom>
               General Details
             </Typography>

--- a/src/apps/sources/components/SourceForm.tsx
+++ b/src/apps/sources/components/SourceForm.tsx
@@ -87,6 +87,20 @@ const SourceForm: React.FC<Props> = ({
         });
     }, [errors]);
 
+    const supportedLocalesLabel = (values: any) => {
+        const labels: Array<JSX.Element> = [];
+        {LOCALES.filter(
+            ({ value }) => value !== values.default_locale
+        ).map(({ value, label }) => (
+            labels.push(
+                <MenuItem key={value} value={value} style={{whiteSpace: 'normal'}}>
+                    { label }
+                </MenuItem>
+            )
+        ))}
+        return labels;
+    };
+
     return (
         <div id="source-form" className={classes.sourceForm}>
             <Formik
@@ -107,6 +121,8 @@ const SourceForm: React.FC<Props> = ({
                             name="short_code"
                             label="Short Code"
                             margin="normal"
+                            multiline
+                            rowsMax={4}
                             component={TextField}
                         />
                         <Field
@@ -117,6 +133,8 @@ const SourceForm: React.FC<Props> = ({
                             name="name"
                             label="Source Name"
                             margin="normal"
+                            multiline
+                            rowsMax={4}
                             component={TextField}
                         />
                         <Field
@@ -201,13 +219,7 @@ const SourceForm: React.FC<Props> = ({
                                 id="supported_locales"
                                 component={Select}
                             >
-                                {LOCALES.filter(
-                                    ({ value }) => value !== values.default_locale
-                                ).map(({ value, label }) => (
-                                    <MenuItem key={value} value={value}>
-                                        {label}
-                                    </MenuItem>
-                                ))}
+                                {supportedLocalesLabel(values)}
                             </Field>
                             <Typography color="error" variant="caption" component="div">
                                 <ErrorMessage name="supported_locales" component="span" />
@@ -216,6 +228,8 @@ const SourceForm: React.FC<Props> = ({
                         <Field
                             // required
                             fullWidth
+                            multiline
+                            rowsMax={4}
                             autoComplete="off"
                             id="custom_validation_schema"
                             name="custom_validation_schema"

--- a/src/index.scss
+++ b/src/index.scss
@@ -80,3 +80,7 @@ code {
   color: inherit;
   width: 100%;
 }
+
+#supported_locales.MuiSelect-selectMenu {
+  white-space: inherit;
+}


### PR DESCRIPTION
* Rakesh | OCLOMRS-860 | MOBN-1411 | Added min width for fieldset
* Rakesh | OCLOMRS-860 | MOBN-1411 | Added multiline and max-row for name, shortcode in dictionaries and sources details page
* Rakesh | OCLOMRS-860 | MOBN-1411 | Wrap whiteSpace for supported locales dropdown
* Rakesh | OCLOMRS-860 | MOBN-1411 | Fixes code review comments
* Rakesh | OCLOMRS-860 | MOBN-1411 | Added multiline for linked_source in dictionary form &
         custom validation schema in Sourceform

# JIRA TICKET NAME:
[OCLOMRS-860](https://issues.openmrs.org/browse/<ticket-id>)

# Summary:
If the details captured while creating a dictionary is too lengthy to get accommodated within the width of the general details section of a dictionary, the text doesn't get wrapped to the next line, instead it keeps going beyond the General details section boundary, thus breaking the alignment of the page.

Example: Open a CIEL dictionary and notice the alignment.
