### PR TITLE
Rakesh, Bindu | OCLOMRS-887 | Change the ability to add Answers/Set m…

### DIFF
--- a/src/apps/concepts/__test__/components/ConceptForm.test.tsx
+++ b/src/apps/concepts/__test__/components/ConceptForm.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import uuid from 'uuid';
+import { render } from '../../../../test-utils';
+import { ConceptForm } from '../../components';
+import { Concept } from '../../types';
+
+type conceptFormProps = React.ComponentProps<typeof ConceptForm>;
+
+const initialValues: Concept = {
+    concept_class: "",
+    datatype: "Coded",
+    descriptions: [],
+    external_id: uuid(),
+    id: "",
+    answers: [],
+    sets: [],
+    mappings: [],
+    names: [],
+    retired: false,
+    extras: {}
+  };;
+
+const baseProps: conceptFormProps = {
+    onSubmit: () => {},
+    loading: true,
+    status: "",
+    errors: {},
+    savedValues: initialValues,
+    context: "view",
+    allMappingErrors: [],
+    conceptClass: "Diagnosis",
+    supportLegacyMappings: true,
+    defaultLocale: "",
+    supportedLocales:[]
+};
+
+function renderUI(props: Partial<conceptFormProps> = {}) {
+    return render(
+        <ConceptForm {...baseProps} {...props} />
+    );
+};
+
+describe('ConceptForm ', () => {
+    
+    let queryByTestId: Function;
+    beforeEach(() => {
+        const queries = renderUI(baseProps);
+        queryByTestId = queries.queryByTestId;
+    });
+
+   it('should show set members sections', () => {
+        expect(queryByTestId('set-members')).not.toBeNull();
+   });
+
+   it('should show answers sections if datatype is coded', () => {
+        expect(queryByTestId('answers')).not.toBeNull();
+   });
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -210,6 +210,8 @@ export const LOCALES: { [key: string]: string }[] = [
 export const CONCEPT_CLASS_QUESTION = "Question";
 export const CONCEPT_CLASSES_SET = ["LabSet", "MedSet", "ConvSet"];
 export const CONCEPT_DATATYPE_NUMERIC = "Numeric";
+export const CONCEPT_DATATYPE_CODED = "Coded";
+
 
 export const CONCEPT_CLASSES: string[] = [
   "Diagnosis",


### PR DESCRIPTION
…embers to a concept based upon the datatype (#44)

* Rakesh, Bindu | OCLOMRS-887 | Change the ability to add Answers/Set members to a concept based upon the datatype

* Rakesh, Bindu | OCLOMRS-887 | Adds snapshot tests, removed check to hide set members for coded concepts

* Rakesh, Bindu | OCLOMRS-887 | retire the answer section concepts when we change the datatype from "coded" to other than coded

* Rakesh, Bindu | OCLOMRS-887 | Fix for failing e2e test

* Bindu, Rakes | OCLOMRS-887 | Handle the review comments

* Bindu, Rakesh | OCLOMRS-887 | removed snapshot tests, added test to vesrify sets and answers

# JIRA TICKET NAME:
[Change the ability to add Answers/Set members to a concept based upon the datatype](https://issues.openmrs.org/browse/OCLOMRS-887)

# Summary:
As a user, 
I should be able to add set members to all the concept class types and answers to coded data type concepts in sources