### PR TITLE
Rakesh | OCLOMRS-866 | MOBN-1436 | Unable to see CIEL dictionary

### DIFF
--- a/src/apps/sources/__test__/api.test.ts
+++ b/src/apps/sources/__test__/api.test.ts
@@ -25,7 +25,6 @@ describe('api', () => {
                 "limit": 20,
                 "page": 1,
                 "q": "*",
-                "sourceType": "Dictionary",
                 "timestamp": expect.anything()
             }
         });
@@ -45,7 +44,6 @@ describe('api', () => {
                 "limit": 20,
                 "page": 1,
                 "q": "*",
-                "sourceType": "Dictionary",
                 "timestamp": expect.anything()
             }
         });

--- a/src/apps/sources/api.ts
+++ b/src/apps/sources/api.ts
@@ -6,7 +6,6 @@ import {
   EditableConceptContainerFields,
 } from "../../utils";
 import { default as containerAPI } from "../containers/api";
-import { OCL_SOURCE_TYPE } from "./constants";
 
 const api = {
   ...containerAPI,
@@ -29,7 +28,6 @@ const api = {
             limit,
             page,
             q: buildPartialSearchQuery(q),
-            sourceType: OCL_SOURCE_TYPE,
             timestamp: new Date().getTime(), // work around seemingly unhelpful caching
           },
         }),
@@ -44,7 +42,6 @@ const api = {
                     limit,
                     page,
                     q: buildPartialSearchQuery(q),
-                    sourceType: OCL_SOURCE_TYPE,
                     timestamp: new Date().getTime() // work around seemingly unhelpful caching
                 }
             }),


### PR DESCRIPTION
# JIRA TICKET NAME:
[Unable to see CIEL dictionary](https://issues.openmrs.org/browse/OCLOMRS-866)

# Summary:

The CIEL and other public sources are not visible in the OCL for OpenMRS web client because the client filters public sources to those with source type "Dictionary" (i.e., it queries the API for sources using the parameter ?sourceType=Dictionary).

On Staging and Production, CIEL's source type is "Interface Terminology"
```
curl https://api.staging.openconceptlab.org/orgs/CIEL/sources/CIEL/
{
  "id": "CIEL",
  "source_type": "Interface Terminology",
  ...
}
```
After discussion with Jonathan Payne, we believe this filtering was a work in progress to filter out external sources when Lincoln Karuhanga had to step away from the project.
