### PR TITLE
OCLOMRS-1030: Concepts belonging to dictionaries for my user aren't displayed

### DIFF
--- a/src/apps/concepts/pages/ViewConceptsPage.tsx
+++ b/src/apps/concepts/pages/ViewConceptsPage.tsx
@@ -214,7 +214,7 @@ const ViewConceptsPage: React.FC<Props> = ({
     initialSourceFilters
   );
 
-  const excludeAddedConceptsUrl = `${url}?collection=!${dictionary?.name}&collectionOwnerUrl=!${dictionary?.owner_url}`;
+  const excludeAddedConceptsUrl = `${url}?collectionUrl=!${dictionary?.url}`;
   const includeAddedConcepts = generalFilters.includes(
     "Include Added Concepts"
   );


### PR DESCRIPTION


# JIRA TICKET NAME:
[Concepts belonging to dictionaries for my user aren't displayed](https://issues.openmrs.org/browse/OCLOMRS-1030)

# Summary:
I changed `collectionOwnerUrl=!${dictionary?.owner_url}` to `collectionOwnerUrl`. parameter