### PR TITLE
OCLOMRS-979 : When creating a dictionary, the selected owner is now v…

### DIFF
--- a/src/apps/dictionaries/components/DictionaryForm.tsx
+++ b/src/apps/dictionaries/components/DictionaryForm.tsx
@@ -245,7 +245,6 @@ const DictionaryForm: React.FC<Props> = ({
               <FormControl fullWidth margin="normal">
                 <InputLabel htmlFor="owner_url">Owner</InputLabel>
                 <Field
-                  value=""
                   disabled={editing || isSubmitting}
                   name="owner_url"
                   id="owner_url"


### PR DESCRIPTION
…isible

# JIRA TICKET NAME:
[OCLOMRS-979](https://issues.openmrs.org/browse/OCLOMRS-979)

# Summary:
When creating a dictionary, the selected owner was not visible
after changes
![image](https://user-images.githubusercontent.com/58779460/115105033-f67a4700-9f79-11eb-9bb0-571f607f4c55.png)

