### PR TITLE
OCLOMRS-855: Missing error message with wrong login credentials

### DIFF
--- a/src/apps/authentication/LoginPage.tsx
+++ b/src/apps/authentication/LoginPage.tsx
@@ -28,7 +28,7 @@ const LoginPage: React.FC<Props> = ({
   isLoggedIn,
   login,
   loading,
-  errors = {}
+  errors 
 }: Props) => {
   const classes = useStyles();
 
@@ -66,7 +66,7 @@ const LoginPage: React.FC<Props> = ({
           <Login
             onSubmit={login}
             loading={loading}
-            status={errors ? errors.detail : ""}
+            status={errors}
           />
         </Grid>
       </Grid>


### PR DESCRIPTION
# JIRA TICKET NAME:
https://issues.openmrs.org/browse/OCLOMRS-855

# Summary:
Fixed the validation error when one uses a wrong password or username by removing undefined object  which was making the error message not to be returned from the OCL API.