### PR TITLE
Re-branding as OpenMRS Dictionary Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ### [![Build Status](https://github.com/openmrs/openmrs-ocl-client/actions/workflows/build.yml/badge.svg)](https://github.com/openmrs/openmrs-ocl-client/actions/workflows/build.yml) [![Coverage Status](https://coveralls.io/repos/github/openmrs/openmrs-ocl-client/badge.svg?branch=master)](https://coveralls.io/github/openmrs/openmrs-ocl-client?branch=master)
 
-# openmrs-ocl-client
-> OCL client for OpenMRS is a web service that will allow OpenMRS users to manage their dictionaries in the cloud,
-> allow re-usability of the existing concepts and allow one to create custom concepts to complement existing ones while building their dictionaries.
+# OpenMRS Dictionary Manager
+
+The OpenMRS Dictionary Manager is a tool to create and maintain OpenMRS concept dictionaries in the cloud, using both expert-curated concepts from sources such as CIEL as well as custom implementation-specific concepts.
 
 ## Available Scripts
 ### `npm start`

--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
       "url": "https://github.com/mars/create-react-app-buildpack.git"
     }
   ],
-  "description": "Open Concept Lab Client for OpenMRS",
+  "description": "OpenMRS Dictionary Manager",
   "env": {},
   "formation": {
     "web": {

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" prefix="og: https://ogp.me/ns#">
 <head>
     <meta charset="utf-8"/>
     <script type="text/javascript" src="%PUBLIC_URL%/env-config.js"></script>
@@ -8,9 +8,15 @@
     <meta name="theme-color" content="#000000"/>
     <meta
             name="description"
-            content="Open Concept Lab for OpenMRS"
+            content="OpenMRS Dictionary Manager"
     />
-    <link rel="apple-touch-icon" href="logo192.png"/>
+    <meta property="twitter:card" content="summary"/>
+    <meta property="og:title" content="OpenMRS Dictionary Manager"/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:url" content="https://openmrs.openconceptlab.org"/>
+    <meta property="og:description" content="A tool to create OpenMRS dictionaries that mix both expert-defined content and your custom concepts"/>
+    <meta property="og:determiner" content="the"/>
+    <meta property="og:locale" content="en_US"/>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -25,7 +31,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>OCL for OpenMRS</title>
+    <title>OpenMRS Dictionary Manager</title>
 </head>
 <body>
 <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/apps/authentication/LoginPage.tsx
+++ b/src/apps/authentication/LoginPage.tsx
@@ -6,7 +6,7 @@ import { Login } from "./components";
 import { authErrorsSelector, authLoadingSelector } from "./redux/reducer";
 import { clearNextPageAction, loginAction } from "./redux";
 import { AppState } from "../../redux/types";
-import { BUILD } from "../../utils";
+import { BUILD, TRADITIONAL_OCL_URL } from "../../utils";
 
 interface Props {
   isLoggedIn: boolean;
@@ -22,9 +22,12 @@ const useStyles = makeStyles({
     display: "flex",
     height: "100vh"
   },
-  headerText: {
+  header: {
     textAlign: "center",
     margin: "-6vh 0 5vh 0"
+  },
+  title: {
+    marginBottom: "1.3rem"
   },
   footerText: {
     textAlign: "center"
@@ -42,10 +45,10 @@ const LoginPage: React.FC<Props> = ({
   const classes = useStyles();
 
   useEffect(() => {
-    document.title = `Login | OCL for OpenMRS`;
+    document.title = `Login | OpenMRS Dictionary Manager`;
 
     return () => {
-      document.title = "OCL for OpenMRS";
+      document.title = "OpenMRS Dictionary Manager";
     };
   }, []);
 
@@ -71,19 +74,22 @@ const LoginPage: React.FC<Props> = ({
           className={classes.loginPage}
           component={Container}
         >
-          <Grid xs={4} item component="div">
-            <div className={classes.headerText}>
-              <Typography variant="h3" component="h3">
-                Open Concept Lab
-              </Typography>
-              <Typography variant="h4" component="h4">
-                for OpenMRS
+          <Grid xs={5} item component="div" justify="center" alignItems="center" className={classes.header}>
+              <Typography variant="h3" component="h3" className={classes.title}>
+                OpenMRS Dictionary Manager
               </Typography>
               <Typography variant="subtitle1" component="span">
-                Use the shared Open Concept Lab to create OpenMRS dictionaries
-                by mixing expert-defined content with your own custom concepts.
+                Use the shared{" "}
+                <a
+                  href={TRADITIONAL_OCL_URL}
+                  target="_blank"
+                  rel="external noopener noreferrer"
+                >
+                  Open Concept Lab
+                </a>{" "}
+                environment to create OpenMRS dictionary by mixing
+                expert-defined content with your own custom concepts.
               </Typography>
-            </div>
             <Login onSubmit={login} loading={loading} status={errors} />
           </Grid>
         </Grid>
@@ -92,7 +98,7 @@ const LoginPage: React.FC<Props> = ({
           className={classes.footerText}
           component="div"
         >
-          OCL for OMRS Build: {BUILD}
+          OpenMRS Dictionary Manager: {BUILD}
         </Typography>
       </>
     );

--- a/src/apps/authentication/components/Login.tsx
+++ b/src/apps/authentication/components/Login.tsx
@@ -62,7 +62,7 @@ const Login: React.FC<Props> = ({ onSubmit, loading, status }) => {
           <Form className="fieldsetParent">
             <fieldset>
               <Typography variant="h6" component="legend">
-                Log In to Open Concept Lab
+                Log In
               </Typography>
               <div className={classes.fields}>
                 <Field
@@ -133,7 +133,7 @@ const Login: React.FC<Props> = ({ onSubmit, loading, status }) => {
                       variant="body2"
                       href={TRADITIONAL_OCL_URL}
                     >
-                      Go to Traditional OCL
+                      Go to Open Concept Lab
                     </Link>
                   </div>
                 </div>

--- a/src/apps/concepts/components/ConceptForm.tsx
+++ b/src/apps/concepts/components/ConceptForm.tsx
@@ -335,7 +335,7 @@ const ConceptForm: React.FC<Props> = ({
                 fullWidth
                 id="external_id"
                 name="external_id"
-                label="OpenMRS UUID (OCL External ID)"
+                label="OpenMRS UUID"
                 margin="normal"
                 disabled={!isExternalIDEditable}
                 component={TextField}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -65,7 +65,7 @@ const Header: React.FC<Props> = ({
 
   const classes = useStyles();
   useEffect(() => {
-    document.title = `${title} | OCL for OpenMRS`;
+    document.title = `${title} | OpenMRS Dictionary Manager`;
   }, [title]);
   const history = useHistory();
 

--- a/src/components/NavDrawer.tsx
+++ b/src/components/NavDrawer.tsx
@@ -55,7 +55,6 @@ const useStyles = makeStyles((theme: Theme) =>
       flexShrink: 0
     },
     drawerOpen: {
-      width: drawerWidth,
       whiteSpace: "normal",
       transition: theme.transitions.create("width", {
         easing: theme.transitions.easing.sharp,
@@ -135,14 +134,16 @@ export const NavDrawer: React.FC<Props> = ({ children, logout, profile }) => {
       >
         <div className={classes.toolbar}>
           {open ? (
+            <>
             <div>
-              <Typography variant="h6" noWrap>
-                Open Concept Lab
-                <IconButton onClick={toggleDrawer}>
-                  <ChevronLeftIcon />
-                </IconButton>
+              <Typography variant="h6">
+                Dictionary Manager
               </Typography>
             </div>
+            <IconButton onClick={toggleDrawer}>
+              <ChevronLeftIcon />
+            </IconButton>
+            </>
           ) : (
             <IconButton onClick={toggleDrawer}>
               <MenuIcon />
@@ -193,14 +194,14 @@ export const NavDrawer: React.FC<Props> = ({ children, logout, profile }) => {
             exact
             activeClassName={classes.selected}
             to="/actions/"
-            key="Progress Notifications"
+            key="Notifications"
           >
-            <Tooltip title="Progress Notifications">
+            <Tooltip title="Notifications">
               <ListItemIcon className="list-item-icon">
                 <NotificationsIcon />
               </ListItemIcon>
             </Tooltip>
-            <ListItemText primary="Progress Notifications" />
+            <ListItemText primary="Notifications" />
           </ListItem>
         </List>
         <Divider component="hr" />
@@ -281,16 +282,16 @@ export const NavDrawer: React.FC<Props> = ({ children, logout, profile }) => {
               </Button>
             </DialogActions>
           </Dialog>
-          {open && (
+        </div>
+        {open && (
             <Typography
               variant="caption"
               component="div"
               className="MuiListItem-gutters"
             >
-              OCL for OMRS Build: {BUILD}
+              OpenMRS Dictionary Manager: {BUILD}
             </Typography>
           )}
-        </div>
       </Drawer>
       <main className={classes.content}>{children}</main>
     </div>


### PR DESCRIPTION
# Summary:
Some light re-branding as the OpenMRS Dictionary Manager

Most of the changes are in these two screenshots:

<img width="756" alt="Screenshot of rebranded login page" src="https://user-images.githubusercontent.com/52504170/121580797-28001380-c9fb-11eb-9d09-9a06f40d4249.png">

<img width="261" alt="Screenshot of rebranded nav bar" src="https://user-images.githubusercontent.com/52504170/121580847-33ebd580-c9fb-11eb-8e0a-5c13c2279e0d.png">

