### PR TITLE
OCLOMRS-1043:Cannot select another language for a source

### DIFF
--- a/src/apps/sources/components/SourceForm.tsx
+++ b/src/apps/sources/components/SourceForm.tsx
@@ -290,10 +290,12 @@ const SourceForm: React.FC<Props> = ({
               </InputLabel>
               <Field
                 multiple
-                value={[]}
+                fullWidth
+                defaultValue={[]}
                 name="supported_locales"
                 id="supported_locales"
                 component={Select}
+                style={{ whiteSpace: "inherit !important" }}
               >
                 {supportedLocalesLabel(values)}
               </Field>


### PR DESCRIPTION
# JIRA TICKET NAME:
[Cannot select another language for a source](https://issues.openmrs.org/browse/OCLOMRS-1043)

# Summary:
I fixed the Source to enable  the user select  another language from the dropdown menu.