### PR TITLE
OCLOMRS-932: Hide retired concepts & add option to include retired concepts

### DIFF
--- a/src/apps/concepts/api.ts
+++ b/src/apps/concepts/api.ts
@@ -55,7 +55,7 @@ const api = {
           ...optionallyIncludeList("conceptClass", classFilters),
           ...optionallyIncludeList("source", sourceFilters),
           timestamp: new Date().getTime(),
-          includeRetired: includeRetired ? 1 : 0
+          includeRetired
         }
       });
     },

--- a/src/apps/concepts/pages/ViewConceptsPage.tsx
+++ b/src/apps/concepts/pages/ViewConceptsPage.tsx
@@ -210,7 +210,7 @@ const ViewConceptsPage: React.FC<Props> = ({
       dataTypeFilters: initialDataTypeFilters,
       classFilters: initialClassFilters,
       sourceFilters: initialSourceFilters,
-      includeRetired: initialGeneralFilters.includes("IncludeRetired")
+      includeRetired: initialGeneralFilters.includes("Include Retired")
     });
     // i don't know how the comparison algorithm works, but for these arrays, it fails.
     // stringify the arrays to work around that

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -310,4 +310,5 @@ export const CONTEXT = {
   view: "view",
   edit: "edit"
 };
-export const CONCEPT_GENERAL: string[] = ["IncludeRetired"];
+
+export const CONCEPT_GENERAL: string[] = ["Include Retired"];


### PR DESCRIPTION

# JIRA TICKET NAME:
[General Filter: Hide Retired Concepts & Add Filter option to Include Retired Concepts](https://issues.openmrs.org/browse/OCLOMRS-932)

# Summary:
I changed includeRetired: includeRetired ? 1 : 0
Back to :

includeRetired

to enable filtering of retired concepts well.