### PR TITLE
OCLOMRS-1031:Your Organizations Sources shows user-owned sources

### DIFF
--- a/cypress/support/step_definitions/dictionary/createVersion/createVersion.ts
+++ b/cypress/support/step_definitions/dictionary/createVersion/createVersion.ts
@@ -55,10 +55,7 @@ When(/the user selects the "(.+)" menu list item/, menuItem =>
 Then("the subscription url should be copied", () => {
   cy.window().then(win => {
     win.navigator.clipboard.readText().then(text => {
-      assert.equal(
-        text,
-        `/users/${getUser()}/collections/${getDictionaryId()}/${getVersionId()}`
-      );
+      expect(text).to.contain(`/users/${getUser()}/collections/${getDictionaryId()}/${getVersionId()}/`)
     });
   });
 });

--- a/src/apps/dictionaries/api.ts
+++ b/src/apps/dictionaries/api.ts
@@ -22,6 +22,7 @@ const api = {
           params: {
             limit,
             page,
+            verbose: true,
             q: buildPartialSearchQuery(q),
             customValidationSchema: CUSTOM_VALIDATION_SCHEMA,
             timestamp: new Date().getTime() // work around seemingly unhelpful caching
@@ -37,6 +38,7 @@ const api = {
           params: {
             limit,
             page,
+            verbose: true,
             q: buildPartialSearchQuery(q),
             customValidationSchema: CUSTOM_VALIDATION_SCHEMA,
             timestamp: new Date().getTime() // work around seemingly unhelpful caching

--- a/src/apps/sources/__test__/api.test.ts
+++ b/src/apps/sources/__test__/api.test.ts
@@ -18,13 +18,21 @@ describe("api", () => {
     const q: string = "";
     const limit: number = 20;
     const page: number = 1;
-    const response = await api.sources.retrieve.private(url, q, limit, page);
+    const verbose: boolean = true;
+    const response = await api.sources.retrieve.private(
+      url,
+      q,
+      limit,
+      page,
+      verbose
+    );
 
     expect(authenticatedInstance.get).toHaveBeenCalledWith(url, {
       params: {
         limit: 20,
         page: 1,
         q: "",
+        verbose: true,
         timestamp: expect.anything()
       }
     });
@@ -36,13 +44,21 @@ describe("api", () => {
     const q: string = "";
     const limit: number = 20;
     const page: number = 1;
-    const response = await api.sources.retrieve.public(url, q, limit, page);
+    const verbose: boolean = true;
+    const response = await api.sources.retrieve.public(
+      url,
+      q,
+      limit,
+      page,
+      verbose
+    );
 
     expect(unAuthenticatedInstance.get).toHaveBeenCalledWith(url, {
       params: {
         limit: 20,
         page: 1,
         q: "",
+        verbose: true,
         timestamp: expect.anything()
       }
     });

--- a/src/apps/sources/api.ts
+++ b/src/apps/sources/api.ts
@@ -22,6 +22,7 @@ const api = {
           params: {
             limit,
             page,
+            verbose: true,
             q: buildPartialSearchQuery(q),
             timestamp: new Date().getTime() // work around seemingly unhelpful caching
           }
@@ -31,6 +32,7 @@ const api = {
           params: {
             limit,
             page,
+            verbose: true,
             q: buildPartialSearchQuery(q),
             timestamp: new Date().getTime() // work around seemingly unhelpful caching
           }

--- a/src/apps/sources/api.ts
+++ b/src/apps/sources/api.ts
@@ -17,7 +17,13 @@ const api = {
     authenticatedInstance.put(sourceUrl, data),
   sources: {
     retrieve: {
-      private: (sourcesUrl: string, q: string = "", limit = 20, page = 1) =>
+      private: (
+        sourcesUrl: string,
+        q: string = "",
+        limit = 20,
+        page = 1,
+        verbose = true
+      ) =>
         authenticatedInstance.get(sourcesUrl, {
           params: {
             limit,
@@ -27,7 +33,13 @@ const api = {
             timestamp: new Date().getTime() // work around seemingly unhelpful caching
           }
         }),
-      public: (sourcesUrl: string, q: string = "", limit = 20, page = 1) =>
+      public: (
+        sourcesUrl: string,
+        q: string = "",
+        limit = 20,
+        page = 1,
+        verbose = true
+      ) =>
         unAuthenticatedInstance.get(sourcesUrl, {
           params: {
             limit,


### PR DESCRIPTION
# JIRA TICKET NAME:
[Your Organizations Sources shows user-owned sources](https://issues.openmrs.org/browse/OCLOMRS-1031)

# Summary:
As Your Organization Source and Your Source were returning the same data, I have updated the query with verbose: true so that now it returns the desired result. And the same with dictionaries.
