### PR TITLE
OCLOMRS-892: Reset the Error Message on create and edit dictionary form

### DIFF
--- a/src/apps/dictionaries/pages/CreateDictionaryPage.tsx
+++ b/src/apps/dictionaries/pages/CreateDictionaryPage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect }  from "react";
 import { DictionaryForm } from "../components";
 import { Grid, Paper } from "@material-ui/core";
 import { connect } from "react-redux";
@@ -6,7 +6,8 @@ import { Redirect } from "react-router-dom";
 import {
   createDictionaryLoadingSelector,
   createDictionaryProgressSelector,
-  createSourceAndDictionaryErrorsSelector
+  createSourceAndDictionaryErrorsSelector,
+  resetCreateDictionaryAction
 } from "../redux";
 import { APIDictionary, Dictionary } from "../types";
 import {
@@ -26,6 +27,7 @@ interface Props {
   ) => void;
   loading: boolean;
   newDictionary?: APIDictionary;
+  resetCreateDictionary: () => void;
 }
 
 const CreateDictionaryPage: React.FC<Props> = ({
@@ -34,9 +36,13 @@ const CreateDictionaryPage: React.FC<Props> = ({
   errors,
   createSourceAndDictionary,
   loading,
+  resetCreateDictionary,
   newDictionary
 }: Props) => {
   const previouslyLoading = usePrevious(loading);
+  
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => resetCreateDictionary, []);
 
   if (!loading && previouslyLoading && newDictionary) {
     return <Redirect to={newDictionary.url} />;
@@ -67,7 +73,8 @@ const mapStateToProps = (state: any) => ({
   errors: createSourceAndDictionaryErrorsSelector(state)
 });
 const mapActionsToProps = {
-  createSourceAndDictionary: createSourceAndDictionaryAction
+  createSourceAndDictionary: createSourceAndDictionaryAction,
+  resetCreateDictionary: resetCreateDictionaryAction
 };
 
 export default connect(

--- a/src/apps/dictionaries/pages/CreateDictionaryPage.tsx
+++ b/src/apps/dictionaries/pages/CreateDictionaryPage.tsx
@@ -17,6 +17,7 @@ import {
 import { APIOrg, APIProfile } from "../../authentication";
 import { usePrevious, CONTEXT } from "../../../utils";
 import { createSourceAndDictionaryAction } from "../redux/actions";
+import { resetCreateSourceAction, resetEditSourceAction } from "../../sources/redux";
 
 interface Props {
   errors?: {};

--- a/src/apps/dictionaries/pages/EditDictionaryPage.tsx
+++ b/src/apps/dictionaries/pages/EditDictionaryPage.tsx
@@ -22,6 +22,7 @@ import {CONTEXT, debug, usePrevious, useQueryParams} from "../../../utils"
 import {ProgressOverlay} from "../../../utils/components";
 import Header from "../../../components/Header";
 import {EditMenu} from "../../containers/components/EditMenu";
+import { resetCreateSourceAction, resetEditSourceAction } from "../../sources/redux";
 
 interface StateProps {
   errors?: {};

--- a/src/apps/dictionaries/pages/EditDictionaryPage.tsx
+++ b/src/apps/dictionaries/pages/EditDictionaryPage.tsx
@@ -12,6 +12,7 @@ import {
   editSourceAndDictionaryAction,
   editSourceAndDictionaryErrorsSelector,
   makeRetrieveDictionaryAction,
+  resetEditDictionaryAction,
   retrieveDictionaryLoadingSelector
 } from "../redux";
 import {APIDictionary, apiDictionaryToDictionary, Dictionary} from "../types";
@@ -43,6 +44,7 @@ interface ActionProps {
   createAndAddLinkedSource: (
     ...args: Parameters<typeof createAndAddLinkedSourceAction>
   ) => void;
+  resetEditDictionary: () => void;
 }
 
 type Props = StateProps & ActionProps;
@@ -63,6 +65,7 @@ const EditDictionaryPage: React.FC<Props> = ({
   dictionaryLoading,
   dictionary,
   editedDictionary,
+  resetEditDictionary,
   retrieveDictionary
 }: Props) => {
   const { pathname: url } = useLocation();
@@ -96,6 +99,8 @@ const EditDictionaryPage: React.FC<Props> = ({
     linkedSource,
     createAndAddLinkedSource
   ]);
+  
+  useEffect(() => resetEditDictionary, []);
 
   if (!loading && previouslyLoading && editedDictionary) {
     return <Redirect to={nextUrl || editedDictionary.url} />;
@@ -171,6 +176,7 @@ const mapStateToProps = (state: any) => ({
 
 const mapActionsToProps = {
   editSourceAndDictionary: editSourceAndDictionaryAction,
+  resetEditDictionary: resetEditDictionaryAction,
   retrieveDictionary: makeRetrieveDictionaryAction(false),
   createAndAddLinkedSource: createAndAddLinkedSourceAction
 };

--- a/src/apps/dictionaries/pages/EditDictionaryPage.tsx
+++ b/src/apps/dictionaries/pages/EditDictionaryPage.tsx
@@ -100,6 +100,7 @@ const EditDictionaryPage: React.FC<Props> = ({
     createAndAddLinkedSource
   ]);
   
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => resetEditDictionary, []);
 
   if (!loading && previouslyLoading && editedDictionary) {

--- a/src/apps/dictionaries/redux/actions.ts
+++ b/src/apps/dictionaries/redux/actions.ts
@@ -140,11 +140,18 @@ export function makeRetrieveDictionaryAction(useCache = false) {
   return createActionThunk(RETRIEVE_DICTIONARY_ACTION, api.retrieve, useCache);
 }
 export const resetCreateDictionaryAction = () => {
-  return (dispatch: Function) => dispatch(resetAction(CREATE_DICTIONARY_ACTION));
+  return (dispatch: Function) => {
+    dispatch(resetAction(CREATE_SOURCE_AND_DICTIONARY_ACTION));
+    dispatch(resetAction(CREATE_DICTIONARY_ACTION));
+  }
 }
 export const resetEditDictionaryAction = () => {
-  return (dispatch: Function) => dispatch(resetAction(EDIT_DICTIONARY_ACTION));
+  return (dispatch: Function) => {
+    dispatch(resetAction(EDIT_SOURCE_AND_DICTIONARY_ACTION));
+    dispatch(resetAction(EDIT_DICTIONARY_ACTION));
+  }
 }
+
 export const retrieveDictionaryAndDetailsAction = (dictionaryUrl: string) => {
   return async (dispatch: Function) => {
     const retrieveDictionaryResult = await dispatch(

--- a/src/apps/dictionaries/redux/actions.ts
+++ b/src/apps/dictionaries/redux/actions.ts
@@ -4,7 +4,8 @@ import {
   FAILURE,
   indexedAction,
   progressAction,
-  startAction
+  startAction,
+  resetAction
 } from "../../../redux";
 import api from "../api";
 import { APIDictionary, Dictionary, NewAPIDictionary, ImportMetaData } from "../types";
@@ -137,6 +138,12 @@ export const createSourceAndDictionaryAction = (dictionaryData: Dictionary) => {
 };
 export function makeRetrieveDictionaryAction(useCache = false) {
   return createActionThunk(RETRIEVE_DICTIONARY_ACTION, api.retrieve, useCache);
+}
+export const resetCreateDictionaryAction = () => {
+  return (dispatch: Function) => dispatch(resetAction(CREATE_DICTIONARY_ACTION));
+}
+export const resetEditDictionaryAction = () => {
+  return (dispatch: Function) => dispatch(resetAction(EDIT_DICTIONARY_ACTION));
 }
 export const retrieveDictionaryAndDetailsAction = (dictionaryUrl: string) => {
   return async (dispatch: Function) => {


### PR DESCRIPTION
# JIRA TICKET NAME:
https://issues.openmrs.org/browse/OCLOMRS-892

# Summary:
I added a react hook to reset the form state when you recreate a form.