### PR TITLE
Kirity, Vinisha, Tarun | OCLOMRS-869 | MOBN-1441 | Make released version component of dictionary responsive and include date created field

### DIFF
--- a/src/apps/dictionaries/__test__/components/ReleasedVersions.test.tsx
+++ b/src/apps/dictionaries/__test__/components/ReleasedVersions.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReleasedVersions from '../../../../apps/dictionaries/components/ReleasedVersions';
+import ReleasedVersions from '../../components/ReleasedVersions';
 import {render, fireEvent, getByText} from '../../../../test-utils';
 import '@testing-library/jest-dom'
 import {APIDictionaryVersion} from "../../types";
@@ -54,10 +54,10 @@ describe("Dictionary release version table", () => {
     it('checks if table headers are as expected', () => {
         const headerRow: Array<string> = [
             "ID",
+            "Date Created",
             "Description",
-            "Concepts",
-            "Subscription URL",
-            "Release Status"
+            "Release Status",
+            "Actions"
         ];
         const {getByText} = renderUI({
             versions: [releasedVersion]
@@ -160,31 +160,52 @@ describe("toggleButton for dictionary release status", () => {
         expect(getByTestId('2').closest('span')).not.toHaveClass('Mui-checked');
         expect(spyOnEditDictionaryVersion).not.toBeCalled();
     });
+});
 
-    describe('when user is not the owner of sources', () => {
-        it('should not open confirmation dialog onclick of dictionary toggle button', () => {
-            const {container, getByRole, getByTestId} = renderUI({
-                versions: [unreleasedVersion],
-                showCreateVersionButton: false
-            });
-            getByRole('checkbox').click();
-            const dialog = container.querySelector('[data-testid="confirm-dialog"]');
-            expect(dialog).toBeNull();
-            expect(getByTestId('2').closest('span')).not.toHaveClass('Mui-checked');
+describe('when user is not the owner of sources', () => {
+    it('should not open confirmation dialog onclick of dictionary toggle button', () => {
+        const {container, getByRole, getByTestId} = renderUI({
+            versions: [unreleasedVersion],
+            showCreateVersionButton: false
         });
+        getByRole('checkbox').click();
+        const dialog = container.querySelector('[data-testid="confirm-dialog"]');
+        expect(dialog).toBeNull();
+        expect(getByTestId('2').closest('span')).not.toHaveClass('Mui-checked');
+    });
 
-        it("should show tooltip with valid message on hovering the toggle button", async () => {
-            const {getByTitle, getByTestId} = renderUI({
-                versions: [unreleasedVersion],
-                showCreateVersionButton: false
-            });
-            const toggleButton: HTMLElement | null = getByTestId('2').closest('span');
-            expect(toggleButton).not.toBeNull();
-            toggleButton !== null && fireEvent.mouseMove(toggleButton);
-            expect(getByTitle("You don’t have permission to change the status")).toBeInTheDocument();
+    it("should show tooltip with valid message on hovering the toggle button", async () => {
+        const {getByTestId} = renderUI({
+            versions: [unreleasedVersion],
+            showCreateVersionButton: false
         });
-    })
+        const toggleButton: HTMLElement | null = getByTestId('2').closest('span');
+        expect(toggleButton).not.toBeNull();
+        toggleButton !== null && fireEvent.mouseMove(toggleButton);
+        expect(toggleButton).toHaveAttribute("title", "You don't have permission to change the status");
+    });
+});
 
+describe('actions button', () => {
+    it('should give both options on click of actions button for a released version', () => {
+        const {getByTestId} = renderUI({
+            versions: [releasedVersion],
+            showCreateVersionButton: false
+        });
+        getByTestId("more-actions").click();
+        expect(getByTestId("view-concepts")).toBeInTheDocument();
+        expect(getByTestId("copy-subscription-url")).toBeInTheDocument();
+    });
 
+    it("should give only view concepts option on click of actions button for an unreleased version", () => {
+        const {container, getByTestId} = renderUI({
+            versions: [unreleasedVersion],
+            showCreateVersionButton: true
+        });
+        getByTestId("more-actions").click();
+        const copyOptionElement: HTMLElement | null = container.querySelector("[data-testid='copy-subscription-url']");
+        expect(getByTestId("view-concepts")).toBeInTheDocument();
+        expect(copyOptionElement).toBeNull();
+    });
 });
 

--- a/src/apps/dictionaries/__test__/pages/ViewDictionaryPage.test.tsx
+++ b/src/apps/dictionaries/__test__/pages/ViewDictionaryPage.test.tsx
@@ -1,0 +1,160 @@
+import '@testing-library/jest-dom'
+import {
+    BrowserRouter as Router,
+} from "react-router-dom";
+import {render} from "@testing-library/react";
+import * as React from "react";
+import {Provider} from "react-redux";
+import store, {AppState, StatusState} from "../../../../redux";
+import {mapDispatchToProps, mapStateToProps, ViewDictionaryPage} from "../../pages/ViewDictionaryPage";
+import {APIDictionary, APIDictionaryVersion, DictionaryState} from "../../types";
+import {APIOrg, APIProfile, AuthState} from "../../../authentication";
+import {
+    createDictionaryVersionAction,
+    editDictionaryVersionAction,
+    retrieveDictionaryAndDetailsAction, retrieveDictionaryVersionsAction
+} from "../../redux";
+import {ConceptsState} from "../../../concepts";
+import {SourceState} from "../../../sources";
+
+type viewDictionaryPageProps = React.ComponentProps<typeof ViewDictionaryPage>;
+
+
+const testDictionary: APIDictionary = {
+    custom_validation_schema: "Openmrs",
+    default_locale: "en",
+    description: "None",
+    external_id: "2",
+    // @ts-ignore
+    extras: {source: undefined},
+    full_name: "Test Dictionary",
+    id: "2",
+    name: "Test",
+    preferred_source: "CIEL",
+    public_access: "View",
+    website: "Website",
+    supported_locales: ["fr", "es"],
+    short_code: "TD",
+    owner: "you",
+    owner_type: "user",
+    owner_url: "",
+    url: "url",
+    active_concepts: "4",
+    references: [{["reference1"]: "concept1"}],
+    concepts_url: "collection/concepts"
+};
+
+const apiProfile: APIProfile = {
+    email: "email", organizations_url: "orgUrl", url: "url", username: "you"
+};
+
+const apiOrg: APIOrg = {
+    id: "", name: "", url: ""
+};
+
+const baseProps: viewDictionaryPageProps = {
+    createDictionaryVersion(args: any): void {
+    },
+    createVersionError: {detail: ""},
+    createVersionLoading: false,
+    dictionary: testDictionary,
+    dictionaryLoading: false,
+    editDictionaryVersion(args: any): void {
+    },
+    profile: apiProfile,
+    retrieveDictionaryAndDetails(args: any): void {
+    },
+    retrieveDictionaryErrors: undefined,
+    retrieveDictionaryVersions(args: any): void {
+    },
+    usersOrgs: [apiOrg],
+    versions: [],
+    versionsLoading: false
+};
+
+const releasedVersion: APIDictionaryVersion = {
+    id: "2",
+    released: true,
+    version_url: "version_url",
+    url: "url",
+    external_id: "3"
+};
+
+const authState: AuthState = { isLoggedIn: true };
+
+const statusState: StatusState = { key: [] };
+
+const dictionariesState: DictionaryState = {
+    dictionaries: [{ items: [] }],
+    versions: [releasedVersion],
+    addReferencesResults: [],
+    dictionary: testDictionary
+};
+
+const conceptState: ConceptsState = {
+    concepts: { items: [] },
+    mappings: [],
+};
+
+const sourceState: SourceState = {
+    sources: [],
+};
+
+const currentState: AppState = {
+    auth: authState,
+    status: statusState,
+    dictionaries: dictionariesState,
+    concepts: conceptState,
+    sources: sourceState,
+};
+
+function renderUI(props: Partial<viewDictionaryPageProps> = {}) {
+    return render(<Provider store={store}>
+            <Router>
+                <ViewDictionaryPage {...baseProps} {...props}  />
+            </Router>
+        </Provider>
+    );
+}
+
+describe('viewDictionaryPage snapshot', () => {
+    it('viewDictionaryPage snapshot test', () => {
+        const {container} = renderUI();
+        expect(container).toMatchSnapshot();
+    });
+});
+
+describe('viewDictionaryPage', () => {
+    it('should list down all the props of the state', () => {
+        expect(mapStateToProps(currentState).dictionaryLoading).not.toBeNull();
+        expect(mapStateToProps(currentState).versionsLoading).not.toBeNull();
+        expect(mapStateToProps(currentState).createVersionLoading).not.toBeNull();
+        expect(mapStateToProps(currentState).profile).not.toBeNull();
+        expect(mapStateToProps(currentState).usersOrgs).not.toBeNull();
+        expect(mapStateToProps(currentState).dictionary).not.toBeNull();
+        expect(mapStateToProps(currentState).versions).not.toBeNull();
+        expect(mapStateToProps(currentState).createVersionError).not.toBeNull();
+        expect(mapStateToProps(currentState).retrieveDictionaryErrors).not.toBeNull();
+    });
+
+    it('should update the loading status with current state', () => {
+        expect(mapStateToProps(currentState).dictionaryLoading).toEqual(false);
+        expect(mapStateToProps(currentState).versionsLoading).toEqual(false);
+        expect(mapStateToProps(currentState).createVersionLoading).toEqual(false);
+    });
+
+    it('should assign existing dictionary to the dictionary prop', () => {
+        expect(mapStateToProps(currentState).dictionary).toEqual(testDictionary);
+    });
+
+    it('should assign existing dictionary versions to the versions prop', () => {
+        expect(mapStateToProps(currentState).versions).toEqual([releasedVersion]);
+    });
+
+    it('should point to correct dispatch action', () => {
+        expect(mapDispatchToProps.retrieveDictionaryAndDetails).toBe(retrieveDictionaryAndDetailsAction);
+        expect(mapDispatchToProps.createDictionaryVersion).toBe(createDictionaryVersionAction);
+        expect(mapDispatchToProps.editDictionaryVersion).toBe(editDictionaryVersionAction);
+        expect(mapDispatchToProps.retrieveDictionaryVersions).toBe(retrieveDictionaryVersionsAction);
+    })
+});

--- a/src/apps/dictionaries/pages/ViewDictionaryPage.tsx
+++ b/src/apps/dictionaries/pages/ViewDictionaryPage.tsx
@@ -21,6 +21,7 @@ import { APIOrg, APIProfile, canModifyContainer } from "../../authentication";
 import {
   createDictionaryVersionAction,
   editDictionaryVersionAction,
+  retrieveDictionaryVersionsAction,
   createDictionaryVersionErrorSelector,
   createDictionaryVersionLoadingSelector,
   dictionarySelector,
@@ -48,6 +49,9 @@ interface Props {
   editDictionaryVersion: (
       ...args: Parameters<typeof editDictionaryVersionAction>
   ) => void;
+  retrieveDictionaryVersions: (
+      ...args: Parameters<typeof retrieveDictionaryVersionsAction>
+  ) => void,
   versions: APIDictionaryVersion[];
   versionsLoading: boolean;
   createVersionLoading: boolean;
@@ -55,7 +59,7 @@ interface Props {
   retrieveDictionaryErrors?: {};
 }
 
-const ViewDictionaryPage: React.FC<Props> = ({
+export const ViewDictionaryPage: React.FC<Props> = ({
   profile,
   usersOrgs = [],
   dictionaryLoading,
@@ -65,6 +69,7 @@ const ViewDictionaryPage: React.FC<Props> = ({
   versionsLoading,
   createDictionaryVersion,
   editDictionaryVersion,
+  retrieveDictionaryVersions,
   createVersionLoading,
   createVersionError,
   retrieveDictionaryErrors
@@ -128,14 +133,22 @@ const ViewDictionaryPage: React.FC<Props> = ({
             <ReleasedVersions
               versions={versions}
               showCreateVersionButton={canEditDictionary}
-              createDictionaryVersion={(data: DictionaryVersion) =>
-                createDictionaryVersion(url, data)
+              createDictionaryVersion={async (data: DictionaryVersion) => {
+                  const response: any = await createDictionaryVersion(url, data);
+                  if (response) {
+                    retrieveDictionaryVersions(url);
+                  }
+                }
               }
               createVersionLoading={createVersionLoading}
               createVersionError={createVersionError}
               dictionaryUrl={url}
-              editDictionaryVersion={(data: DictionaryVersion) =>
-                  editDictionaryVersion(url, data)
+              editDictionaryVersion={async (data: DictionaryVersion) => {
+                  const response: any = await  editDictionaryVersion(url, data);
+                  if (response) {
+                    retrieveDictionaryVersions(url);
+                  }
+                }
               }
             />
           )}
@@ -154,7 +167,7 @@ const ViewDictionaryPage: React.FC<Props> = ({
   );
 };
 
-const mapStateToProps = (state: AppState) => ({
+export const mapStateToProps = (state: AppState) => ({
   profile: profileSelector(state),
   usersOrgs: orgsSelector(state),
   dictionaryLoading: retrieveDictionaryLoadingSelector(state),
@@ -165,10 +178,11 @@ const mapStateToProps = (state: AppState) => ({
   createVersionError: createDictionaryVersionErrorSelector(state),
   retrieveDictionaryErrors: retrieveDictionaryErrorSelector(state)
 });
-const mapDispatchToProps = {
+export const mapDispatchToProps = {
   retrieveDictionaryAndDetails: retrieveDictionaryAndDetailsAction,
   createDictionaryVersion: createDictionaryVersionAction,
-  editDictionaryVersion: editDictionaryVersionAction
+  editDictionaryVersion: editDictionaryVersionAction,
+  retrieveDictionaryVersions: retrieveDictionaryVersionsAction
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(ViewDictionaryPage);

--- a/src/apps/dictionaries/pages/tests/e2e/ViewDictionaryPage.test.ts
+++ b/src/apps/dictionaries/pages/tests/e2e/ViewDictionaryPage.test.ts
@@ -45,8 +45,8 @@ describe("View Dictionary", () => {
     );
     cy.findByText("View Concepts").should("exist");
 
-    cy.findByText("Releases").should("exist");
-    cy.findByText("No released versions").should("exist");
-    cy.findByText("Release new version").should("exist");
+    cy.findByText("Versions").should("exist");
+    cy.findByText("No versions created").should("exist");
+    cy.findByText("Create new version").should("exist");
   });
 });

--- a/src/apps/dictionaries/redux/actions.ts
+++ b/src/apps/dictionaries/redux/actions.ts
@@ -294,7 +294,7 @@ const editDictionaryAction = createActionThunk(
   EDIT_DICTIONARY_ACTION,
   api.update
 );
-const retrieveDictionaryVersionsAction = createActionThunk(
+export const retrieveDictionaryVersionsAction = createActionThunk(
   RETRIEVE_DICTIONARY_VERSIONS_ACTION,
   api.versions.retrieve
 );

--- a/src/apps/dictionaries/types.ts
+++ b/src/apps/dictionaries/types.ts
@@ -59,6 +59,7 @@ export interface DictionaryVersion {
   description?: string;
   external_id: string;
   extras?: { [key: string]: string };
+  created_on?: string;
 }
 
 export interface APIDictionaryVersion extends DictionaryVersion {


### PR DESCRIPTION


# JIRA TICKET NAME:
[OCLOMRS-869](https://issues.openmrs.org/browse/OCLOMRS-869)

# Summary:
Released Version component is not responsive. For a smaller window, UI is breaking.
Make this component responsive so that it will not break the UI. For a smaller window, horizontal scroll bar should appear.
Each version of a dictionary can have multiple actions associated to it such as View concepts, Copy subscription URL, Download the zip file of concepts, etc. Such actions buttons need to be arranged on the UI in such a way that it is aligned properly and improves the UX. Also Include created date as a new column next to the version ID