### PR TITLE
OCLOMRS-962:Error:Cannot Edit Organization

### DIFF
--- a/src/apps/organisations/api.ts
+++ b/src/apps/organisations/api.ts
@@ -35,7 +35,7 @@ const api = {
   organisation: {
     retrieve: (url: string) => authenticatedInstance.get(url),
     update: (orgUrl: string, data: EditableOrganisationFields) =>
-      authenticatedInstance.post(orgUrl, data),
+      authenticatedInstance.put(orgUrl, data),
     delete: (orgUrl: string) => authenticatedInstance.delete(orgUrl),
     retrieveSources: (orgUrl: string) =>
       authenticatedInstance.get(`${orgUrl}sources/`),


### PR DESCRIPTION
# JIRA TICKET NAME:
[Error:Cannot Edit Organization](https://issues.openmrs.org/browse/<OCLOMRS-962>)

# Summary:
I replaced the `post` in the  `src/apps/organisations/api.ts` file with `put` because the error from the api  after editing the changes indicated we are re-creating the page and couldn't save the changes successfully but with `put` when updating the file saves the changes successfully.