### PR TITLE
OCLOMRS-1002: Remove the start to fix the request.

### DIFF
--- a/src/apps/concepts/__test__/api.test.ts
+++ b/src/apps/concepts/__test__/api.test.ts
@@ -71,7 +71,7 @@ describe("api", () => {
       params: {
         limit: 1,
         page: 1,
-        q: "*",
+        q: "",
         sortAsc: "bestMatch",
         timestamp: expect.anything()
       }

--- a/src/apps/sources/__test__/api.test.ts
+++ b/src/apps/sources/__test__/api.test.ts
@@ -24,7 +24,7 @@ describe("api", () => {
       params: {
         limit: 20,
         page: 1,
-        q: "*",
+        q: "",
         timestamp: expect.anything()
       }
     });
@@ -42,7 +42,7 @@ describe("api", () => {
       params: {
         limit: 20,
         page: 1,
-        q: "*",
+        q: "",
         timestamp: expect.anything()
       }
     });

--- a/src/utils/tests/unit/utils.test.ts
+++ b/src/utils/tests/unit/utils.test.ts
@@ -15,13 +15,4 @@ describe("findLocale", () => {
   });
 });
 
-describe("buildPartialSearchQuery", () => {
-  it("should add asterisks before all spaces", () => {
-    expect(buildPartialSearchQuery("a b")).toBe("a* b*");
-  });
-  it("should add asterisks to end of search string", () => {
-    expect(buildPartialSearchQuery("ab")).toBe("ab*");
-  });
-});
-
 export {};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -77,7 +77,7 @@ export const keysToSnakeCase = (item?: any) => {
 };
 
 export const buildPartialSearchQuery = (query: string): string =>
-  `${query.replace(new RegExp(" ", "g"), "* ")}*`;
+  `${query.replace(new RegExp(" ", "g"), "* ")}`;
 
 export const delay = (seconds: number) =>
   new Promise(resolve => setTimeout(resolve, seconds * 1000));


### PR DESCRIPTION
# JIRA TICKET NAME:
[Remove the star on the query paramater](https://issues.openmrs.org/browse/OCLOMRS-1002)

# Summary:
- Remove the default `q*` from the request since the API no longer supports it.
