### PR TITLE
OCLOMRS-959: Display OCL for OpenMRS Client Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ FROM nginx:1.19-alpine
 # Make port 80 available to the world outside the container
 EXPOSE 80
 
+# Copy the CI build number
+ARG OCL_BUILD
+ENV OCL_BUILD $OCL_BUILD
+
 # Copy the tagged files from the build to the production environmnet of the nginx server
 COPY --from=build-deps /usr/src/app/build /usr/share/nginx/html
 

--- a/src/apps/authentication/LoginPage.tsx
+++ b/src/apps/authentication/LoginPage.tsx
@@ -6,6 +6,7 @@ import { Login } from "./components";
 import { authErrorsSelector, authLoadingSelector } from "./redux/reducer";
 import { clearNextPageAction, loginAction } from "./redux";
 import { AppState } from "../../redux/types";
+import { BUILD } from "../../utils";
 
 interface Props {
   isLoggedIn: boolean;
@@ -24,6 +25,9 @@ const useStyles = makeStyles({
   headerText: {
     textAlign: "center",
     margin: "-6vh 0 5vh 0"
+  },
+  footerText: {
+    textAlign: "center"
   }
 });
 
@@ -59,29 +63,38 @@ const LoginPage: React.FC<Props> = ({
     return <Redirect to="/" />;
   } else {
     return (
-      <Grid
-        container
-        justify="center"
-        alignItems="center"
-        className={classes.loginPage}
-        component={Container}
-      >
-        <Grid xs={4} item component="div">
-          <div className={classes.headerText}>
-            <Typography variant="h3" component="h3">
-              Open Concept Lab
-            </Typography>
-            <Typography variant="h4" component="h4">
-              for OpenMRS
-            </Typography>
-            <Typography variant="subtitle1" component="span">
-              Use the shared Open Concept Lab to create OpenMRS dictionaries by
-              mixing expert-defined content with your own custom concepts.
-            </Typography>
-          </div>
-          <Login onSubmit={login} loading={loading} status={errors} />
+      <>
+        <Grid
+          container
+          justify="center"
+          alignItems="center"
+          className={classes.loginPage}
+          component={Container}
+        >
+          <Grid xs={4} item component="div">
+            <div className={classes.headerText}>
+              <Typography variant="h3" component="h3">
+                Open Concept Lab
+              </Typography>
+              <Typography variant="h4" component="h4">
+                for OpenMRS
+              </Typography>
+              <Typography variant="subtitle1" component="span">
+                Use the shared Open Concept Lab to create OpenMRS dictionaries
+                by mixing expert-defined content with your own custom concepts.
+              </Typography>
+            </div>
+            <Login onSubmit={login} loading={loading} status={errors} />
+          </Grid>
         </Grid>
-      </Grid>
+        <Typography
+          variant="caption"
+          className={classes.footerText}
+          component="div"
+        >
+          OCL for OMRS Build: {BUILD}
+        </Typography>
+      </>
     );
   }
 };

--- a/src/apps/concepts/components/ViewConceptsHeader.tsx
+++ b/src/apps/concepts/components/ViewConceptsHeader.tsx
@@ -107,7 +107,7 @@ const ViewConceptsHeader: React.FC<Props> = ({
       backText={
         containerType === SOURCE_CONTAINER ? undefined : "Back to dictionary"
       }
-    ></Header>
+    />
   );
 };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 interface Props {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   title: string;
   justifyChildren?: string;
   loadingList: boolean[];

--- a/src/components/NavDrawer.tsx
+++ b/src/components/NavDrawer.tsx
@@ -38,6 +38,7 @@ import {
 } from "../apps/authentication";
 import { action } from "../redux/utils";
 import { AppState } from "../redux";
+import { BUILD } from "../utils";
 
 const drawerWidth = 240;
 
@@ -134,14 +135,14 @@ export const NavDrawer: React.FC<Props> = ({ children, logout, profile }) => {
       >
         <div className={classes.toolbar}>
           {open ? (
-            <span>
+            <div>
               <Typography variant="h6" noWrap>
                 Open Concept Lab
                 <IconButton onClick={toggleDrawer}>
                   <ChevronLeftIcon />
                 </IconButton>
               </Typography>
-            </span>
+            </div>
           ) : (
             <IconButton onClick={toggleDrawer}>
               <MenuIcon />
@@ -280,6 +281,15 @@ export const NavDrawer: React.FC<Props> = ({ children, logout, profile }) => {
               </Button>
             </DialogActions>
           </Dialog>
+          {open && (
+            <Typography
+              variant="caption"
+              component="div"
+              className="MuiListItem-gutters"
+            >
+              OCL for OMRS Build: {BUILD}
+            </Typography>
+          )}
         </div>
       </Drawer>
       <main className={classes.content}>{children}</main>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,6 +9,9 @@ export const TRADITIONAL_OCL_URL =
 export const OCL_SIGNUP_URL =
   // @ts-ignore OCL_SIGNUP_URL is injected at runtime via index.html
   window.OCL_SIGNUP_URL || "https://qa.openconceptlab.org/accounts/signup/";
+export const BUILD: string =
+  // @ts-ignore BUILD is injected at runtime via index.html
+  window.BUILD || "local";
 
 export const CUSTOM_VALIDATION_SCHEMA = "OpenMRS";
 

--- a/startup.sh
+++ b/startup.sh
@@ -10,6 +10,8 @@ echo "// Version: $(date -u)" > ${ENV_FILE}
   echo "var OCL_API_HOST = \"${OCL_API_HOST}\";" >> ${ENV_FILE}
 [ -n "${OCL_SIGNUP_URL}" ] && \
   echo "var OCL_SIGNUP_URL = \"${OCL_SIGNUP_URL}\";" >> ${ENV_FILE}
+[ -n "${OCL_BUILD}" ] && \
+  echo "var BUILD = \"${OCL_BUILD}\";" >> ${ENV_FILE}
 
 echo "Using env-config.js:"
 cat ${ENV_FILE}


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-959: Display OCL for OpenMRS Client Build](https://issues.openmrs.org/browse/OCLOMRS-959)

# Summary:

Adds a build number indicator to the login page and to the nav bar when the nav bar is expanded as show below:

<img width="526" alt="Screenshot showing the login page with a build number" src="https://user-images.githubusercontent.com/52504170/113345378-5b8a3780-9300-11eb-9c41-c5754c49c347.png">

<img width="243" alt="Screenshot showing an expanded nav bar with a build number" src="https://user-images.githubusercontent.com/52504170/113345385-5f1dbe80-9300-11eb-8063-0b562e5ff48a.png">

