### PR TITLE
OCLOMRS-1035: Answers are not being displayed even the concepts are coded: part2

### DIFF
--- a/src/apps/concepts/pages/ViewConceptPage.tsx
+++ b/src/apps/concepts/pages/ViewConceptPage.tsx
@@ -54,6 +54,10 @@ const ViewConceptPage: React.FC<Props> = ({
     retrieveConcept(url);
   }, [url, retrieveConcept]);
 
+  const fromDictionary = linkedDictionary || dictionaryToAddTo;
+  const conceptsDictionary = linkedDictionary ? `${linkedDictionary}concepts/` : `${dictionaryToAddTo}concepts/`; 
+  const backUrl = fromDictionary ? conceptsDictionary : `${conceptSource}concepts/`;
+
   return (
     <>
       <Header
@@ -63,7 +67,7 @@ const ViewConceptPage: React.FC<Props> = ({
             ? concept.display_name
             : "View concept"
         }
-        backUrl={linkedDictionary ? `${linkedDictionary}concepts/` : `${dictionaryToAddTo}concepts/` }
+        backUrl={backUrl}
       >
         <ProgressOverlay
           delayRender


### PR DESCRIPTION
# JIRA TICKET NAME:
[Answers are not being displayed even the concepts are coded: part2](https://issues.openmrs.org/browse/OCLOMRS-1035)

# Summary:
- Go back to source concepts if there is no linkedDictionary or dictionaryToAddTo.