### PR TITLE
OCLOMRS-934: Fix the NO button on the dialog modal for deleting an organisation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8516,9 +8516,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "inquirer": {
       "version": "7.3.3",

--- a/src/apps/organisations/pages/EditOrgPage.tsx
+++ b/src/apps/organisations/pages/EditOrgPage.tsx
@@ -105,11 +105,11 @@ const EditOrganisationPage: React.FC<Props> = ({
         <MenuButton backUrl={orgUrl} confirmDelete={() => setOpenDialog(true)}/>
         <ConfirmationDialog
           open={openDialog}
-          setOpen={() => setOpenDialog(true)}
+          setOpen={() => setOpenDialog(!openDialog)}
           onConfirm={() => 
             {
               deleteOrg(orgUrl);
-              setOpenDialog(false);
+              setOpenDialog(!openDialog);
               setOpenAlert(true);
             }}
           message={confirmationMsg()}


### PR DESCRIPTION
Issue worked on 
# JIRA TICKET NAME:
[OCLOMRS-934](https://issues.openmrs.org/browse/OCLOMRS-934)

# Summary:
- I added functionality to the NO button found on the warning modal that appears when a user clicks the delete Organisation button on the Edit Organisation Page. 
