### PR TITLE
OCLOMRS-923: Concept counts not displayed when using API2

### DIFF
--- a/src/apps/containers/api.ts
+++ b/src/apps/containers/api.ts
@@ -2,7 +2,20 @@ import { authenticatedInstance } from "../../api";
 
 const api = {
   retrieve: (containerUrl: string) =>
-    authenticatedInstance.get(containerUrl, { params: { verbose: true } })
+    authenticatedInstance.get(containerUrl, {
+      params: { 
+        verbose: true,
+        includeReferences: true
+      } 
+    }),
+  versions: {
+    retrieve: (containerUrl: string) =>
+      authenticatedInstance.get(`${containerUrl}versions/`, {
+        params: { 
+          verbose: true
+        } 
+      })
+  }
 };
 
 export default api;

--- a/src/apps/dictionaries/api.ts
+++ b/src/apps/dictionaries/api.ts
@@ -56,8 +56,7 @@ const api = {
     }
   },
   versions: {
-    retrieve: (dictionaryUrl: string) =>
-      authenticatedInstance.get(`${dictionaryUrl}versions/?verbose=true`),
+    ...containerAPI.versions,
     create: (
       dictionaryUrl: string,
       data: DictionaryVersion
@@ -70,10 +69,10 @@ const api = {
         authenticatedInstance.put(`${dictionaryUrl}${data.id}/`, data)
   },
   retrieveMappings: (
-    sourceUrl: string,
+    dictionaryUrl: string,
     fromConceptIds: string[]
   ) =>
-    authenticatedInstance.get(`${sourceUrl}mappings/`, {
+    authenticatedInstance.get(`${dictionaryUrl}mappings/`, {
       params: {
         fromConcept: fromConceptIds.join(","),
         limit: 0 // bad, todo optimize this

--- a/src/apps/sources/api.ts
+++ b/src/apps/sources/api.ts
@@ -46,8 +46,7 @@ const api = {
             }),
     },
   },versions: {
-    retrieve: (sourceUrl: string) =>
-      authenticatedInstance.get(`${sourceUrl}versions/?verbose=true`),
+    ...containerAPI.versions,
     create: (
       sourceUrl: string,
       data: SourceVersion


### PR DESCRIPTION
# JIRA TICKET NAME:
[Concept counts not displayed when using API2](https://issues.openmrs.org/browse/OCLOMRS-923)

# Summary:

Fixes this issue by appending the `includeReferences=true` when loading the dictionary.
