### PR TITLE
Add a script to run Cypress in a Docker container

### DIFF
--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Script to run the e2e tests in a Dockerised environment
+docker container inspect odm-cypress 2>/dev/null 1>&2
+result=$?
+if [[ $result -ne 0 ]]; then
+    docker run -it --name odm-cypress --network=host -v "$PWD:/e2e" -w /e2e cypress/included:7.5.0
+else
+    docker start -i odm-cypress
+fi


### PR DESCRIPTION
# Summary:

Adds a script to run Cypress tests in a Docker container. This is intended to be used in conjunction with the `start_local_instance.sh` script, so to use it, run:

```sh
./start_local_instance.sh
./run_e2e.sh
./stop_local_instance.sh
```
