### PR TITLE
OCLOMRS-862 | Display more specific validation messages on Concept create/edit screen 

### DIFF
--- a/src/redux/__test__/utils.test.ts
+++ b/src/redux/__test__/utils.test.ts
@@ -1,0 +1,36 @@
+import { errorMsgResponse } from '../utils';
+
+const errorMsgs: { [key: string]: string; } =  {
+    OPENMRS_ONE_FULLY_SPECIFIED_NAME_PER_LOCALE: 'A concept may not have more than one fully specified name in any locale',
+    OPENMRS_NO_MORE_THAN_ONE_SHORT_NAME_PER_LOCALE: 'A concept cannot have more than one short name in a locale',
+    OPENMRS_NAMES_EXCEPT_SHORT_MUST_BE_UNIQUE: 'All names except short names must be unique for a concept and locale',
+    OPENMRS_FULLY_SPECIFIED_NAME_UNIQUE_PER_SOURCE_LOCALE: 'Concept fully specified name must be unique for same source and locale',
+    OPENMRS_MUST_HAVE_EXACTLY_ONE_PREFERRED_NAME: 'A concept may not have more than one preferred name (per locale)',
+    OPENMRS_SHORT_NAME_CANNOT_BE_PREFERRED: 'A short name cannot be marked as locale preferred',
+    OPENMRS_AT_LEAST_ONE_FULLY_SPECIFIED_NAME: 'A concept must have at least one fully specified name',
+    OPENMRS_PREFERRED_NAME_UNIQUE_PER_SOURCE_LOCALE: 'Concept preferred name must be unique for same source and locale'
+};
+
+describe('errorResponseMsg', () => {
+    for (let error in errorMsgs){
+        const response = {
+            data: {
+                "name": [
+                    errorMsgs[error]
+                ]
+            }
+        };
+        it(`should return appropriate error msg for ${error} scenario `, ()=> {
+            expect(errorMsgResponse(response)).toEqual(
+                errorMsgs[error]
+            )
+        });
+    }
+
+    it ('should return generics error msg if no error response from server', () => {
+        const response = {};
+        expect(errorMsgResponse(response)).toEqual(
+            "Action could not be completed. Please retry."
+        )
+    });
+});

--- a/src/redux/utils.ts
+++ b/src/redux/utils.ts
@@ -100,6 +100,21 @@ export function invalidateCache(action: string, dispatch: Function) {
   dispatch(resetAction(action));
 }
 
+export function errorMsgResponse(response: any) {
+  let errorMsgResponse = [];
+  const genericErrorMessage =
+      "Action could not be completed. Please retry.";
+
+  for (let key in response.data) {
+    errorMsgResponse.push(
+        Array.isArray(response.data[key])
+            ? response.data[key].join(',')
+            : response.data[key]
+    )
+  };
+  return errorMsgResponse.length > 0 ? errorMsgResponse.join('\n') : genericErrorMessage;
+};
+
 export const createActionThunk = <T extends any[]>(
   actionOrActionType: IndexedAction | string,
   task: (...args: T) => Promise<AxiosResponse<any>>,
@@ -140,14 +155,17 @@ export const createActionThunk = <T extends any[]>(
           result = response.data;
         } catch (error) {
           debug(error, "redux/utils/#createActionThunk#:catch");
-          const genericErrorMessage =
-            "Action could not be completed. Please retry.";
+
+
 
           const response = error.response;
-          const errorMessage: string | {} | [] =
+
+          let errorMsg = errorMsgResponse(response);
+
+          const errorMessage: string | undefined | {} | [] =
             response?.data || response
-              ? STATUS_CODES_TO_MESSAGES[response.status] || genericErrorMessage
-              : genericErrorMessage;
+              ? STATUS_CODES_TO_MESSAGES[response.status] || errorMsg
+              : errorMsg;
 
           dispatch({
             type: `${actionType}_${FAILURE}`,


### PR DESCRIPTION
* Rakesh | OCLOMRS-862 | MOBN-1419 | Show form validation errors from backend in UI
* Rakesh  | OCLOMRS-862 | MOBN-1419 | Added test cases for errorMsg function

# JIRA TICKET NAME:
[OCLOMRS-862](https://issues.openmrs.org/browse/OCLOMRS-862)

# Summary:
Today when the user creates/edits a concept, user doesn't get clear validation message on the UI. Instead user gets a generic message that the action couldn't be completed.

Identifies the list of backend validation messages and enable the same on UI
