### PR TITLE
OCLOMRS-1022: Answers are not being displayed even the concepts are coded

### DIFF
--- a/src/apps/concepts/pages/ViewConceptPage.tsx
+++ b/src/apps/concepts/pages/ViewConceptPage.tsx
@@ -63,6 +63,7 @@ const ViewConceptPage: React.FC<Props> = ({
             ? concept.display_name
             : "View concept"
         }
+        backUrl={linkedDictionary ? `${linkedDictionary}concepts/` : `${dictionaryToAddTo}concepts/` }
       >
         <ProgressOverlay
           delayRender


### PR DESCRIPTION
Give it a backUrl which will skip the older concept version url

# JIRA TICKET NAME:
[Answers are not being displayed even the concepts are coded](https://issues.openmrs.org/browse/OCLOMRS-1022)

# Summary:
- Gave the header a backUrl which points to the dictionary concepts page to avoid going to the older concept version page which was the bug.

https://user-images.githubusercontent.com/30952856/130160565-59d6d57e-b918-4bf6-94d5-d0a14360d6a9.mov


