### PR TITLE
OCLOMRS-1032:'All Public Concepts' tab is adjusted to 'Public Sources'

### DIFF
--- a/src/apps/sources/__test__/utils.test.ts
+++ b/src/apps/sources/__test__/utils.test.ts
@@ -3,7 +3,7 @@ import { getSourceTypeFromPreviousPath } from "../utils";
 describe("getSourceTypeFromPreviousPath", () => {
   it("should return public sources for /sources/", () => {
     expect(getSourceTypeFromPreviousPath("/sources/")).toEqual(
-      "All Public Concepts"
+      "Public Sources"
     );
   });
 

--- a/src/apps/sources/constants.ts
+++ b/src/apps/sources/constants.ts
@@ -12,7 +12,7 @@ export const TAB_LIST: TabType[] = [
     labelURL: "/user/orgs/sources/"
   },
   {
-    labelName: "All Public Concepts",
+    labelName: "Public Sources",
     labelURL: "/sources/"
   }
 ];

--- a/src/apps/sources/utils.ts
+++ b/src/apps/sources/utils.ts
@@ -1,7 +1,7 @@
 export const getSourceTypeFromPreviousPath = (previousPath: String) => {
   switch (previousPath) {
     case "/sources/":
-      return "All Public Concepts";
+      return "Public Sources";
     case "/user/sources/":
       return "Your Sources";
     case "/user/orgs/sources/":


### PR DESCRIPTION
# JIRA TICKET NAME:
[The tab that should be called "Public Sources" is called "All Public Concepts"](https://issues.openmrs.org/browse/OCLOMRS-1032)

# Summary: 'All Public Concepts' tab is adjusted to 'Public Sources'
