### PR TITLE
OCLOMRS-1096: Apply the transformReferences parameter

### DIFF
--- a/src/apps/dictionaries/api.ts
+++ b/src/apps/dictionaries/api.ts
@@ -70,12 +70,13 @@ const api = {
     add: (
       dictionaryUrl: string,
       references?: string[],
-      cascade: string = "sourcemappings"
+      cascade: string = "sourcemappings",
+      transformReferences: string = "resourceVersions"
     ) =>
       authenticatedInstance.put(
         `${dictionaryUrl}references/`,
         { data: { expressions: references } }, // the nesting is not an error. Check API docs
-        { params: { cascade: cascade } }
+        { params: { cascade: cascade, transformReferences: transformReferences } }
       ),
     delete: (
       dictionaryUrl: string,


### PR DESCRIPTION
# JIRA TICKET NAME:
[Apply the new transformReferences=resourceVersions parameter when submitting a request to the OCL API to add a new concept to a collection](https://issues.openmrs.org/browse/OCLOMRS-1096)

# Summary:
Adding the transformReferences=resourceVersions parameter causes the OCL API to transform the expression "/orgs/CIEL/sources/CIEL/12345/" into a versioned expression, like this: "/orgs/CIEL/sources/CIEL/12345/39393/" , which is exactly what the OCL API used to do before we introduced expansions and dynamic references.