### PR TITLE
OCLOMRS-964 : make header stick to the top

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,7 +23,10 @@ import { Link, useHistory } from "react-router-dom";
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     appBar: {
-      paddingLeft: theme.spacing(7) + 1
+      paddingLeft: theme.spacing(7) + 1,
+      position: "sticky",
+      top: "0",
+      width: "100%"
     },
     content: {
       marginTop: "6vh",


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-964](https://issues.openmrs.org/browse/OCLOMRS-964)

This functionality is not working for all the pages
this might be because of these:
- position sticky will most probably not work if overflow is set to hidden, scroll, or auto on any of the parents of the element.
- position sticky may not work correctly if any parent element has a set height.
but not able to found any of these above possibilities

https://user-images.githubusercontent.com/58779460/115831760-a7c42580-a42f-11eb-8020-fccad284e542.mp4

eg:
it is working on View Dictionary page
Not working o View Concept page
