### PR TITLE
OCLOMRS-1048: Back button goes back to dictionary instead of search results

### DIFF
--- a/src/apps/concepts/pages/ViewConceptPage.tsx
+++ b/src/apps/concepts/pages/ViewConceptPage.tsx
@@ -54,7 +54,11 @@ const ViewConceptPage: React.FC<Props> = ({
     retrieveConcept(url);
   }, [url, retrieveConcept]);
 
-  const backUrl = linkedDictionary ? `${linkedDictionary}concepts/` : dictionaryToAddTo ? undefined : `${conceptSource}concepts/`;
+  const backUrl = linkedDictionary
+    ? `${linkedDictionary}concepts/`
+    : dictionaryToAddTo
+    ? undefined
+    : `${conceptSource}concepts/`;
 
   return (
     <>
@@ -66,7 +70,6 @@ const ViewConceptPage: React.FC<Props> = ({
             : "View concept"
         }
         backUrl={backUrl}
-
       >
         <ProgressOverlay
           delayRender

--- a/src/apps/concepts/pages/ViewConceptPage.tsx
+++ b/src/apps/concepts/pages/ViewConceptPage.tsx
@@ -54,8 +54,7 @@ const ViewConceptPage: React.FC<Props> = ({
     retrieveConcept(url);
   }, [url, retrieveConcept]);
 
-  const fromDictionary = linkedDictionary ?? dictionaryToAddTo;
-  const backUrl = `${fromDictionary ? fromDictionary : conceptSource}concepts/`
+  const backUrl = linkedDictionary ? `${linkedDictionary}concepts/` : dictionaryToAddTo ? undefined : `${conceptSource}concepts/`;
 
   return (
     <>
@@ -67,6 +66,7 @@ const ViewConceptPage: React.FC<Props> = ({
             : "View concept"
         }
         backUrl={backUrl}
+
       >
         <ProgressOverlay
           delayRender


### PR DESCRIPTION
# JIRA TICKET NAME:
[Pick concepts - Go back button goes back to dictionary instead of search results](https://issues.openmrs.org/browse/OCLOMRS-1048)

# Summary:
- Modify the backUrl for when you are importing
