### PR TITLE
OCLOMRS-1094: Use concept url when removing concept from collection

### DIFF
--- a/src/apps/concepts/components/ConceptsActionMenu.tsx
+++ b/src/apps/concepts/components/ConceptsActionMenu.tsx
@@ -34,7 +34,7 @@ const addConceptsToDictionaryMenu = (
 };
 
 const removeConceptsFromDictionaryMenu = (
-  removeConceptsFromDictionary: (conceptVersionUrls: string[]) => void,
+  removeConceptsFromDictionary: (conceptUrls: string[]) => void,
   row: APIConcept,
   toggleMenu: (
     index: number,
@@ -46,7 +46,7 @@ const removeConceptsFromDictionaryMenu = (
     <MenuItem
       onClick={() => {
         if (removeConceptsFromDictionary)
-          removeConceptsFromDictionary([row.version_url]);
+          removeConceptsFromDictionary([row.url]);
         toggleMenu(index);
       }}
     >
@@ -105,7 +105,7 @@ const removeMenu = (
     event?: React.MouseEvent<HTMLButtonElement, MouseEvent> | undefined
   ) => void,
   linkedSource: string | undefined,
-  removeConceptsFromDictionary: (conceptVersionUrls: string[]) => void
+  removeConceptsFromDictionary: (conceptUrls: string[]) => void
 ) => {
   return !showRemoveFromDictionaryMenuItem(row, buttons.edit, linkedSource)
     ? null
@@ -144,7 +144,7 @@ interface ConceptsActionMenuProps {
   ) => void;
   menu: { index: number; anchor: null | HTMLElement };
   canModifyConcept: (concept: APIConcept) => boolean;
-  removeConceptsFromDictionary: (conceptVersionUrls: string[]) => void;
+  removeConceptsFromDictionary: (conceptUrls: string[]) => void;
   addConceptsToDictionary: Function;
   linkedSource: string | undefined;
   linkedDictionary: string | undefined;

--- a/src/apps/concepts/components/ConceptsTable.tsx
+++ b/src/apps/concepts/components/ConceptsTable.tsx
@@ -20,7 +20,7 @@ interface Props extends QueryParams {
   buttons?: { [key: string]: boolean };
   addConceptsToDictionary: Function;
   dictionaryToAddTo?: string;
-  removeConceptsFromDictionary: (conceptVersionUrls: string[]) => void;
+  removeConceptsFromDictionary: (conceptUrls: string[]) => void;
   linkedDictionary?: string;
   linkedSource?: string;
   canModifyConcept: (concept: APIConcept) => boolean;

--- a/src/apps/concepts/components/ConceptsTableRow.tsx
+++ b/src/apps/concepts/components/ConceptsTableRow.tsx
@@ -199,7 +199,7 @@ const actionCell = (
     event?: React.MouseEvent<HTMLButtonElement, MouseEvent> | undefined
   ) => void,
   menu: { index: number; anchor: null | HTMLElement },
-  removeConceptsFromDictionary: (conceptVersionUrls: string[]) => void,
+  removeConceptsFromDictionary: (conceptUrls: string[]) => void,
   addConceptsToDictionary: Function,
 
   linkedSource: string | undefined,
@@ -246,7 +246,7 @@ interface ConceptsTableRowProps {
     event?: React.MouseEvent<HTMLButtonElement, MouseEvent> | undefined
   ) => void;
   menu: { index: number; anchor: null | HTMLElement };
-  removeConceptsFromDictionary: (conceptVersionUrls: string[]) => void;
+  removeConceptsFromDictionary: (conceptUrls: string[]) => void;
   addConceptsToDictionary: Function;
   dictionaryToAddTo?: string;
   isItemSelected: boolean;

--- a/src/apps/concepts/pages/ViewConceptsPage.tsx
+++ b/src/apps/concepts/pages/ViewConceptsPage.tsx
@@ -366,8 +366,8 @@ const ViewConceptsPage: React.FC<Props> = ({
               canModifyConcept={(concept: APIConcept) =>
                 canModifyConcept(concept.url, profile, usersOrgs)
               }
-              removeConceptsFromDictionary={(conceptVersionUrls: string[]) =>
-                removeConceptsFromDictionary(containerUrl, conceptVersionUrls)
+              removeConceptsFromDictionary={(conceptUrls: string[]) =>
+                removeConceptsFromDictionary(containerUrl, conceptUrls)
               }
             />
           </Grid>

--- a/src/apps/concepts/redux/actions.ts
+++ b/src/apps/concepts/redux/actions.ts
@@ -200,7 +200,7 @@ export const upsertConceptAndMappingsAction = (
             // we don't remove the toConceptUrls because we can't be sure no other mapping depends on them
             // that would break the OCL module importer
             // ...state.concepts.mappings.map(mapping => mapping.url), todo ensure the cascade is working and delete this if so
-            concept.version_url
+            concept.url
           ].filter(reference => reference) as string[];
           await dispatch(
             removeReferencesFromDictionary(linkedDictionary, referencesToRemove)

--- a/src/apps/concepts/redux/reducer.ts
+++ b/src/apps/concepts/redux/reducer.ts
@@ -69,7 +69,7 @@ export const reducer = createReducer<ConceptsState>(initialState, {
     }: { actionIndex: number; payload: {}; meta: [string, string[]] }
   ) => {
     state.concepts.items = state.concepts.items.filter(
-      (concept: APIConcept) => !meta[1].includes(concept.version_url)
+      (concept: APIConcept) => !meta[1].includes(concept.url)
     );
   },
   [LOGOUT_ACTION]: () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
[Unable to delete concept from collection with OCL Platform 2.0.117+](https://issues.openmrs.org/browse/OCLOMRS-1094)

# Summary:
Removing a concept within a dictionary (collection) in the Dictionary Manager visually removes the concept, but the concept isn't actually deleted from the collection within OCL and refreshing the page reveals the bug as the concept "reappears" within the dictionary.

As @bmamlin suggested [here](https://issues.openmrs.org/browse/OCLOMRS-1094), I updated the delete request body, but still, the API request is returning a 204 response and fails the deletion. So I'll keep this pull request as a draft for now.