### PR TITLE
OCLOMRS-933: Add ability to include and exclude already added concepts.

### DIFF
--- a/src/apps/concepts/api.ts
+++ b/src/apps/concepts/api.ts
@@ -32,6 +32,7 @@ const api = {
       classFilters?: string[];
       sourceFilters?: string[];
       includeRetired?: boolean;
+      includeAdded?: boolean;
     }) => {
       const {
         conceptsUrl = "#",
@@ -43,7 +44,8 @@ const api = {
         dataTypeFilters = [] as string[],
         classFilters = [] as string[],
         sourceFilters = [] as string[],
-        includeRetired = false
+        includeRetired = false,
+        includeAdded = false
       } = retrieveParams;
       return authenticatedInstance.get(conceptsUrl, {
         params: {
@@ -55,7 +57,8 @@ const api = {
           ...optionallyIncludeList("conceptClass", classFilters),
           ...optionallyIncludeList("source", sourceFilters),
           timestamp: new Date().getTime(),
-          includeRetired
+          includeRetired,
+          includeAdded
         }
       });
     },

--- a/src/apps/concepts/pages/ViewConceptsPage.tsx
+++ b/src/apps/concepts/pages/ViewConceptsPage.tsx
@@ -183,10 +183,15 @@ const ViewConceptsPage: React.FC<Props> = ({
   const [dataTypeFilters, setInitialDataTypeFilters] = useState<string[]>(
     initialDataTypeFilters
   );
-  const [generalFilters, setGeneralFilters] = useState(initialGeneralFilters);
+  const [generalFilters, setGeneralFilters] = useState<string[]>(initialGeneralFilters);
   const [sourceFilters, setSourceFilters] = useState<string[]>(
     initialSourceFilters
   );
+
+  const excludeAddedConceptsUrl = `${url}?collection=!${dictionary?.name}&collectionOwnerUrl=!${dictionary?.owner_url}`;
+  const includeAddedConcepts = generalFilters.includes('Include Added Concepts');
+  const isImporting = dictionaryToAddTo !== undefined;
+
   const [q, setQ] = useState(initialQ);
 
   const gimmeAUrl = (params: QueryParams = {}, conceptsUrl: string = url) => {
@@ -214,7 +219,7 @@ const ViewConceptsPage: React.FC<Props> = ({
       : retrieveDictionary(containerUrl);
 
     retrieveConcepts({
-      conceptsUrl: url,
+      conceptsUrl: isImporting ? (includeAddedConcepts ? url : excludeAddedConceptsUrl) : url,
       page: page,
       limit: limit,
       q: initialQ,
@@ -223,7 +228,8 @@ const ViewConceptsPage: React.FC<Props> = ({
       dataTypeFilters: initialDataTypeFilters,
       classFilters: initialClassFilters,
       sourceFilters: initialSourceFilters,
-      includeRetired: initialGeneralFilters.includes("Include Retired")
+      includeRetired: initialGeneralFilters.includes("Include Retired"),
+      includeAdded: generalFilters.includes("Include Added Concepts")
     });
     // i don't know how the comparison algorithm works, but for these arrays, it fails.
     // stringify the arrays to work around that

--- a/src/apps/sources/pages/ViewSourcePage.tsx
+++ b/src/apps/sources/pages/ViewSourcePage.tsx
@@ -113,7 +113,8 @@ export const ViewSourcePage: React.FC<Props> = ({
     retrieveConceptsSummary({
       conceptsUrl: `${url}concepts/`,
       limit: 1,
-      includeRetired: true
+      includeRetired: true,
+      includeAdded: false
     });
   }, [url, retrieveConceptsSummary]);
   useEffect(() => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -311,4 +311,4 @@ export const CONTEXT = {
   edit: "edit"
 };
 
-export const CONCEPT_GENERAL: string[] = ["Include Retired"];
+export const CONCEPT_GENERAL: string[] = ["Include Retired", "Include Added Concepts"];


### PR DESCRIPTION
# JIRA TICKET NAME:
[General Filter: Hide Added Concepts & Add Filter option to Include Added Concepts
](https://issues.openmrs.org/browse/OCLOMRS-933)

# Summary:
- Added ability to include and exclude.
## Caveats
- Used the endpoint provided by backend that returns only concepts that are not yet added, refer to this PR https://github.com/openconceptlab/ocl_issues/issues/728