### PR TITLE
OCLOMRS-897:Update the wget command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,4 @@ services:
     - 8080:80
     restart: always
     healthcheck:
-      test: ["CMD", "curl", "-sSf", "localhost"]
+      test: ["CMD", "wget", "-q", "-s", "http://localhost/"]


### PR DESCRIPTION
# JIRA TICKET NAME:
[BLOCKER: Cannot deploy to production due to old broken wget command](https://issues.openmrs.org/browse/OCLOMRS-897)

# Summary:
- To deploy to production, we’ll need to get a change like this: https://github.com/openmrs/openmrs-contrib-ansible-docker-compose/commit/cfd1815679fefa25806fb6ce6bad323417b548e1 committed for the OCL production client (an upgrade in the nginx image used means the old wget command used to check the service status is broken) and get that pushed out to the relevant server
