### PR TITLE
OCLOMRS-1021: Cannot map to some sources unless logged in as a different user

### DIFF
--- a/src/apps/concepts/components/MappingsTableRow.tsx
+++ b/src/apps/concepts/components/MappingsTableRow.tsx
@@ -79,6 +79,15 @@ const conceptCodeFromUrl = (url: string): string => {
   return letters.join("");
 };
 
+const conceptFromUrl = (url: string): string => {
+  let letters = url.split("/");
+  letters.reverse();
+  letters.splice(0, 3, '');
+  letters.reverse();
+
+  return letters.join("/");
+};
+
 interface SourceOption extends Option {
   isInternalSource: boolean;
 }
@@ -288,6 +297,8 @@ const MappingsTableRow: React.FC<Props> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fixedMappingType]);
 
+  const sourceUrl = toSourceUrl ? toSourceUrl : toConceptUrl ? conceptFromUrl(toConceptUrl) : undefined;
+
   return (
     <>
       <TableRow
@@ -323,8 +334,8 @@ const MappingsTableRow: React.FC<Props> = ({
                 }
               }}
               value={
-                toSourceUrl
-                  ? option(toSourceUrl, conceptCodeFromUrl(toSourceUrl))
+                sourceUrl
+                  ? option(sourceUrl, conceptCodeFromUrl(sourceUrl))
                   : undefined
               }
               placeholder="Select a source"


### PR DESCRIPTION
# JIRA TICKET NAME:
[Cannot map to some sources unless logged in as a different user](https://issues.openmrs.org/browse/OCLOMRS-1021)

# Summary:
- For where `to_source_url` is null consider `to_concept_url` and modify it to suit the source options
