### PR TITLE
OCLOMRS-491: Restyle already added concepts and add a tick icon.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,12 +96,14 @@ const AuthenticatedRoutes: React.FC = () => {
           newConcept={true}
           viewConcept={true}
           viewConcepts={true}
+          viewDictConcepts={false}
         />
       </Route>
       <Route path='/:ownerType/:owner/collections/:collection/concepts'>
         <ConceptRoutes
           containerType={DICTIONARY_CONTAINER}
           viewConcepts={true}
+          viewDictConcepts={true}
         />
       </Route>
       <Route path='/:ownerType/:owner/collections/:collection/:version/concepts'>

--- a/src/apps/concepts/Routes.tsx
+++ b/src/apps/concepts/Routes.tsx
@@ -11,6 +11,7 @@ interface Props {
   newConcept?: boolean;
   viewConcept?: boolean;
   editConcept?: boolean;
+  viewDictConcepts?: boolean;
   containerType: string;
 }
 
@@ -19,7 +20,8 @@ const Routes: React.FC<Props> = ({
   viewConcepts = false,
   newConcept = false,
   viewConcept = false,
-  editConcept = false
+  editConcept = false,
+  viewDictConcepts = false,
 }) => {
   // @ts-ignore
   let { path } = useRouteMatch();
@@ -28,7 +30,7 @@ const Routes: React.FC<Props> = ({
     <Switch>
       {!viewConcepts ? null : (
         <Route exact path={`${path}/`}>
-          <ViewConceptsPage key={containerType} containerType={containerType} />
+          <ViewConceptsPage key={containerType} containerType={containerType} viewDictConcepts={viewDictConcepts} />
         </Route>
       )}
       {!newConcept ? null : (

--- a/src/apps/concepts/components/AlreadyAddedIcon.tsx
+++ b/src/apps/concepts/components/AlreadyAddedIcon.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+import { CheckOutlined as CheckedIcon } from "@material-ui/icons";
+import { Tooltip } from "@material-ui/core";
+
+export const AlreadyAddedIcon: React.FC = () => {
+  return (
+      <Tooltip title="Already Added">
+          <CheckedIcon />
+      </Tooltip>
+  );
+};

--- a/src/apps/concepts/components/AlreadyAddedIcon.tsx
+++ b/src/apps/concepts/components/AlreadyAddedIcon.tsx
@@ -6,7 +6,7 @@ import { Tooltip } from "@material-ui/core";
 export const AlreadyAddedIcon: React.FC = () => {
   return (
       <Tooltip title="Already Added">
-          <CheckedIcon />
+          <CheckedIcon style={{marginLeft: "0.75rem"}}/>
       </Tooltip>
   );
 };

--- a/src/apps/concepts/components/ConceptsTableRow.tsx
+++ b/src/apps/concepts/components/ConceptsTableRow.tsx
@@ -10,6 +10,7 @@ import {
 import { MoreVert as MoreVertIcon } from "@material-ui/icons";
 import { Link } from "react-router-dom";
 import { ConceptsActionMenu } from "./ConceptsActionMenu";
+import { AlreadyAddedIcon } from "./AlreadyAddedIcon";
 
 export function showEditMenuItem(
   concept: APIConcept,
@@ -206,6 +207,12 @@ const actionCell = (
   );
 };
 
+const AlreadyCheckedCell = () =>
+  <TableCell padding='checkbox'>
+    <AlreadyAddedIcon />
+  </TableCell>;
+
+
 interface ConceptsTableRowProps {
   row: APIConcept;
   index: number;
@@ -254,6 +261,8 @@ export function ConceptsTableRow(props: ConceptsTableRowProps) {
       tabIndex={-1}
       key={`${row.id}-${index}`}
       selected={isItemSelected}
+      className={row?.added ? 'added': ''}
+      style={row?.added ? { backgroundColor: '#bbc5fb' } : { backgroundColor: 'none' }}
     >
       {selected.length <= 0
         ? null
@@ -262,18 +271,20 @@ export function ConceptsTableRow(props: ConceptsTableRowProps) {
       {conceptClassCell(toggleSelect, row)}
       {conceptDataTypeCell(toggleSelect, row)}
       {conceptIDCell(toggleSelect, row)}
-      {actionCell(
-        row,
-        buttons,
-        canModifyConcept,
-        index,
-        toggleMenu,
-        menu,
-        removeConceptsFromDictionary,
-        addConceptsToDictionary,
-        linkedSource,
-        linkedDictionary
-      )}
+      {row.added ? AlreadyCheckedCell(): 
+        actionCell(
+          row,
+          buttons,
+          canModifyConcept,
+          index,
+          toggleMenu,
+          menu,
+          removeConceptsFromDictionary,
+          addConceptsToDictionary,
+          linkedSource,
+          linkedDictionary
+        )
+      }
     </TableRow>
   );
 }

--- a/src/apps/concepts/pages/CreateOrEditConceptPage.tsx
+++ b/src/apps/concepts/pages/CreateOrEditConceptPage.tsx
@@ -17,7 +17,6 @@ import { APIConcept, apiConceptToConcept, APIMapping, Concept } from "../types";
 import { Redirect, useLocation, useParams } from "react-router";
 import { connect } from "react-redux";
 import Header from "../../../components/Header";
-import { startCase, toLower } from "lodash";
 import {
   debug,
   ProgressOverlay,

--- a/src/apps/concepts/types.ts
+++ b/src/apps/concepts/types.ts
@@ -58,6 +58,7 @@ export interface BaseConcept {
   url?: string;
   version_url?: string;
   extras: Extras | null;
+  added?: boolean;
 }
 
 export interface Concept extends BaseConcept {


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-491](https://issues.openmrs.org/browse/OCLOMRS-491)

# Summary:
- Disable the add concept button on the CIEL concepts page when a specific concept is added.
<img width="1114" alt="Screenshot 2021-03-18 at 20 20 44" src="https://user-images.githubusercontent.com/30952856/111669182-93d14680-8827-11eb-84c9-f8b629e82d2f.png">
<img width="1440" alt="Screenshot 2021-03-18 at 20 19 42" src="https://user-images.githubusercontent.com/30952856/111669195-97fd6400-8827-11eb-94a6-ce7a5e8e5e7c.png">


