### PR TITLE
OCLOMRS-1046:Paging, searching and filtering through the list of concepts no longer works

### DIFF
--- a/src/apps/concepts/pages/ViewConceptsPage.tsx
+++ b/src/apps/concepts/pages/ViewConceptsPage.tsx
@@ -268,7 +268,26 @@ const ViewConceptsPage: React.FC<Props> = ({
     // i don't know how the comparison algorithm works, but for these arrays, it fails.
     // stringify the arrays to work around that
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [retrieveConcepts, retrieveDictionary, retrieveSource, containerUrl]);
+  }, [
+    retrieveConcepts, 
+    retrieveDictionary, 
+    retrieveSource, 
+    containerUrl,
+    url,
+    page,
+    limit,
+    initialQ,
+    sortDirection,
+    sortBy,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    initialDataTypeFilters.toString(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    initialClassFilters.toString(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    initialSourceFilters.toString(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    initialGeneralFilters.toString()
+  ]);
 
   const canModifyDictionary =
     containerType === DICTIONARY_CONTAINER &&


### PR DESCRIPTION
# JIRA TICKET NAME:
[Paging through the list of concepts no longer works](https://issues.openmrs.org/browse/OCLOMRS-1046)

# Summary:
- This fixes pagination, filtering and searching through concepts.