### PR TITLE
OCLOMRS-927: Export head dictionary as CSV and JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7194,6 +7194,11 @@
         }
       }
     },
+    "export-from-json": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/export-from-json/-/export-from-json-1.3.4.tgz",
+      "integrity": "sha512-upTnwNl5XIzzejEEzYOSkuJweT4qOXFK+IZyfSJj6rFJslUD70MGgs5pWJ7QXWHJWdkngqR4+N4zs3h4qy3MvA=="
+    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "axios": "^0.21.1",
     "clsx": "^1.1.1",
     "dayjs": "^1.9.3",
+    "export-from-json": "^1.3.4",
     "formik": "^1.5.8",
     "formik-material-ui": "0.0.22",
     "lodash": "^4.17.15",

--- a/src/apps/dictionaries/components/DictionaryConceptsSummary.tsx
+++ b/src/apps/dictionaries/components/DictionaryConceptsSummary.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import exportFromJSON from 'export-from-json'; //This seems to be reusuable in all sorts of exports i.e json,csv,txt etc
 import { APIDictionary } from "../../dictionaries";
 import {
   Button,
@@ -8,12 +9,11 @@ import {
   Typography,
   Menu,
   MenuItem,
-  IconButton,
+  IconButton
 } from "@material-ui/core";
 import { MoreVert, TableChartOutlined, FormatListBulleted } from "@material-ui/icons";
 import { Link } from "react-router-dom";
-import {useAnchor} from "../../../utils";
-import { CSVLink } from "react-csv";
+import {useAnchor, getDate} from "../../../utils";
 
 interface Props {
   dictionary: APIDictionary;
@@ -55,13 +55,10 @@ const DictionaryConceptsSummary: React.FC<Props> = ({ dictionary }) => {
   ).length;
   const customConceptCount = conceptReferences.length - fromPreferredSource;
 
-  const csvHeaders = [
-    { label: 'Concept Expression', key: 'expression' },
-    { label: 'Reference Type', key: 'reference_type' }
-  ];
 
   const { updated_on = ''} = dictionary || {};
-  // console.log(new Date(updated_on).toIsoDate())
+  const updatedDate = getDate(updated_on);
+
   return (
     <Paper className="fieldsetParent">
       <fieldset>
@@ -82,17 +79,11 @@ const DictionaryConceptsSummary: React.FC<Props> = ({ dictionary }) => {
           anchorEl={menuAnchor}
           open={Boolean(menuAnchor)}
           onClose={handleMenuClose}>
-            <MenuItem>
-            <CSVLink
-                headers={csvHeaders}
-                data={dictionary?.references}
-                filename={`${dictionary.name}_head_${dictionary.updated_on}.csv`}
-                enclosingCharacter={``}>
+            <MenuItem onClick={() => exportFromJSON({data: [dictionary], fileName: `${dictionary.name}_head_${updatedDate}.csv`, exportType: 'csv'})}>
               <TableChartOutlined /> 
               <span className={classes.addLeftPadding}>Export Head as CSV</span>
-              </CSVLink>
             </MenuItem>
-            <MenuItem>
+            <MenuItem onClick={() => exportFromJSON({data: dictionary, fileName: `${dictionary.name}_head_${updatedDate}.json`, exportType: 'json'})}>
               <FormatListBulleted /> 
               <span className={classes.addLeftPadding}>Export Head as JSON</span>
             </MenuItem>

--- a/src/apps/dictionaries/components/DictionaryConceptsSummary.tsx
+++ b/src/apps/dictionaries/components/DictionaryConceptsSummary.tsx
@@ -5,9 +5,15 @@ import {
   ButtonGroup,
   makeStyles,
   Paper,
-  Typography
+  Typography,
+  Menu,
+  MenuItem,
+  IconButton,
 } from "@material-ui/core";
+import { MoreVert, TableChartOutlined, FormatListBulleted } from "@material-ui/icons";
 import { Link } from "react-router-dom";
+import {useAnchor} from "../../../utils";
+import { CSVLink } from "react-csv";
 
 interface Props {
   dictionary: APIDictionary;
@@ -16,11 +22,24 @@ interface Props {
 const useStyles = makeStyles({
   conceptCountBreakDown: {
     marginLeft: "3vw"
+  },
+  iconButton: {
+    bottom: "1rem",
+    left: "28rem",
+    padding: "5px"
+  },
+  totalText: {
+    marginTop: "-1rem"
+  },
+  addLeftPadding: {
+    paddingLeft: "0.5rem"
   }
 });
 
 const DictionaryConceptsSummary: React.FC<Props> = ({ dictionary }) => {
+  const [menuAnchor, handleMenuClick, handleMenuClose] = useAnchor();
   const classes = useStyles();
+  console.log(dictionary, 'direction');
 
   const {
     references,
@@ -36,13 +55,49 @@ const DictionaryConceptsSummary: React.FC<Props> = ({ dictionary }) => {
   ).length;
   const customConceptCount = conceptReferences.length - fromPreferredSource;
 
+  const csvHeaders = [
+    { label: 'Concept Expression', key: 'expression' },
+    { label: 'Reference Type', key: 'reference_type' }
+  ];
+
+  const { updated_on = ''} = dictionary || {};
+  // console.log(new Date(updated_on).toIsoDate())
   return (
     <Paper className="fieldsetParent">
       <fieldset>
         <Typography component="legend" variant="h5" gutterBottom>
           Concepts(HEAD Version)
         </Typography>
-        <Typography variant="h6" gutterBottom>
+        <IconButton
+          className={classes.iconButton}
+          data-testid={"more-actions"}
+          aria-label='more'
+          aria-controls='menu'
+          aria-haspopup='true'
+          onClick={handleMenuClick}>
+          <MoreVert />
+        </IconButton>
+        <Menu
+          id='long-menu'
+          anchorEl={menuAnchor}
+          open={Boolean(menuAnchor)}
+          onClose={handleMenuClose}>
+            <MenuItem>
+            <CSVLink
+                headers={csvHeaders}
+                data={dictionary?.references}
+                filename={`${dictionary.name}_head_${dictionary.updated_on}.csv`}
+                enclosingCharacter={``}>
+              <TableChartOutlined /> 
+              <span className={classes.addLeftPadding}>Export Head as CSV</span>
+              </CSVLink>
+            </MenuItem>
+            <MenuItem>
+              <FormatListBulleted /> 
+              <span className={classes.addLeftPadding}>Export Head as JSON</span>
+            </MenuItem>
+        </Menu>
+        <Typography variant="h6" gutterBottom className={classes.totalText}>
           <b>Total Concepts: {conceptReferences.length}</b>
         </Typography>
         <Typography

--- a/src/apps/dictionaries/types.ts
+++ b/src/apps/dictionaries/types.ts
@@ -37,6 +37,7 @@ export interface APIDictionary extends BaseAPIDictionary {
   active_concepts: string;
   references: { [key: string]: string }[];
   concepts_url: string;
+  updated_on?: string;
 }
 
 export interface DictionaryState {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -116,3 +116,11 @@ export function stableSort<T>(array: T[], comparator: (a: T, b: T) => number) {
   });
   return stabilizedThis.map((el) => el[0]);
 }
+
+export const getDate = (date: any) => {
+  if (typeof date === 'object') {
+    const isoDate = date.toISOString();
+    return isoDate.substr(0, isoDate.indexOf('T'));
+  }
+  return typeof date === 'string' ? date.substr(0, date.indexOf('T')) : date;
+};


### PR DESCRIPTION
# JIRA TICKET NAME:
[Bulk Export of dictionaries to spreadsheet and JSON](https://issues.openmrs.org/browse/OCLOMRS-901)

# Summary:
[OCLOMRS-972](https://issues.openmrs.org/browse/OCLOMRS-927)

# Caveats
- I used another library `export-from-json` because it can easily export data in most forms hence `reusable` and deals well with nested data. cc @ibacher 