### PR TITLE
OCLOMRS-889: Don't pull in concepts from other sources for mappings

### DIFF
--- a/src/apps/concepts/redux/actions.ts
+++ b/src/apps/concepts/redux/actions.ts
@@ -174,8 +174,11 @@ export const upsertConceptAndMappingsAction = (
       );
 
       const state: AppState = getState();
+      // we *only* want to import either concept answers or members of the concept set
       const toConceptUrls: string[] = [
-        ...state.concepts.mappings.map(mapping => mapping.to_concept_url)
+        ...state.concepts.mappings
+          .filter(mapping => mapping.map_type === "CONCEPT-SET" || mapping.map_type === "Q-AND-A")
+          .map(mapping => mapping.to_concept_url)
       ].filter(reference => reference) as string[];
 
       try {


### PR DESCRIPTION
# JIRA TICKET NAME:
https://issues.openmrs.org/browse/OCLOMRS-889

# Summary:
I removed the [mappings, MAPPINGS_BATCH_INDEX, "mappings"] element so that we no longer try to add a concept to the dictionary simply because we have mapped one of our concepts to it. 
