### PR TITLE
OCLOMRS-929: Obscure api token on user profile page

### DIFF
--- a/src/apps/authentication/components/UserTokenDetails.tsx
+++ b/src/apps/authentication/components/UserTokenDetails.tsx
@@ -11,7 +11,11 @@ const useStyles = makeStyles({
     token: {
         wordBreak: "break-all",
         color: "black",
-        textAlign: "center"
+        textAlign: "center",
+        filter: "blur(5px)",
+        '&:hover': {
+            filter: "none"
+        }
     },
     container: {
         minWidth: "0"


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-929](https://issues.openmrs.org/browse/OCLOMRS-929)

# Summary:
This change uses a simple blur effect to obscure the user's API token on their profile page. The token is visible on hover and can be copied to clipboard just as before. This simple approach can help protect user API tokens from being accidentally compromised until we come up with a better approach.
