### PR TITLE
OCLOMRS-1068:Add ability to reorder members in a concept set

### DIFF
--- a/src/apps/concepts/components/MappingsTable.tsx
+++ b/src/apps/concepts/components/MappingsTable.tsx
@@ -71,11 +71,13 @@ const MappingsTable: React.FC<Props> = ({
   const classes = useStyles();
   const [sorted, setSorted] = useState<Mapping[]>();
   const [isAnswer, setAnswer] = useState(false);
+  const [isSetMember, setSetMember] = useState(false);
 
   useEffect(() => setAnswer(title === "Answer"), [title]);
+  useEffect(() => setSetMember(title === "Set Member"), [title]);
 
   useEffect(() => {
-    if (sorted && isAnswer) {
+    if ((sorted && isAnswer) || (sorted && isSetMember)) {
       const values = sorted;
       values.sort((v1, v2) => {
         if (v1.extras?.sort_weight) {
@@ -97,10 +99,10 @@ const MappingsTable: React.FC<Props> = ({
       });
       setSorted(values);
     }
-  }, [sorted, isAnswer]);
+  }, [sorted, isAnswer, isSetMember]);
 
   useEffect(() => {
-    if (isAnswer && isSubmitting) {
+    if ((isAnswer && isSubmitting)||(isSetMember && isSubmitting)) {
       for (let i = 0; i < values.length; i++) {
         handleChange(
           buildEvent(`${valuesKey}[${i}].extras`, { sort_weight: i + 1 })
@@ -109,6 +111,7 @@ const MappingsTable: React.FC<Props> = ({
     }
   }, [
     isAnswer,
+    isSetMember,
     isSubmitting,
     submitCount,
     handleChange,
@@ -190,7 +193,7 @@ const MappingsTable: React.FC<Props> = ({
               </TableCell>
             </TableRow>
           </TableHead>
-          {isAnswer && editing ? (
+          {(isAnswer && editing) || (isSetMember && editing)? (
             <DragDropContext
               onDragEnd={param => {
                 const srcI = param.source.index;

--- a/src/apps/concepts/components/MappingsTable.tsx
+++ b/src/apps/concepts/components/MappingsTable.tsx
@@ -77,7 +77,7 @@ const MappingsTable: React.FC<Props> = ({
   useEffect(() => setSetMember(title === "Set Member"), [title]);
 
   useEffect(() => {
-    if ((sorted && isAnswer) || (sorted && isSetMember)) {
+    if (sorted && isAnswer) {
       const values = sorted;
       values.sort((v1, v2) => {
         if (v1.extras?.sort_weight) {
@@ -99,10 +99,35 @@ const MappingsTable: React.FC<Props> = ({
       });
       setSorted(values);
     }
-  }, [sorted, isAnswer, isSetMember]);
+  }, [sorted, isAnswer]);
 
   useEffect(() => {
-    if ((isAnswer && isSubmitting)||(isSetMember && isSubmitting)) {
+    if (sorted && isSetMember) {
+      const values = sorted;
+      values.sort((v1, v2) => {
+        if (v1.extras?.sort_weight) {
+          if (v2.extras?.sort_weight) {
+            return (
+              (v1.extras.sort_weight as number) -
+              (v2.extras.sort_weight as number)
+            );
+          }
+
+          return 1;
+        }
+
+        if (v2.extras?.sort_weight) {
+          return -1;
+        }
+
+        return 0;
+      });
+      setSorted(values);
+    }
+  }, [sorted, isSetMember]);
+
+  useEffect(() => {
+    if (isAnswer && isSubmitting) {
       for (let i = 0; i < values.length; i++) {
         handleChange(
           buildEvent(`${valuesKey}[${i}].extras`, { sort_weight: i + 1 })
@@ -111,6 +136,22 @@ const MappingsTable: React.FC<Props> = ({
     }
   }, [
     isAnswer,
+    isSubmitting,
+    submitCount,
+    handleChange,
+    values.length,
+    valuesKey
+  ]);
+
+  useEffect(() => {
+    if (isSetMember && isSubmitting) {
+      for (let i = 0; i < values.length; i++) {
+        handleChange(
+          buildEvent(`${valuesKey}[${i}].extras`, { sort_weight: i + 1 })
+        );
+      }
+    }
+  }, [
     isSetMember,
     isSubmitting,
     submitCount,
@@ -193,7 +234,7 @@ const MappingsTable: React.FC<Props> = ({
               </TableCell>
             </TableRow>
           </TableHead>
-          {(isAnswer && editing) || (isSetMember && editing)? (
+          {(isAnswer && editing) || (isSetMember && editing) ? (
             <DragDropContext
               onDragEnd={param => {
                 const srcI = param.source.index;


### PR DESCRIPTION
# JIRA TICKET NAME:
[Add ability to reorder members in a concept set](https://issues.openmrs.org/browse/OCLOMRS-1068)

# Summary:
Reordering of set members feature is added