### PR TITLE
OCLOMRS-942: Wrong organisations returned for users

### DIFF
--- a/src/apps/authentication/api.ts
+++ b/src/apps/authentication/api.ts
@@ -4,7 +4,9 @@ const api = {
   login: (username: string, password: string) =>
     unAuthenticatedInstance.post("/users/login/", { username, password }),
   getProfile: () => authenticatedInstance.get("/user/"),
-  getUserOrgs: (username:string) => authenticatedInstance.get(`/users/${username}/orgs/?limit=0&sortAsc=name`)
+  getUserOrgs: (username: string) =>
+    authenticatedInstance
+      .get(`/users/${username}/orgs/?limit=0`)
 };
 
 export default api;

--- a/src/apps/authentication/components/UserOrganisationDetails.tsx
+++ b/src/apps/authentication/components/UserOrganisationDetails.tsx
@@ -1,70 +1,68 @@
 import React from "react";
-import {Paper, Typography} from "@material-ui/core";
-import {makeStyles} from "@material-ui/core/styles";
-import {APIOrg} from "../types";
+import { Paper, Typography } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import { APIOrg } from "../types";
 import List from "@material-ui/core/List";
-import * as _ from "lodash";
-
 interface Props {
-    orgs?: APIOrg[];
+  orgs?: APIOrg[];
 }
 
 const useStyles = makeStyles({
-    container: {
-        minWidth: "0"
-    },
-    orgList: {
-        maxHeight: 280,
-        overflow: "scroll",
-        color: "black"
-    },
-    orgItem: {
-        paddingBottom: "12px"
-    }
+  container: {
+    minWidth: "0"
+  },
+  orgList: {
+    maxHeight: 280,
+    overflow: "scroll",
+    color: "black"
+  },
+  orgItem: {
+    paddingBottom: "12px"
+  }
 });
 
-const UserOrganisationDetails: React.FC<Props> = ({
-                                                      orgs
-                                                  }) => {
-    const classes = useStyles();
+const UserOrganisationDetails: React.FC<Props> = ({ orgs }) => {
+  const classes = useStyles();
 
-    const getUserOrganisationsList = () => {
-        const OrganisationsList: Array<JSX.Element> = [];
-        if (orgs) {
-            _.sortBy(orgs, (org) => org.name).map(org => (
-                OrganisationsList.push(
-                    <li key={org.id} className={classes.orgItem}>
-                        {org.name}
-                    </li>
-                )
-            ));
-        }
-        return OrganisationsList;
-    };
+  const getUserOrganisationsList = () => {
+    const OrganisationsList: Array<JSX.Element> = orgs
+      ? [...orgs]
+          .sort((a, b) =>
+            a.name.toLocaleLowerCase().localeCompare(b.name.toLocaleLowerCase())
+          )
+          .map(org => (
+            <li key={org.id} className={classes.orgItem}>
+              {org.name}
+            </li>
+          ))
+      : [];
+    return OrganisationsList;
+  };
 
-    const getUserOrgsEmptyMessage = () => {
-        if (orgs && (orgs.length === 0)) {
-            return (<Typography data-testid="noUserOrgsMessage" align='center'>You're not part of any Organisation</Typography>)
-        }
-        return null;
-    };
+  const getUserOrgsEmptyMessage = () => {
+    if (orgs && orgs.length === 0) {
+      return (
+        <Typography data-testid="noUserOrgsMessage" align="center">
+          You're not part of any Organisation
+        </Typography>
+      );
+    }
+    return null;
+  };
 
-    return (
-        <Paper className='fieldsetParent'>
-            <fieldset className={classes.container}>
-                <Typography component='legend' variant='h5' gutterBottom>
-                    Your Organisations
-                </Typography>
-                {getUserOrgsEmptyMessage()}
-                <List className={classes.orgList}>
-                    <ul>
-                        {getUserOrganisationsList()}
-                    </ul>
-                </List>
-            </fieldset>
-        </Paper>
-    );
+  return (
+    <Paper className="fieldsetParent">
+      <fieldset className={classes.container}>
+        <Typography component="legend" variant="h5" gutterBottom>
+          Your Organisations
+        </Typography>
+        {getUserOrgsEmptyMessage()}
+        <List className={classes.orgList}>
+          <ul>{getUserOrganisationsList()}</ul>
+        </List>
+      </fieldset>
+    </Paper>
+  );
 };
-
 
 export default UserOrganisationDetails;


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-942: Wrong organisations returned for users](https://issues.openmrs.org/browse/OCLOMRS-942)

# Summary:

Drops the `sortAsc=name` parameter from the request getting the list of organisations and adopts case-insensitive, locale-sensitive sorting for the list of organisations where this is displayed to users.