### PR TITLE
OCLOMRS-1069: Scroll position issue when navigating between dictionary results

### DIFF
--- a/src/apps/dictionaries/components/ViewDictionariesPage.tsx
+++ b/src/apps/dictionaries/components/ViewDictionariesPage.tsx
@@ -1,20 +1,19 @@
 import React, { useEffect } from "react";
-import { APIDictionary } from "../types";
-import { ProgressOverlay } from "../../../utils/components";
-import { useQueryParams } from "../../../utils";
 import { useHistory, useLocation } from "react-router";
-import qs from "qs";
-import ViewDictionaries from "../components/ViewDictionaries";
-import {
-  retrievePublicDictionariesAction,
-  toggleShowVerifiedAction
-} from "../redux";
+import { Link } from "react-router-dom";
 import { Fab, Tooltip } from "@material-ui/core";
 import { Add as AddIcon } from "@material-ui/icons";
-import { Link } from "react-router-dom";
-import { ContainerOwnerTabs } from "../../containers/components";
+
+import ViewDictionaries from "../components/ViewDictionaries";
 import { Header } from "../../../components";
+import { ContainerOwnerTabs } from "../../containers/components";
+import { retrievePublicDictionariesAction, toggleShowVerifiedAction } from "../redux";
+
 import { TAB_LIST, PER_PAGE, TITLE } from "../constants";
+import { useQueryParams, generateURLWithQueryParams } from "../../../utils";
+import { ProgressOverlay } from "../../../utils/components";
+
+import { APIDictionary } from "../types";
 
 interface Props {
   loading: boolean;
@@ -53,13 +52,15 @@ const ViewPublicDictionariesPage: React.FC<Props> = ({
     );
   }, [retrieveDictionaries, url, initialQ, page, showOnlyVerified]);
 
-  const gimmeAUrl = (params: { page?: number; q?: string }) => {
-    const newParams: { page?: number; q?: string } = {
-      ...queryParams,
-      ...params
-    };
-    return `${url}?${qs.stringify(newParams)}`;
-  };
+  const changePage = (params: { page?: number; q?: string }) => {
+    const targetURL = generateURLWithQueryParams(url, params);
+    goTo(targetURL);
+    window.scrollTo({
+      top: 0,
+      left: 0,
+      behavior: "smooth"
+    })
+  }
 
   return (
     <Header title="Dictionaries">
@@ -69,8 +70,8 @@ const ViewPublicDictionariesPage: React.FC<Props> = ({
           initialQ={initialQ}
           page={page}
           perPage={PER_PAGE}
-          onSearch={(q: string) => goTo(gimmeAUrl({ q }))}
-          onPageChange={(page: number) => goTo(gimmeAUrl({ page }))}
+          onSearch={(q: string) => changePage({ q })}
+          onPageChange={(page: number) => changePage({ page })}
           dictionaries={dictionaries}
           numFound={numFound}
           title={TITLE}

--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -1,0 +1,15 @@
+import qs from "qs";
+
+type QueryParams = { [key: string]: string | number }
+
+export const generateURLWithQueryParams = (
+    currentBaseUrl: string,
+    params: QueryParams,
+    currentQueryParams?: QueryParams
+) => {
+    const newParams: QueryParams = {
+        ...currentQueryParams,
+        ...params
+    };
+    return `${currentBaseUrl}?${qs.stringify(newParams)}`;
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,8 @@
 import { LOCALES } from "./constants";
 import { snakeCase } from "lodash";
 
+export * from "./urlUtils";
+
 export const findLocale = (localeCode: string, fallback = "en") =>
   LOCALES.find(currentLocale => currentLocale.value === localeCode) ||
   (LOCALES.find(currentLocale => currentLocale.value === fallback) as {


### PR DESCRIPTION
# JIRA TICKET NAME:
[OCLOMRS-1069: Scroll position issue when navigating between dictionary results](https://issues.openmrs.org/browse/OCLOMRS-1069)

# Summary:
When navigating between pages of dictionary results, the page remains at the last scrolled position. It should move to top when going to a different page of dictionaries.