### PR TITLE
Rakesh | OCLOMRS-877 | MOBN-1448 | User allowed to create multiple different concepts with same UUID

### DIFF
--- a/src/apps/concepts/components/ConceptForm.tsx
+++ b/src/apps/concepts/components/ConceptForm.tsx
@@ -219,11 +219,14 @@ const ConceptForm: React.FC<Props> = ({
   const toggleExternalIDEditable = () =>
     setExternalIDEditable(!isExternalIDEditable);
 
+
   useEffect(() => {
     const { current: currentRef } = formikRef;
     if (currentRef) {
       currentRef.setSubmitting(loading || !allowEditing);
     }
+    // the below line is to fetch new random uuid
+    initialValues.external_id = uuid();
   }, [loading, allowEditing]);
 
   useEffect(() => {


### PR DESCRIPTION


# JIRA TICKET NAME:
[User allowed to create multiple different concepts with same UUID](https://issues.openmrs.org/browse/OCLOMRS-877)

# Summary:
Expected:
UUID field in Custom Concept creating experience should auto-populate a unique UID for each new custom concept created.
If for some reason the user manually edited the UUID field to have the same UUID as another concept, the user should not be allowed to save this.
The UUID should be unique for all the concepts. Otherwise it will create issues when importing into OpenMRS.

Right now in staging, there are two problems:
1) the UUID field auto-generates the same UUID # for every custom concept, instead of a random one each time
2) the user is allowed to create multiple different concepts with the same UUID (when they should not be able to save the form)